### PR TITLE
Allow override of Battle.net region via provider

### DIFF
--- a/src/Battle.net/Provider.php
+++ b/src/Battle.net/Provider.php
@@ -23,6 +23,8 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     protected $scopeSeparator = '+';
 
+    protected static $region = null;
+
     /**
      * {@inheritdoc}
      */
@@ -82,6 +84,10 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     protected function getRegion()
     {
+        if (self::$region) {
+            return self::$region;
+        }
+
         return $this->getConfig('region', 'us');
     }
 
@@ -91,5 +97,10 @@ class Provider extends AbstractProvider implements ProviderInterface
     public static function additionalConfigKeys()
     {
         return ['region'];
+    }
+
+    public static function setRegion($region)
+    {
+        self::$region = $region;
     }
 }


### PR DESCRIPTION
Blizzard's Battle.net API is region sensitive. The problem at hand is that we currently can only set the region statically in the config making it impossible to host the same site for people with e.g. EU and US accounts.

This adds the possibility of dynamically setting the region during runtime if necessary. If nothing is set it will default to what is specified in the config.