### PR TITLE
Revert "Fixed bug so that user id can be unionid"

### DIFF
--- a/src/WeChatServiceAccount/Provider.php
+++ b/src/WeChatServiceAccount/Provider.php
@@ -60,8 +60,8 @@ class Provider extends AbstractProvider
     {
         return (new User())->setRaw($user)->map([
             // HACK: use unionid as user id
-            'id'       => isset($user['unionid']) ? $user['unionid'] : $user['openid'],
-            // HACK: Tencent scope snsapi_base only return openid
+            'id'       => in_array('unionid', $this->getScopes()) ? $user['unionid'] : $user['openid'],
+             // HACK: Tencent scope snsapi_base only return openid
             'nickname' => isset($user['nickname']) ? $user['nickname'] : null,
             'name'     => null,
             'email'    => null,


### PR DESCRIPTION
Reverts SocialiteProviders/Providers#311

the code is wrong!

should set config and env:

`config/services.php`

```
    'wechat_service_account' => [
        'client_id' => env('WECHAT_SERVICE_ACCOUNT_APP_ID'),
        'client_secret' => env('WECHAT_SERVICE_ACCOUNT_APP_SECRET'),
        'redirect' => env('WECHAT_SERVICE_ACCOUNT_CALLBACK_URL'),
        'scopes' => preg_split('/,/', env('WECHAT_SERVICE_ACCOUNT_SCOPES'), null, PREG_SPLIT_NO_EMPTY),
        'union_id_with' => preg_split('/,/', env('WECHAT_SERVICE_ACCOUNT_UNION_ID_WITH'), null, PREG_SPLIT_NO_EMPTY),
    ],
```

`.env`

```
WECHAT_SERVICE_ACCOUNT_APP_ID=wx222
WECHAT_SERVICE_ACCOUNT_APP_SECRET=zxcv
WECHAT_SERVICE_ACCOUNT_CALLBACK_URL="http://example.com/login/wechat-service-account/callback"
WECHAT_SERVICE_ACCOUNT_SCOPES=unionid
WECHAT_SERVICE_ACCOUNT_UNION_ID_WITH=wechat_web,wechat_mini_program
```

docs:

- Chinese https://sinkcup.github.io/laravel-socialite-wechat-login
- English https://laravel-socialite-providers.github.io/providers/wechat-service-account/