### PR TITLE
remove weixin provider scopes function

### DIFF
--- a/src/Weixin/Provider.php
+++ b/src/Weixin/Provider.php
@@ -127,14 +127,4 @@ class Provider extends AbstractProvider implements ProviderInterface
 
         return $this->credentialsResponseBody;
     }
-
-    /**
-     * {@inheritdoc}.
-     */
-    public function scopes(array $scopes)
-    {
-        $this->scopes = array_unique($scopes);
-
-        return $this;
-    }
 }


### PR DESCRIPTION
sync with laravel/socialite

compatible with Laravel\Socialite\Two\AbstractProvider::scopes($scopes)

see: [Let user pass a single scope as a string](https://github.com/laravel/socialite/commit/63e6baba3da1a24267a72ee9f36e418d35402c9b)