### PR TITLE
Add support for socialiteproviders/manager 3.0

### DIFF
--- a/src/Flexkids/composer.json
+++ b/src/Flexkids/composer.json
@@ -8,7 +8,7 @@
     }],
     "require": {
         "php": ">=5.5.9",
-        "socialiteproviders/manager": "^2.0"
+        "socialiteproviders/manager": "~2.0 || ~3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Sorry the generator template has no support for socialiteproviders/manager 3.0. I have also created an PR for the generator to correct this.