### PR TITLE
Change Battle.net user info URL

### DIFF
--- a/src/Battle.net/Provider.php
+++ b/src/Battle.net/Provider.php
@@ -46,7 +46,7 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     protected function getUserByToken($token)
     {
-        $response = $this->getHttpClient()->get('https://'.$this->getRegion().'.api.battle.net/account/user', [
+        $response = $this->getHttpClient()->get('https://'.$this->getRegion().'.battle.net/oauth/userinfo', [
             'headers' => [
                 'Authorization' => 'Bearer '.$token,
             ],


### PR DESCRIPTION
As Blizzard recently switched to their new developer portal they also change their endpoints a little. One of those changes was to change the endpoint to retrieve user infos (as referenced here: https://develop.battle.net/documentation/guides/using-oauth/authorization-code-flow).

