### PR TITLE
Override scope separator to use space instead of comma.

### DIFF
--- a/src/LaravelPassport/Provider.php
+++ b/src/LaravelPassport/Provider.php
@@ -22,6 +22,11 @@ class Provider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
+    protected $scopeSeparator = ' ';
+
+    /**
+     * {@inheritdoc}
+     */
     public static function additionalConfigKeys()
     {
         return [


### PR DESCRIPTION
Laravel passport uses a space separator between different scopes in the authorization request. From the documentation: "The scope parameter should be a space-delimited list of scopes" (https://laravel.com/docs/5.6/passport#assigning-scopes-to-tokens)