### PR TITLE
Fixed NPE and JSON for Flickr provider

### DIFF
--- a/src/Flickr/Server.php
+++ b/src/Flickr/Server.php
@@ -47,6 +47,7 @@ class Server extends BaseServer
     {
         $data = $this->getProfile($data['user']['id']);
         $data = $data['person'];
+        $data['realname']['_content'] = isset($data['realname']['_content']) ? $data['realname']['_content'] : '';
 
         $user = new User();
         $user->id = $data['id'];
@@ -104,8 +105,7 @@ class Server extends BaseServer
 
         $client = $this->createHttpClient();
 
-        $response = $client->get($url)->send();
-
-        return $response->json();
+        $response = $client->request('GET', $url);
+        return json_decode($response->getBody()->getContents(), true);
     }
 }

--- a/src/Flickr/Server.php
+++ b/src/Flickr/Server.php
@@ -51,7 +51,7 @@ class Server extends BaseServer
         $user = new User();
         $user->id = $data['id'];
         $user->nickname = $data['username']['_content'];
-        $user->name = array_get($data, 'realname._content', '');
+        $user->name = array_get($data, 'realname._content');
         $user->extra = array_diff_key($data, array_flip([
             'id', 'username', 'realname',
         ]));

--- a/src/Flickr/Server.php
+++ b/src/Flickr/Server.php
@@ -106,6 +106,7 @@ class Server extends BaseServer
         $client = $this->createHttpClient();
 
         $response = $client->request('GET', $url);
+
         return json_decode($response->getBody()->getContents(), true);
     }
 }

--- a/src/Flickr/Server.php
+++ b/src/Flickr/Server.php
@@ -47,12 +47,11 @@ class Server extends BaseServer
     {
         $data = $this->getProfile($data['user']['id']);
         $data = $data['person'];
-        $data['realname']['_content'] = isset($data['realname']['_content']) ? $data['realname']['_content'] : '';
 
         $user = new User();
         $user->id = $data['id'];
         $user->nickname = $data['username']['_content'];
-        $user->name = $data['realname']['_content'];
+        $user->name = array_get($data, 'realname._content', '');
         $user->extra = array_diff_key($data, array_flip([
             'id', 'username', 'realname',
         ]));


### PR DESCRIPTION
Where the original would use a 'json()' method on the request, this was undefined. Hence, it now takes advantage of the 'json_decode()' function. Furthermore, the response I received did not contain a 'realname' entry and thus was throwing an NPE, a check is now in place to check for this field.

