### PR TITLE
Remove Slack's default scopes to avoid conflicts

### DIFF
--- a/src/Slack/Provider.php
+++ b/src/Slack/Provider.php
@@ -18,11 +18,6 @@ class Provider extends AbstractProvider implements ProviderInterface
     const IDENTIFIER = 'SLACK';
 
     /**
-     * {@inheritdoc}
-     */
-    protected $scopes = ['identity.basic', 'identity.email', 'identity.team', 'identity.avatar'];
-
-    /**
      * The separating character for the requested scopes.
      *
      * @var string

--- a/src/Slack/Provider.php
+++ b/src/Slack/Provider.php
@@ -25,6 +25,20 @@ class Provider extends AbstractProvider implements ProviderInterface
     protected $scopeSeparator = ',';
 
     /**
+     * {@inheritdoc}
+     */
+    public function getScopes()
+    {
+        if (count($this->scopes) > 0) {
+            return $this->scopes;
+        }
+
+        // Provide some default scopes if the user didn't define some.
+        // See: https://github.com/SocialiteProviders/Providers/pull/53
+        return ['identity.basic', 'identity.email', 'identity.team', 'identity.avatar'];
+    }
+
+    /**
      * Middleware that throws exceptions for non successful slack api calls
      * "http_error" request option is set to true.
      *


### PR DESCRIPTION
The default scopes for the Slack provider are an issue since some combinations are forbidden. Here is what I get when I try to redirect a user with the following code:

```php
Socialite::with('slack')->scopes(['channels:history', 'channels:read', 'users:read', 'emoji:read', 'team:read'])->redirect();
```

![image](https://cloud.githubusercontent.com/assets/817508/24617140/75c948de-1893-11e7-9b62-b34c7039a879.png)

The removal of the default scopes is **a breaking changement!** Merge this carefully.