### PR TITLE
Add root composer.json file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2016 SocialiteProviders
+Copyright (c) 2015-2019 SocialiteProviders
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "socialiteproviders/providers",
+    "description": "Collection of all OAuth2 Providers for Laravel Socialite",
+    "license": "MIT",
+    "require": {
+        "php": "^5.6 || ^7.0",
+        "socialiteproviders/manager": "~2.0 || ~3.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialiteProviders\\": "src/"
+        }
+    }
+}


### PR DESCRIPTION
This PR resolves https://github.com/SocialiteProviders/Manager/issues/132
Because all the providers have same directory architecture now - we can register root `src` directory as `SocialiteProviders\\`. PSR-4 autoloader should handle this correctly.

If new package called `socialiteproviders/providers` will be added in Packagist - then by pulling it into the application we will be able to use any provider we want without separate packages installations.

Additionally I've updated year in license file.