### PR TITLE
[Change] Introduces the Ability to Login to a Specific (Microsoft Graph) Tenant

### DIFF
--- a/src/Microsoft-Graph/Provider.php
+++ b/src/Microsoft-Graph/Provider.php
@@ -26,11 +26,45 @@ class Provider extends AbstractProvider implements ProviderInterface
     protected $scopeSeparator = ' ';
 
     /**
+     * Allows you to override the tenant id that the provider is configured
+     * with.
+     *
+     * @param string $tenantId
+     *
+     * @return \SocialiteProviders\Graph\Provider
+     */
+    public function setTenantId($tenantId)
+    {
+        $this->config = array_merge($this->config, [
+            'tenant_id' => $tenantId,
+        ]);
+
+        return $this;
+    }
+
+    /**
+     * Returns the configured tenant that we're authenticating with, or common
+     * if one is not configured.
+     *
+     * @return string
+     */
+    private function getTenantId()
+    {
+        return $this->getConfig('tenant_id', 'common');
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getAuthUrl($state)
     {
-        return $this->buildAuthUrlFromBase('https://login.microsoftonline.com/common/oauth2/v2.0/authorize', $state);
+        return $this->buildAuthUrlFromBase(
+            sprintf(
+                'https://login.microsoftonline.com/%s/oauth2/v2.0/authorize',
+                $this->getTenantId()
+            ),
+            $state
+        );
     }
 
     /**
@@ -38,7 +72,10 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     protected function getTokenUrl()
     {
-        return 'https://login.microsoftonline.com/common/oauth2/v2.0/token';
+        return sprintf(
+            'https://login.microsoftonline.com/%s/oauth2/v2.0/token',
+            $this->getTenantId()
+        );
     }
 
     /**


### PR DESCRIPTION
This change was made to accommodate the ability to configure the tenant that you are authenticating against in the graph api. It covers the case where you would prefer to use the tenant specific profile for a guest user. I.E. All users authenticating to my application must be in the same tenant on Microsoft.

I discovered this issue when I attempted to add a guest user to my (multi-tenant) application. Since the application I'm working on maps it's tenants to Microsoft graph tenants I wanted to ensure that the guest user that was logging into my application does in fact have an account on the corresponding Microsoft tenant. With the common login endpoint the user was being returned with an id that did not match the user listing specific to a tenant. To resolve this I had to update to leverage the oauth endpoint for that specific tenant vs the common authentication endpoint.

The goal of this change was to ensure we preserve the existing functionality as the default behaviour so existing deployments leverage the common authentication endpoint.

