### PR TITLE
GitLab provider: `scopes` array should not have empty string

### DIFF
--- a/src/GitLab/Provider.php
+++ b/src/GitLab/Provider.php
@@ -16,7 +16,7 @@ class Provider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
-    protected $scopes = [''];
+    protected $scopes = [];
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
`scopes` array in GitLab provider has empty string by default.
if the scopes ```['', 'read_repository']```
(by ```\Socialite::driver('gitlab')->scopes(['read_repository'])->redirect();```)
the query strings will be like ```&scopes=%2Cread_repository```
but I want ```&scopes=read_repository```
therefore the empty string should be deleted.