### PR TITLE
Providers from stock should implement manager interfaces

### DIFF
--- a/src/Bitbucket/Provider.php
+++ b/src/Bitbucket/Provider.php
@@ -4,8 +4,9 @@ namespace SocialiteProviders\Bitbucket;
 
 use Laravel\Socialite\Two\BitbucketProvider;
 use SocialiteProviders\Manager\ConfigTrait;
+use SocialiteProviders\Manager\Contracts\OAuth2\ProviderInterface;
 
-class Provider extends BitbucketProvider
+class Provider extends BitbucketProvider implements ProviderInterface
 {
     use ConfigTrait;
 

--- a/src/Facebook/Provider.php
+++ b/src/Facebook/Provider.php
@@ -4,8 +4,9 @@ namespace SocialiteProviders\Facebook;
 
 use Laravel\Socialite\Two\FacebookProvider;
 use SocialiteProviders\Manager\ConfigTrait;
+use SocialiteProviders\Manager\Contracts\OAuth2\ProviderInterface;
 
-class Provider extends FacebookProvider
+class Provider extends FacebookProvider implements ProviderInterface
 {
     use ConfigTrait;
 

--- a/src/GitHub/Provider.php
+++ b/src/GitHub/Provider.php
@@ -4,8 +4,9 @@ namespace SocialiteProviders\GitHub;
 
 use Laravel\Socialite\Two\GithubProvider;
 use SocialiteProviders\Manager\ConfigTrait;
+use SocialiteProviders\Manager\Contracts\OAuth2\ProviderInterface;
 
-class Provider extends GithubProvider
+class Provider extends GithubProvider implements ProviderInterface
 {
     use ConfigTrait;
 


### PR DESCRIPTION
These providers extends stock Socialite providers. It will be better to additionally set that they are implements `SocialiteProviders\Manager\Contracts\OAuth2\ProviderInterface` interface too.