### PR TITLE
Fixed Undefined index error in Strava provider

### DIFF
--- a/src/Strava/Provider.php
+++ b/src/Strava/Provider.php
@@ -51,9 +51,11 @@ class Provider extends AbstractProvider
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([
-            'id'    => $user['id'], 'nickname' => null,
+            'id'    => $user['id'],
+            'nickname' => null,
             'name'  => $user['firstname'].' '.$user['lastname'],
-            'email' => $user['email'], 'avatar' => $user['profile_medium'],
+            'email' => null,
+            'avatar' => $user['profile_medium'],
         ]);
     }
 


### PR DESCRIPTION
As per the Strava docs

January 15, 2019
Email address is no longer part of the profile:read_all scope and is removed from the athlete model.