### PR TITLE
Line API will not return avatar url when user did not set one

### DIFF
--- a/src/Line/Provider.php
+++ b/src/Line/Provider.php
@@ -56,7 +56,7 @@ class Provider extends AbstractProvider implements ProviderInterface
             'nickname' => null,
             'name' => $user['displayName'],
             'email' => null,
-            'avatar' => $user['pictureUrl'],
+            'avatar' => array_key_exists('pictureUrl', $user) ? $user['pictureUrl'] : null,
         ]);
     }
 


### PR DESCRIPTION
Conduct array key check while mapping to object

