### PR TITLE
[Dataporten] Update Provider.php

### DIFF
--- a/src/Dataporten/Provider.php
+++ b/src/Dataporten/Provider.php
@@ -16,7 +16,7 @@ class Provider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
-    protected $scopes = ['basic'];
+    protected $scopes = [];
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
Default to the authorized scopes for a Dataporten Oauth 2 Client. The default authorized scopes are 'userid' and 'profile'.