### PR TITLE
Allow retrieval of subdomain from a parameter

### DIFF
--- a/src/Shopify/Provider.php
+++ b/src/Shopify/Provider.php
@@ -92,7 +92,7 @@ class Provider extends AbstractProvider implements ProviderInterface
     private function shopifyUrl($uri = null)
     {
         if (!empty($this->parameters['subdomain'])) {
-            return 'https://' . $this->parameters['subdomain'] . '.myshopify.com' . $uri;
+            return 'https://'.$this->parameters['subdomain'].'.myshopify.com'.$uri;
         }
         if ($this->getConfig('subdomain')) {
             return "https://{$this->getConfig('subdomain')}.myshopify.com".$uri;

--- a/src/Shopify/Provider.php
+++ b/src/Shopify/Provider.php
@@ -91,6 +91,9 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     private function shopifyUrl($uri = null)
     {
+        if (!empty($this->parameters['subdomain'])) {
+            return 'https://' . $this->parameters['subdomain'] . '.myshopify.com' . $uri;
+        }
         if ($this->getConfig('subdomain')) {
             return "https://{$this->getConfig('subdomain')}.myshopify.com".$uri;
         }


### PR DESCRIPTION
This change allows the Shopify subdomain to be retrieved from the parameters if it exists.

This makes it easy to use the Provider via the Socialite facade e.g.

```php
return Socialite::with('Shopify')
                ->with([ 'subdomain' => $request->shopify_url ])
                ->redirect();
```

rather than having to redeclare a full config object, e.g.

```php
$config = config('services.shopify');
$config = new \SocialiteProviders\Manager\Config(
    $config['client_id'],
    $config['client_secret'],
    $config['redirect_url'],
    ['subdomain' => $request->shopify_url]
);
return \Socialite::with($this->driver)->setConfig($config)->redirect();
```