### PR TITLE
Fix Google Provider ProviderInterface

### DIFF
--- a/src/Google/Provider.php
+++ b/src/Google/Provider.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Arr;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-class Provider extends AbstractProvider implements ProviderInterface
+class Provider extends AbstractProvider
 {
     /**
      * Unique Provider Identifier.


### PR DESCRIPTION
This PR removes `ProviderInterface` from Google `Provider` because it's already defined in parent class.

This provider was added in #266 but it always throws an exception:
> Interface 'SocialiteProviders\Google\ProviderInterface' not found