### PR TITLE
Dynamic myshopify.com subdomain

### DIFF
--- a/src/Shopify/Provider.php
+++ b/src/Shopify/Provider.php
@@ -84,7 +84,6 @@ class Provider extends AbstractProvider implements ProviderInterface
     /**
      * Work out the shopify domain based on either the
      * `subdomain` config setting or the current request
-     *
      * @param  string $uri URI to append to the domain
      * @return string      The fully qualified *.myshopify.com url
      */

--- a/src/Shopify/Provider.php
+++ b/src/Shopify/Provider.php
@@ -23,7 +23,7 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     protected function getAuthUrl($state)
     {
-        return $this->buildAuthUrlFromBase('https://'.$this->getConfig('subdomain').'.myshopify.com/admin/oauth/authorize', $state);
+        return $this->buildAuthUrlFromBase($this->shopifyUrl('/admin/oauth/authorize'), $state);
     }
 
     /**
@@ -31,7 +31,7 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     protected function getTokenUrl()
     {
-        return 'https://'.$this->getConfig('subdomain').'.myshopify.com/admin/oauth/access_token';
+        return $this->shopifyUrl('/admin/oauth/access_token');
     }
 
     /**
@@ -39,7 +39,7 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     protected function getUserByToken($token)
     {
-        $response = $this->getHttpClient()->get('https://'.$this->getConfig('subdomain').'.myshopify.com/admin/shop.json', [
+        $response = $this->getHttpClient()->get($this->shopifyUrl('/admin/shop.json'), [
             'headers' => [
                 'Accept' => 'application/json',
                 'X-Shopify-Access-Token' => $token,
@@ -56,7 +56,7 @@ class Provider extends AbstractProvider implements ProviderInterface
     {
         return (new User())->setRaw($user)->map([
             'id'       => $user['id'],
-            'nickname' => $user['shopify_domain'],
+            'nickname' => $user['myshopify_domain'],
             'name'     => null,
             'email'    => null,
             'avatar'   => null,
@@ -79,5 +79,21 @@ class Provider extends AbstractProvider implements ProviderInterface
     public static function additionalConfigKeys()
     {
         return ['subdomain'];
+    }
+
+    /**
+     * Work out the shopify domain based on either the
+     * `subdomain` config setting or the current request
+     *
+     * @param  string $uri URI to append to the domain
+     * @return string      The fully qualified *.myshopify.com url
+     */
+    private function shopifyUrl($uri = null)
+    {
+        if ($this->getConfig('subdomain')) {
+            return "https://{$this->getConfig('subdomain')}.myshopify.com".$uri;
+        }
+
+        return 'https://'.$this->request->get('shop').$uri;
     }
 }

--- a/src/Shopify/Provider.php
+++ b/src/Shopify/Provider.php
@@ -83,7 +83,7 @@ class Provider extends AbstractProvider implements ProviderInterface
 
     /**
      * Work out the shopify domain based on either the
-     * `subdomain` config setting or the current request
+     * `subdomain` config setting or the current request.
      * @param  string $uri URI to append to the domain
      * @return string      The fully qualified *.myshopify.com url
      */


### PR DESCRIPTION
The oauth domain is not a constant with shopify - each store hais on its own subdomain.
The current setup of defining a subdomain in the services config array will not work when for example installing an app or sales channel from the Shopify app store. The subdomain value need to be dynamic from the shop GET parameter.

This PR swaps out the current subdomain config item for the shop param in the current request.
I don't think this is the ideal solution, but it works and at least gets the ball rolling to sort out the issue.

I have implemented it to have no breaking changes - if the subdomain is set - that will be used, if not it will fallback to the shop param on the request.

