### PR TITLE
fix email should be userPrincipalName attribute

### DIFF
--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -72,7 +72,7 @@ class Provider extends AbstractProvider implements ProviderInterface
             'id'       => $user['id'],
             'nickname' => null,
             'name'     => $user['displayName'],
-            'email'    => $user['mail'],
+            'email'    => $user['userPrincipalName'],
             'avatar'   => null,
 
             'businessPhones'    => $user['businessPhones'],


### PR DESCRIPTION
https://github.com/microsoftgraph/microsoft-graph-docs/blob/master/api-reference/v1.0/resources/user.md#properties

| Property       | Type    |Description|
|:---------------|:--------|:----------|
|mail|String|The SMTP address for the user, for example, "jeff@contoso.onmicrosoft.com". Read-Only. Supports $filter.|
|userPrincipalName|String|The user principal name (UPN) of the user. The UPN is an Internet-style login name for the user based on the Internet standard RFC 822. By convention, this should map to the user's email name. The general format is alias@domain, where domain must be present in the tenant’s collection of verified domains. This property is required when a user is created. The verified domains for the tenant can be accessed from the **verifiedDomains** property of [organization](organization.md). Supports $filter and $orderby.
