### PR TITLE
Fixed Discord provider not allowing user without email

### DIFF
--- a/src/Discord/Provider.php
+++ b/src/Discord/Provider.php
@@ -68,7 +68,7 @@ class Provider extends AbstractProvider implements ProviderInterface
             'id'       => $user['id'],
             'nickname' => sprintf('%s#%s', $user['username'], $user['discriminator']),
             'name'     => $user['username'],
-            'email'    => $user['email'],
+            'email'    => (array_key_exists('email', $user)) ? $user['email'] : null,
             'avatar'   => (is_null($user['avatar'])) ? null : sprintf('https://cdn.discordapp.com/avatars/%s/%s.jpg', $user['id'], $user['avatar']),
         ]);
     }


### PR DESCRIPTION
Currently, the Discord provider doesn't take into account when email OAuth scope is not selected and throws an exception.

When using `identify` and excluding `email` scopes, Discord provider tries to retrieve `email` array key within `mapUserToObject()` without checking if `email` exists. 

