### PR TITLE
Fixes a type error in Jira integration

### DIFF
--- a/src/Jira/RsaSha1Signature.php
+++ b/src/Jira/RsaSha1Signature.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\Jira;
 
+use GuzzleHttp\Psr7\Uri;
 use League\OAuth1\Client\Signature\Signature;
 use League\OAuth1\Client\Signature\SignatureInterface;
 
@@ -59,11 +60,11 @@ class RsaSha1Signature extends Signature implements SignatureInterface
      *
      * @param string $uri
      *
-     * @return Url
+     * @return Uri
      */
     protected function createUrl($uri)
     {
-        $theUri = new \GuzzleHttp\Psr7\Uri($uri);
+        $theUri = new Uri($uri);
 
         return $theUri;
     }
@@ -78,7 +79,7 @@ class RsaSha1Signature extends Signature implements SignatureInterface
      *
      * @return string
      */
-    protected function baseString(Url $url, $method = 'POST', array $parameters = [])
+    protected function baseString(Uri $url, $method = 'POST', array $parameters = [])
     {
         $baseString = rawurlencode($method).'&';
         $schemeHostPath = $url->getScheme().'://'.$url->getHost();


### PR DESCRIPTION
Without this fix, there is a type error in signature of baseString function:

```
Type error: Argument 1 passed to SocialiteProviders\Jira\RsaSha1Signature::baseString() 
must be an instance of SocialiteProviders\Jira\Url, 
instance of GuzzleHttp\Psr7\Uri given, 
called in src/Jira/RsaSha1Signature.php on line 26
```
