### PR TITLE
Changing Microsoft Live Provider scopeSceparator from ',' to ' ' - ad…

### DIFF
--- a/src/Microsoft-Live/Provider.php
+++ b/src/Microsoft-Live/Provider.php
@@ -21,6 +21,11 @@ class Provider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
+    protected $scopeSeparator = ' ';
+
+    /**
+     * {@inheritdoc}
+     */
     protected function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase(


### PR DESCRIPTION
Changing Microsoft Live Provider scopeSceparator from ',' to ' ' - adding extra scopes results in a bad request

