### PR TITLE
update Spotify provider mapUserToObject

### DIFF
--- a/src/Spotify/Provider.php
+++ b/src/Spotify/Provider.php
@@ -61,10 +61,11 @@ class Provider extends AbstractProvider implements ProviderInterface
     {
         return (new User())->setRaw($user)->map([
             'id' => $user['id'],
-            'nickname' => $user['display_name'],
-            'name' => $user['id'],
+            'nickname' => null,
+            'name' => $user['display_name'],
             'email' => isset($user['email']) ? $user['email'] : null,
             'avatar' => array_get($user, 'images.0.url'),
+            'profileUrl' => isset($user['href']) ? $user['href'] : null,
         ]);
     }
 


### PR DESCRIPTION
fix Spotify user object:
- correct `name` from `$user['id']` to `$user['display_name']`
- correct `nickname` to `null`
- add `profileUrl` value which exists as `$user['href']` for any given Spotify user profile
...as per https://developer.spotify.com/web-api/console/get-users-profile/