### PR TITLE
Fix the Uber provider

### DIFF
--- a/src/Uber/Provider.php
+++ b/src/Uber/Provider.php
@@ -72,4 +72,23 @@ class Provider extends AbstractProvider implements ProviderInterface
             'grant_type' => 'authorization_code',
         ]);
     }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getCodeFields($state = null)
+    {
+        $fields = [
+            'client_id' => $this->clientId, 'redirect_uri' => $this->redirectUrl,
+            'scope' => array_values($this->getScopes()),
+            'response_type' => 'code',
+        ];
+
+        if ($this->usesState()) {
+            $fields['state'] = $state;
+        }
+
+        return array_merge($fields, $this->parameters);
+    }
 }

--- a/src/Uber/Provider.php
+++ b/src/Uber/Provider.php
@@ -73,7 +73,6 @@ class Provider extends AbstractProvider implements ProviderInterface
         ]);
     }
 
-
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
The Uber api does not accept multiple scope to be sent as a string with separators. It must be an array of scopes like: ``scope[0]=profile&scope[1]=history``