### PR TITLE
Fix broken PSR-4 autoloader

### DIFF
--- a/src/Acclaim/composer.json
+++ b/src/Acclaim/composer.json
@@ -5,6 +5,9 @@
     "authors": [{
         "name": "Pavan Kumar",
         "email": "katakampavan.btech@gmail.com"
+    }, {
+        "name": "Anton Komarev",
+        "email": "ell@cybercog.su"
     }],
     "require": {
         "php": "^5.6 || ^7.0",
@@ -12,7 +15,7 @@
     },
     "autoload": {
         "psr-4": {
-            "SocialiteProviders\\Acclaim\\": "src/"
+            "SocialiteProviders\\Acclaim\\": ""
         }
     }
 }

--- a/src/App.net/composer.json
+++ b/src/App.net/composer.json
@@ -5,6 +5,9 @@
     "authors": [{
         "name": "DraperStudio",
         "email": "hello@draperstud.io"
+    }, {
+        "name": "Anton Komarev",
+        "email": "ell@cybercog.su"
     }],
     "require": {
         "php": "^5.6 || ^7.0",
@@ -12,7 +15,7 @@
     },
     "autoload": {
         "psr-4": {
-            "SocialiteProviders\\AppNet\\": "src/"
+            "SocialiteProviders\\AppNet\\": ""
         }
     }
 }

--- a/src/Microsoft-TeamService/composer.json
+++ b/src/Microsoft-TeamService/composer.json
@@ -5,6 +5,9 @@
     "authors": [{
         "name": "Te7a-Houdini",
         "email": "ahmedabdelftah95165@gmail.com"
+    }, {
+        "name": "Anton Komarev",
+        "email": "ell@cybercog.su"
     }],
     "require": {
         "php": "^5.6 || ^7.0",
@@ -12,7 +15,7 @@
     },
     "autoload": {
         "psr-4": {
-            "SocialiteProviders\\TeamService\\": "src/"
+            "SocialiteProviders\\TeamService\\": ""
         }
     }
 }

--- a/src/Teamleader/composer.json
+++ b/src/Teamleader/composer.json
@@ -5,6 +5,9 @@
     "authors": [{
         "name": "13°",
         "email": "dev@13-grad.com"
+    }, {
+        "name": "Anton Komarev",
+        "email": "ell@cybercog.su"
     }],
     "require": {
         "php": "^5.6 || ^7.0",
@@ -12,7 +15,7 @@
     },
     "autoload": {
         "psr-4": {
-            "SocialiteProviders\\Teamleader\\": "src/"
+            "SocialiteProviders\\Teamleader\\": ""
         }
     }
 }

--- a/src/UCL/composer.json
+++ b/src/UCL/composer.json
@@ -4,6 +4,9 @@
     "license": "MIT",
     "authors": [{
         "name": "Balázs Dura-Kovács"
+    }, {
+        "name": "Anton Komarev",
+        "email": "ell@cybercog.su"
     }],
     "require": {
         "php": ">=7.0",
@@ -11,7 +14,7 @@
     },
     "autoload": {
         "psr-4": {
-            "SocialiteProviders\\UCL\\": "src/"
+            "SocialiteProviders\\UCL\\": ""
         }
     }
 }


### PR DESCRIPTION
These providers were broken:
- Microsoft-TeamService
- App.net
- Acclaim
- UCL
- Teamleader

PSR-4 autoloader tried to find sources in not exists `/src` directory.

Additionally I've found that these 2 Providers don't have split repositories (but it exists in split.sh):
- UCL
- Teamleader