### PR TITLE
Updated scope request for twitch due to new API

### DIFF
--- a/src/Twitch/Provider.php
+++ b/src/Twitch/Provider.php
@@ -16,7 +16,7 @@ class Provider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
-    protected $scopes = ['user_read'];
+    protected $scopes = ['user:read:email'];
 
     /**
      * {@inherticdoc}.


### PR DESCRIPTION
The scope "user_read" no longer returns a value for email under API  v3 and v5.   The "new" twitch API requires the scope "user:read:email" to obtain the email address.

Note: The default version of the API is v3 until Dec. 31, 2018. However, both v3 and v5 are deprecated and will be removed altogether at the end of 2018.

Reference:  https://dev.twitch.tv/docs/authentication/#scopes

