### PR TITLE
[Yammer] Fix token parsing

### DIFF
--- a/src/Yammer/Provider.php
+++ b/src/Yammer/Provider.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\Yammer;
 
+use Illuminate\Support\Arr;
 use SocialiteProviders\Manager\OAuth2\User;
 use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
@@ -73,6 +74,6 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     protected function parseAccessToken($body)
     {
-        return json_decode($body, true)['access_token']['token'];
+        return Arr::get($body, 'access_token.token');
     }
 }


### PR DESCRIPTION
Yammer's current implementation tries to use `json_decode` on the body while parsing the token, although it's already an array. I've fixed that.