### PR TITLE
Trello: Added id, name, email and avatar

### DIFF
--- a/src/Trello/Provider.php
+++ b/src/Trello/Provider.php
@@ -18,11 +18,11 @@ class Provider extends AbstractProvider
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user['extra'])->map([
-            'id'       => null,
+            'id' => $user['extra']['id'],
             'nickname' => $user['nickname'],
-            'name'     => null,
-            'email'    => null,
-            'avatar'   => null,
+            'name' => $user['extra']['fullName'],
+            'email' => $user['extra']['email'],
+            'avatar' => $user['extra']['uploadedAvatarUrl'],
         ]);
     }
 }


### PR DESCRIPTION
I replaced the default null values for the according fields.

If you want to access the email address, you have to pass the `account` scope.