### PR TITLE
Updates for V2 of the Dribbble API

### DIFF
--- a/src/Dribbble/Provider.php
+++ b/src/Dribbble/Provider.php
@@ -43,7 +43,7 @@ class Provider extends AbstractProvider implements ProviderInterface
     protected function getUserByToken($token)
     {
         $response = $this->getHttpClient()->get(
-            'https://api.dribbble.com/v1/user?access_token='.$token
+            'https://api.dribbble.com/v2/user?access_token='.$token
         );
 
         return json_decode($response->getBody()->getContents(), true);
@@ -55,7 +55,7 @@ class Provider extends AbstractProvider implements ProviderInterface
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([
-            'id'     => $user['id'], 'nickname' => $user['username'],
+            'id'     => $user['id'], 'nickname' => $user['login'],
             'name'   => $user['name'], 'email' => Arr::get($user, 'email'),
             'avatar' => $user['avatar_url'],
         ]);


### PR DESCRIPTION
V1 of the Dribbble API is now deprecated (http://developer.dribbble.com/changes/2017-12-05-api-v2/) and any new applications much use V2.

Only a couple of small changes.