### PR TITLE
Fixes to Steam provider

### DIFF
--- a/src/Steam/Provider.php
+++ b/src/Steam/Provider.php
@@ -81,10 +81,8 @@ class Provider extends AbstractProvider
      */
     protected function getUserByToken($token)
     {
-        $endpoint = 'https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=%s&steamids=%s';
-
         $response = $this->getHttpClient()->get(
-            sprintf($endpoint, $this->getConfig('client_secret'), $token)
+            sprintf('https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=%s&steamids=%s', $this->clientSecret, $token)
         );
 
         $contents = json_decode($response->getBody()->getContents(), true);

--- a/src/Steam/Provider.php
+++ b/src/Steam/Provider.php
@@ -119,4 +119,9 @@ class Provider extends AbstractProvider
     protected function getTokenUrl()
     {
     }
+
+    public static function additionalConfigKeys()
+    {
+        return ['proxy'];
+    }
 }

--- a/src/Steam/Provider.php
+++ b/src/Steam/Provider.php
@@ -24,7 +24,7 @@ class Provider extends AbstractProvider
      *
      * @return \LightOpenID
      */
-    private function getOpenID()
+    protected function getOpenID()
     {
         $openID = new LightOpenID(
             $redirect = $this->getConfig('redirect'),

--- a/src/Steam/Provider.php
+++ b/src/Steam/Provider.php
@@ -27,7 +27,7 @@ class Provider extends AbstractProvider
     protected function getOpenID()
     {
         $openID = new LightOpenID(
-            $redirect = $this->getConfig('redirect'),
+            $redirect = $this->redirectUrl,
             $this->getConfig('proxy')
         );
 


### PR DESCRIPTION
Hey. I made a few changes to Steam provider for it to be easier to both test and use:
- changed private to protected, to allow to overwrite the method if needed
- changed direct config references (to 'redirect' and 'client_secret') to corresponding class properties, so they can be set using socialite's default methods. That's how it works in other providers
- overwritten additionalConfigKeys method to allow the use of 'proxy' config value

All of the changes should be safe. I would be thankful if you could merge and release the changes as soon as possible, because there's no way I know of to pull from forked splitted repo.