### PR TITLE
GameWisp Provider

### DIFF
--- a/build/split.sh
+++ b/build/split.sh
@@ -66,6 +66,7 @@ split Fitbit                src/Fitbit:git@github.com:SocialiteProviders/Fitbit.
 split Flattr                src/Flattr:git@github.com:SocialiteProviders/Flattr.git                         "master"
 split Flickr                src/Flickr:git@github.com:SocialiteProviders/Flickr.git                         "master"
 split Foursquare            src/Foursquare:git@github.com:SocialiteProviders/Foursquare.git                 "master"
+split GameWisp              src/GitLab:git@github.com:SocialiteProviders/GameWisp.git                       "master"
 split GitLab                src/GitLab:git@github.com:SocialiteProviders/GitLab.git                         "master"
 split Goodreads             src/Goodreads:git@github.com:SocialiteProviders/Goodreads.git                   "master"
 split Google-Plus           src/Google-Plus:git@github.com:SocialiteProviders/Google-Plus.git               "master"

--- a/build/split.sh
+++ b/build/split.sh
@@ -66,7 +66,7 @@ split Fitbit                src/Fitbit:git@github.com:SocialiteProviders/Fitbit.
 split Flattr                src/Flattr:git@github.com:SocialiteProviders/Flattr.git                         "master"
 split Flickr                src/Flickr:git@github.com:SocialiteProviders/Flickr.git                         "master"
 split Foursquare            src/Foursquare:git@github.com:SocialiteProviders/Foursquare.git                 "master"
-split GameWisp              src/GameWisp:git@github.com:SocialiteProviders/GameWisp.git                       "master"
+split GameWisp              src/GameWisp:git@github.com:SocialiteProviders/GameWisp.git                     "master"
 split GitLab                src/GitLab:git@github.com:SocialiteProviders/GitLab.git                         "master"
 split Goodreads             src/Goodreads:git@github.com:SocialiteProviders/Goodreads.git                   "master"
 split Google-Plus           src/Google-Plus:git@github.com:SocialiteProviders/Google-Plus.git               "master"

--- a/build/split.sh
+++ b/build/split.sh
@@ -66,7 +66,7 @@ split Fitbit                src/Fitbit:git@github.com:SocialiteProviders/Fitbit.
 split Flattr                src/Flattr:git@github.com:SocialiteProviders/Flattr.git                         "master"
 split Flickr                src/Flickr:git@github.com:SocialiteProviders/Flickr.git                         "master"
 split Foursquare            src/Foursquare:git@github.com:SocialiteProviders/Foursquare.git                 "master"
-split GameWisp              src/GitLab:git@github.com:SocialiteProviders/GameWisp.git                       "master"
+split GameWisp              src/GameWisp:git@github.com:SocialiteProviders/GameWisp.git                       "master"
 split GitLab                src/GitLab:git@github.com:SocialiteProviders/GitLab.git                         "master"
 split Goodreads             src/Goodreads:git@github.com:SocialiteProviders/Goodreads.git                   "master"
 split Google-Plus           src/Google-Plus:git@github.com:SocialiteProviders/Google-Plus.git               "master"

--- a/src/GameWisp/GameWispExtendSocialite.php
+++ b/src/GameWisp/GameWispExtendSocialite.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SocialiteProviders\GameWisp;
+
+use SocialiteProviders\Manager\SocialiteWasCalled;
+
+class GameWispExtendSocialite
+{
+    /**
+     * Register the provider.
+     *
+     * @param \SocialiteProviders\Manager\SocialiteWasCalled $socialiteWasCalled
+     */
+    public function handle(SocialiteWasCalled $socialiteWasCalled)
+    {
+        $socialiteWasCalled->extendSocialite(
+            'gamewisp', __NAMESPACE__.'\Provider'
+        );
+    }
+}

--- a/src/GameWisp/Provider.php
+++ b/src/GameWisp/Provider.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace SocialiteProviders\GameWisp;
+
+use SocialiteProviders\Manager\OAuth2\User;
+use Laravel\Socialite\Two\ProviderInterface;
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
+
+class Provider extends AbstractProvider implements ProviderInterface
+{
+    /**
+     * Unique Provider Identifier.
+     */
+    const IDENTIFIER = 'GAMEWISP';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopes = ['user_read'];
+
+    /**
+     * {@inherticdoc}.
+     */
+    protected $scopeSeparator = ',';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAuthUrl($state)
+    {
+        return $this->buildAuthUrlFromBase(
+            'https://api.gamewisp.com/pub/v1/oauth/authorize', $state
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenUrl()
+    {
+        return 'https://api.gamewisp.com/pub/v1/oauth/token';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByToken($token)
+    {
+        $query = [
+            'access_token' => $token,
+            'include' => 'profile.picture',
+        ];
+
+        $response = $this->getHttpClient()->get(
+            'https://api.gamewisp.com/pub/v1/user/information', [
+            'query' => $query,
+            'headers' => [
+                'Accept' => 'application/json',
+                'Authorization' => 'Bearer '.$token,
+            ],
+        ]);
+
+        return json_decode($response->getBody()->getContents(), true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+        //need to do some work here to get the email address and the profile picture.
+        //hotfix the api to return email addresses with the user object.
+        return (new User())->setRaw($user)->map([
+            'id' => array_get($user, 'data.id'), 'username' => array_get($user, 'data.username'),
+            'email' => array_get($user, 'data.email'), 'avatar' => array_get($user, 'data.profile.data.picture.data.content'),
+            'deactivated' => array_get($user, 'data.deactivated'), 'banned' => array_get($user, 'data.banned'),
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenFields($code)
+    {
+        return array_merge(parent::getTokenFields($code), [
+            'grant_type' => 'authorization_code',
+        ]);
+    }
+}

--- a/src/GameWisp/composer.json
+++ b/src/GameWisp/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "socialiteproviders/gamewisp",
+    "description": "GameWisp OAuth2 Provider for Laravel Socialite",
+    "license": "MIT",
+    "authors": [{
+        "name": "Eli Hooten",
+        "email": "eli@gamewisp.com"
+    }],
+    "require": {
+        "php": "^5.6 || ^7.0",
+        "socialiteproviders/manager": "~2.0 || ~3.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialiteProviders\\GameWisp\\": ""
+        }
+    }
+}


### PR DESCRIPTION
Added support for GameWisp. A fan funding service for livestreamers. 

This is a resubmission of [this closed PR](https://github.com/SocialiteProviders/Providers/pull/82).
