### PR TITLE
Update for compatibility with manager

### DIFF
--- a/src/Harvest/composer.json
+++ b/src/Harvest/composer.json
@@ -8,7 +8,7 @@
     }],
     "require": {
         "php": "^5.6 || ^7.0",
-        "socialiteproviders/manager": "^2.0" || "^3.0"
+        "socialiteproviders/manager": "^2.0 || ^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Harvest/composer.json
+++ b/src/Harvest/composer.json
@@ -8,7 +8,7 @@
     }],
     "require": {
         "php": "^5.6 || ^7.0",
-        "socialiteproviders/manager": "^2.0"
+        "socialiteproviders/manager": "^2.0" || "^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Latest version of "socialiteproviders/manager": "^3.3"

Error without this modification:
 - socialiteproviders/harvest v1.0.0 requires socialiteproviders/manager ^2.0 -> satisfiable by socialiteproviders/manager[2.0.x-dev].

