### PR TITLE
TwitterProvider(OAuth1) additional query string

### DIFF
--- a/src/Twitter/Server.php
+++ b/src/Twitter/Server.php
@@ -97,4 +97,27 @@ class Server extends BaseServer
     {
         return $data['screen_name'];
     }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function getAuthorizationUrl($temporaryIdentifier)
+    {
+        // Somebody can pass through an instance of temporary
+        // credentials and we'll extract the identifier from there.
+        if ($temporaryIdentifier instanceof TemporaryCredentials) {
+            $temporaryIdentifier = $temporaryIdentifier->getIdentifier();
+        }
+        $query_oauth_token = array('oauth_token' => $temporaryIdentifier);
+        
+        $parameters = (isset($this->parameters))
+            ? array_merge($query_oauth_token, $this->parameters)
+            : $query_oauth_token;
+        
+        $url = $this->urlAuthorization();
+        $queryString = http_build_query($parameters);
+
+        return $this->buildUrl($url, $queryString);
+    }
+
 }

--- a/src/Twitter/Server.php
+++ b/src/Twitter/Server.php
@@ -97,7 +97,7 @@ class Server extends BaseServer
     {
         return $data['screen_name'];
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -108,16 +108,14 @@ class Server extends BaseServer
         if ($temporaryIdentifier instanceof TemporaryCredentials) {
             $temporaryIdentifier = $temporaryIdentifier->getIdentifier();
         }
-        $query_oauth_token = array('oauth_token' => $temporaryIdentifier);
-        
+        $query_oauth_token = ['oauth_token' => $temporaryIdentifier];
         $parameters = (isset($this->parameters))
             ? array_merge($query_oauth_token, $this->parameters)
             : $query_oauth_token;
-        
+
         $url = $this->urlAuthorization();
         $queryString = http_build_query($parameters);
 
         return $this->buildUrl($url, $queryString);
     }
-
 }


### PR DESCRIPTION
TwitterProvider(Oauth1) doesn't compatible an additional query string regardless of having a method with().

Laracast discussion 'Is it possible to use force_login for Twitter in Laravel Socialite?'.
https://laracasts.com/discuss/channels/laravel/is-it-possible-to-use-force-login-for-twitter-in-laravel-socialite

I updating method getAuthorizationUrl().
It allows additional query strings like calling with(['fource_url'=>true]) options as well as ['lang' => 'ja'] option.

if 'SocialiteProviders\Manager\OAuth1\Server' add this function, It might be compatible any other OAuth1 providers.
Please review it. thx.