### PR TITLE
Upgrade to manager 3.3

### DIFF
--- a/src/Harvest/composer.json
+++ b/src/Harvest/composer.json
@@ -8,7 +8,7 @@
     }],
     "require": {
         "php": "^5.6 || ^7.0",
-        "socialiteproviders/manager": "^2.0 || ^3.0"
+        "socialiteproviders/manager": "^2.0 || ^3.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Latest change not work for socialiteproviders/manager 3.3

```
Installation request for socialiteproviders/harvest ^1.0 -> satisfiable by socialiteproviders/harvest[v1.0.0].
    - Installation request for socialiteproviders/manager (locked at v3.3.1, required as ^3.3) -> satisfiable by socialiteproviders/manager[v3.3.1].
```

