### PR TITLE
Create a provider for Sign In with Apple

### DIFF
--- a/src/Apple/AppleExtendSocialite.php
+++ b/src/Apple/AppleExtendSocialite.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SocialiteProviders\Apple;
+
+use SocialiteProviders\Manager\SocialiteWasCalled;
+
+class AppleExtendSocialite
+{
+    /**
+     * Register the provider.
+     *
+     * @param  \SocialiteProviders\Manager\SocialiteWasCalled  $socialiteWasCalled
+     */
+    public function handle(SocialiteWasCalled $socialiteWasCalled)
+    {
+        $socialiteWasCalled->extendSocialite(
+            'apple', __NAMESPACE__.'\Provider'
+        );
+    }
+}

--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace SocialiteProviders\Apple;
+
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
+use SocialiteProviders\Manager\OAuth2\User;
+
+class Provider extends AbstractProvider
+{
+    /**
+     * Unique Provider Identifier.
+     */
+    const IDENTIFIER = 'APPLE';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopes = [
+        'openid',
+        'email',
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopeSeparator = ' ';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAuthUrl($state)
+    {
+        return $this->buildAuthUrlFromBase(
+            'https://appleid.apple.com/auth/authorize', $state
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenUrl()
+    {
+        return 'https://appleid.apple.com/auth/token';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenFields($code)
+    {
+        return array_merge(parent::getTokenFields($code), [
+            'grant_type' => 'authorization_code',
+        ]);
+    }
+}

--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -16,7 +16,7 @@ class Provider extends AbstractProvider
      * {@inheritdoc}
      */
     protected $scopes = [
-        'openid',
+        'name',
         'email',
     ];
 

--- a/src/Apple/composer.json
+++ b/src/Apple/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "socialiteproviders/apple",
+    "description": "Apple OAuth2 Provider for Laravel Socialite",
+    "license": "MIT",
+    "require": {
+        "php": "^5.6 || ^7.0",
+        "socialiteproviders/manager": "~2.0 || ~3.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialiteProviders\\Apple\\": ""
+        }
+    }
+}


### PR DESCRIPTION
This starts to add `Sign In with Apple` support, and is based off of [Aaron Parecki's blog on Okta](https://developer.okta.com/blog/2019/06/04/what-the-heck-is-sign-in-with-apple).

I haven't been able to add the `getUserByToken` or `mapUserToObject` methods yet unfortunately as I can't find an API endpoint for this. 🤔

I thought it may be worth adding this PR and if anyone finds an endpoint for user data, this can be updated.

If it's better to just close this because of the lack of those methods, feel free to do so.