### PR TITLE
Remove contract declaration because already defined in parent class

### DIFF
--- a/src/23andme/Provider.php
+++ b/src/23andme/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\TwentyThreeAndMe;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/37Signals/Provider.php
+++ b/src/37Signals/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\ThirtySevenSignals;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Acclaim/Provider.php
+++ b/src/Acclaim/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Acclaim;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Admitad/Provider.php
+++ b/src/Admitad/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Admitad;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/AngelList/Provider.php
+++ b/src/AngelList/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\AngelList;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/App.net/Provider.php
+++ b/src/App.net/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\AppNet;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/ArcGIS/Provider.php
+++ b/src/ArcGIS/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\ArcGIS;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Asana/Provider.php
+++ b/src/Asana/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Asana;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Battle.net/Provider.php
+++ b/src/Battle.net/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Battlenet;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Bit.ly/Provider.php
+++ b/src/Bit.ly/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Bitly;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Box/Provider.php
+++ b/src/Box/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Box;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Buffer/Provider.php
+++ b/src/Buffer/Provider.php
@@ -3,11 +3,11 @@
 namespace SocialiteProviders\Buffer;
 
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
+
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/CampaignMonitor/Provider.php
+++ b/src/CampaignMonitor/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\CampaignMonitor;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Cheddar/Provider.php
+++ b/src/Cheddar/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Cheddar;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Coinbase/Provider.php
+++ b/src/Coinbase/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Coinbase;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/ConstantContact/Provider.php
+++ b/src/ConstantContact/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\ConstantContact;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Coursera/Provider.php
+++ b/src/Coursera/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Coursera;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Dailymile/Provider.php
+++ b/src/Dailymile/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Dailymile;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Dailymotion/Provider.php
+++ b/src/Dailymotion/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Dailymotion;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Dataporten/Provider.php
+++ b/src/Dataporten/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Dataporten;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Deezer/Provider.php
+++ b/src/Deezer/Provider.php
@@ -3,10 +3,10 @@
 namespace SocialiteProviders\Deezer;
 
 use SocialiteProviders\Manager\OAuth2\User;
-use Laravel\Socialite\Two\ProviderInterface;
+
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/DigitalOcean/Provider.php
+++ b/src/DigitalOcean/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\DigitalOcean;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Discord/Provider.php
+++ b/src/Discord/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Discord;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Disqus/Provider.php
+++ b/src/Disqus/Provider.php
@@ -3,11 +3,10 @@
 namespace SocialiteProviders\Disqus;
 
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Douban/Provider.php
+++ b/src/Douban/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Douban;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Dribbble/Provider.php
+++ b/src/Dribbble/Provider.php
@@ -3,11 +3,10 @@
 namespace SocialiteProviders\Dribbble;
 
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Dropbox/Provider.php
+++ b/src/Dropbox/Provider.php
@@ -3,11 +3,10 @@
 namespace SocialiteProviders\Dropbox;
 
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Envato/Provider.php
+++ b/src/Envato/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Envato;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Eventbrite/Provider.php
+++ b/src/Eventbrite/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Eventbrite;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Everyplay/Provider.php
+++ b/src/Everyplay/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Everyplay;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/EyeEm/Provider.php
+++ b/src/EyeEm/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\EyeEm;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Fitbit/Provider.php
+++ b/src/Fitbit/Provider.php
@@ -3,11 +3,10 @@
 namespace SocialiteProviders\Fitbit;
 
 use GuzzleHttp\ClientInterface;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Flattr/Provider.php
+++ b/src/Flattr/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Flattr;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Foursquare/Provider.php
+++ b/src/Foursquare/Provider.php
@@ -3,11 +3,10 @@
 namespace SocialiteProviders\Foursquare;
 
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/GameWisp/Provider.php
+++ b/src/GameWisp/Provider.php
@@ -3,11 +3,10 @@
 namespace SocialiteProviders\GameWisp;
 
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/GitLab/Provider.php
+++ b/src/GitLab/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\GitLab;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Google-Plus/Provider.php
+++ b/src/Google-Plus/Provider.php
@@ -3,11 +3,10 @@
 namespace SocialiteProviders\Google;
 
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Harvest/Provider.php
+++ b/src/Harvest/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Harvest;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Heroku/Provider.php
+++ b/src/Heroku/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Heroku;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Hitbox/Provider.php
+++ b/src/Hitbox/Provider.php
@@ -3,11 +3,10 @@
 namespace SocialiteProviders\Hitbox;
 
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/HubSpot/Provider.php
+++ b/src/HubSpot/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\HubSpot;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Human-API/Provider.php
+++ b/src/Human-API/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\HumanApi;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/IFSP/Provider.php
+++ b/src/IFSP/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\IFSP;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Imgur/Provider.php
+++ b/src/Imgur/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Imgur;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Instagram/Provider.php
+++ b/src/Instagram/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Instagram;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Intercom/Provider.php
+++ b/src/Intercom/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Intercom;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Jawbone/Provider.php
+++ b/src/Jawbone/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Jawbone;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Kakao/KakaoProvider.php
+++ b/src/Kakao/KakaoProvider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Kakao;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class KakaoProvider extends AbstractProvider implements ProviderInterface
+class KakaoProvider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/LaravelPassport/Provider.php
+++ b/src/LaravelPassport/Provider.php
@@ -3,11 +3,10 @@
 namespace SocialiteProviders\LaravelPassport;
 
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Line/Provider.php
+++ b/src/Line/Provider.php
@@ -3,11 +3,10 @@
 namespace SocialiteProviders\Line;
 
 use Laravel\Socialite\Two\InvalidStateException;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/LinkedIn/Provider.php
+++ b/src/LinkedIn/Provider.php
@@ -4,12 +4,11 @@ namespace SocialiteProviders\LinkedIn;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/MailChimp/Provider.php
+++ b/src/MailChimp/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\MailChimp;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/MakerLog/Provider.php
+++ b/src/MakerLog/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\MakerLog;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Mattermost/Provider.php
+++ b/src/Mattermost/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Mattermost;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Medium/Provider.php
+++ b/src/Medium/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Medium;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Meetup/Provider.php
+++ b/src/Meetup/Provider.php
@@ -3,11 +3,10 @@
 namespace SocialiteProviders\Meetup;
 
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Microsoft-Azure/Provider.php
+++ b/src/Microsoft-Azure/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Azure;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Microsoft-Graph/Provider.php
+++ b/src/Microsoft-Graph/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Graph;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Microsoft-Live/Provider.php
+++ b/src/Microsoft-Live/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Live;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Microsoft-TeamService/Provider.php
+++ b/src/Microsoft-TeamService/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\TeamService;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Microsoft;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Mixcloud/Provider.php
+++ b/src/Mixcloud/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Mixcloud;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Mixer/Provider.php
+++ b/src/Mixer/Provider.php
@@ -3,11 +3,10 @@
 namespace SocialiteProviders\Mixer;
 
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Mollie/Provider.php
+++ b/src/Mollie/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Mollie;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Moves/Provider.php
+++ b/src/Moves/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Moves;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Naver/NaverProvider.php
+++ b/src/Naver/NaverProvider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Naver;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class NaverProvider extends AbstractProvider implements ProviderInterface
+class NaverProvider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/OSChina/Provider.php
+++ b/src/OSChina/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\OSChina;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Odnoklassniki/Provider.php
+++ b/src/Odnoklassniki/Provider.php
@@ -3,11 +3,10 @@
 namespace SocialiteProviders\Odnoklassniki;
 
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Okta/Provider.php
+++ b/src/Okta/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Okta;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Orcid/Provider.php
+++ b/src/Orcid/Provider.php
@@ -4,13 +4,10 @@ namespace SocialiteProviders\Orcid;
 
 use Exception;
 use Illuminate\Support\Arr;
-#use Laravel\Socialite\Two\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
-use Laravel\Socialite\Two\ProviderInterface;
-#use Laravel\Socialite\Two\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier

--- a/src/Patreon/Provider.php
+++ b/src/Patreon/Provider.php
@@ -3,11 +3,10 @@
 namespace SocialiteProviders\Patreon;
 
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/PayPal-Sandbox/Provider.php
+++ b/src/PayPal-Sandbox/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\PayPalSandbox;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/PayPal/Provider.php
+++ b/src/PayPal/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\PayPal;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Paymill/Provider.php
+++ b/src/Paymill/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Paymill;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Pinterest/Provider.php
+++ b/src/Pinterest/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Pinterest;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Pipedrive/Provider.php
+++ b/src/Pipedrive/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Pipedrive;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Podio/Provider.php
+++ b/src/Podio/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Podio;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/ProductHunt/Provider.php
+++ b/src/ProductHunt/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\ProductHunt;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/ProjectV/Provider.php
+++ b/src/ProjectV/Provider.php
@@ -3,11 +3,10 @@
 namespace SocialiteProviders\ProjectV;
 
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Pushbullet/Provider.php
+++ b/src/Pushbullet/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Pushbullet;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/QQ/Provider.php
+++ b/src/QQ/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\QQ;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Redbooth/Provider.php
+++ b/src/Redbooth/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Redbooth;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Reddit/Provider.php
+++ b/src/Reddit/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Reddit;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/RunKeeper/Provider.php
+++ b/src/RunKeeper/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\RunKeeper;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/SalesForce/Provider.php
+++ b/src/SalesForce/Provider.php
@@ -3,11 +3,10 @@
 namespace SocialiteProviders\SalesForce;
 
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/SciStarter/Provider.php
+++ b/src/SciStarter/Provider.php
@@ -4,11 +4,10 @@ namespace SocialiteProviders\SciStarter;
 
 use GuzzleHttp\ClientInterface;
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/SharePoint/Provider.php
+++ b/src/SharePoint/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\SharePoint;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Shopify/Provider.php
+++ b/src/Shopify/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Shopify;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Slack/Provider.php
+++ b/src/Slack/Provider.php
@@ -6,12 +6,11 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\HandlerStack;
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
 use Psr\Http\Message\ResponseInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Smashcast/Provider.php
+++ b/src/Smashcast/Provider.php
@@ -3,11 +3,10 @@
 namespace SocialiteProviders\Smashcast;
 
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Snapchat/Provider.php
+++ b/src/Snapchat/Provider.php
@@ -3,11 +3,10 @@
 namespace SocialiteProviders\Snapchat;
 
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/SoundCloud/Provider.php
+++ b/src/SoundCloud/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\SoundCloud;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Spotify/Provider.php
+++ b/src/Spotify/Provider.php
@@ -3,11 +3,10 @@
 namespace SocialiteProviders\Spotify;
 
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/StackExchange/Provider.php
+++ b/src/StackExchange/Provider.php
@@ -2,7 +2,6 @@
 
 namespace SocialiteProviders\StackExchange;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -10,7 +9,7 @@ use SocialiteProviders\Manager\OAuth2\User;
  * https://api.stackexchange.com/docs/authentication
  * Class Provider.
  */
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Steam/Provider.php
+++ b/src/Steam/Provider.php
@@ -3,12 +3,11 @@
 namespace SocialiteProviders\Steam;
 
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
 use LightOpenID;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Steem/Provider.php
+++ b/src/Steem/Provider.php
@@ -4,11 +4,10 @@ namespace SocialiteProviders\Steem;
 
 use GuzzleHttp\ClientInterface;
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/StockTwits/Provider.php
+++ b/src/StockTwits/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\StockTwits;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Strava/Provider.php
+++ b/src/Strava/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Strava;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Stripe/Provider.php
+++ b/src/Stripe/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Stripe;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/TVShowTime/Provider.php
+++ b/src/TVShowTime/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\TVShowTime;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Teamleader/Provider.php
+++ b/src/Teamleader/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Teamleader;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Teamweek/Provider.php
+++ b/src/Teamweek/Provider.php
@@ -3,11 +3,10 @@
 namespace SocialiteProviders\Teamweek;
 
 use GuzzleHttp\ClientInterface;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Trakt/Provider.php
+++ b/src/Trakt/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Trakt;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Twitch/Provider.php
+++ b/src/Twitch/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Twitch;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/UCL/Provider.php
+++ b/src/UCL/Provider.php
@@ -4,11 +4,10 @@ namespace SocialiteProviders\UCL;
 
 use Illuminate\Support\Arr;
 use Laravel\Socialite\Two\InvalidStateException;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/UFS/Provider.php
+++ b/src/UFS/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\UFS;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Uber/Provider.php
+++ b/src/Uber/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Uber;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Ufutx/Provider.php
+++ b/src/Ufutx/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Ufutx;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Unsplash/Provider.php
+++ b/src/Unsplash/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Unsplash;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Untappd/Provider.php
+++ b/src/Untappd/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Untappd;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/VKontakte/Provider.php
+++ b/src/VKontakte/Provider.php
@@ -3,11 +3,10 @@
 namespace SocialiteProviders\VKontakte;
 
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     protected $fields = ['id', 'email', 'first_name', 'last_name', 'screen_name', 'photo'];
 

--- a/src/Venmo/Provider.php
+++ b/src/Venmo/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Venmo;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/VersionOne/Provider.php
+++ b/src/VersionOne/Provider.php
@@ -4,11 +4,10 @@ namespace SocialiteProviders\VersionOne;
 
 use Guzzle\Http\Exception\BadResponseException;
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Vimeo/Provider.php
+++ b/src/Vimeo/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Vimeo;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Weibo/Provider.php
+++ b/src/Weibo/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Weibo;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Weixin-Web/Provider.php
+++ b/src/Weixin-Web/Provider.php
@@ -3,11 +3,10 @@
 namespace SocialiteProviders\WeixinWeb;
 
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Weixin/Provider.php
+++ b/src/Weixin/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Weixin;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/WordPress/Provider.php
+++ b/src/WordPress/Provider.php
@@ -3,11 +3,10 @@
 namespace SocialiteProviders\WordPress;
 
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Yahoo/Provider.php
+++ b/src/Yahoo/Provider.php
@@ -3,11 +3,10 @@
 namespace SocialiteProviders\Yahoo;
 
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Yammer/Provider.php
+++ b/src/Yammer/Provider.php
@@ -3,11 +3,10 @@
 namespace SocialiteProviders\Yammer;
 
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Yandex/Provider.php
+++ b/src/Yandex/Provider.php
@@ -3,11 +3,11 @@
 namespace SocialiteProviders\Yandex;
 
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\ProviderInterface;
+
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Yiban/Provider.php
+++ b/src/Yiban/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Yiban;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/YouTube/Provider.php
+++ b/src/YouTube/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\YouTube;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/Zendesk/Provider.php
+++ b/src/Zendesk/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\Zendesk;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.

--- a/src/deviantART/Provider.php
+++ b/src/deviantART/Provider.php
@@ -2,11 +2,10 @@
 
 namespace SocialiteProviders\deviantART;
 
-use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.


### PR DESCRIPTION
Removed `Laravel\Socialite\Two\ProviderInterface` contract definition from all the providers because it's already defined in parent  class `SocialiteProviders\Manager\OAuth2\AbstractProvider` which each of these providers are extending.

All of these providers requiring `Manager` v2+ and `AbstractProvider` implements `SocialiteProviders\Manager\Contracts\OAuth2\ProviderInterface` which extends default Socialite provider interface since 2.0.0 [(proof)](https://github.com/SocialiteProviders/Manager/blob/81227c65830fb5592e15f5b0db0ab481484fdba2/src/Contracts/OAuth2/ProviderInterface.php).