### PR TITLE
Stripe api change 20190219

### DIFF
--- a/src/Stripe/Provider.php
+++ b/src/Stripe/Provider.php
@@ -55,8 +55,15 @@ class Provider extends AbstractProvider
      */
     protected function mapUserToObject(array $user)
     {
+        $nickname = null;
+        if (isset($user['settings']['dashboard']['display_name'])) { // 2019-02-19 API change
+            $nickname = $user['settings']['dashboard']['display_name'];
+        } else if (isset($user['display_name'])) { // original location
+            $nickname = $user['display_name'];
+        }
+
         return (new User())->setRaw($user)->map([
-            'id'   => $user['id'], 'nickname' => $user['settings']['dashboard']['display_name'],
+            'id' => $user['id'], 'nickname' => $nickname,
             'name' => null, 'email' => $user['email'], 'avatar' => null,
         ]);
     }

--- a/src/Stripe/Provider.php
+++ b/src/Stripe/Provider.php
@@ -56,7 +56,7 @@ class Provider extends AbstractProvider
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([
-            'id'   => $user['id'], 'nickname' => $user['display_name'],
+            'id'   => $user['id'], 'nickname' => $user['settings']['dashboard']['display_name'],
             'name' => null, 'email' => $user['email'], 'avatar' => null,
         ]);
     }


### PR DESCRIPTION
Per the Stripe API Changelog (https://stripe.com/docs/upgrades#api-changelog):

As of the 2019-02-19 release
> The display_name and timezone fields have been moved to settings[dashboard].
