### PR TITLE
Added scopes for Vimeo Authentication

### DIFF
--- a/src/Vimeo/Provider.php
+++ b/src/Vimeo/Provider.php
@@ -15,6 +15,16 @@ class Provider extends AbstractProvider
     /**
      * {@inheritdoc}
      */
+    protected $scopes = [ 'public' ];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopeSeparator = ' ';
+
+    /**
+     * {@inheritdoc}
+     */
     protected function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase(


### PR DESCRIPTION
Vimeo authentication supports scopes, so I just added the properties for default scope, and separator in order to make it work.

See Vimeo doc for more about scopes: https://developer.vimeo.com/api/authentication