### PR TITLE
Fixes google provider identifier

### DIFF
--- a/src/Google/Provider.php
+++ b/src/Google/Provider.php
@@ -11,7 +11,7 @@ class Provider extends AbstractProvider implements ProviderInterface
     /**
      * Unique Provider Identifier.
      */
-    const IDENTIFIER = 'GOOGLEOAUTH';
+    const IDENTIFIER = 'GOOGLE';
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
This PR changes identifier from `GOOGLEOAUTH` to `GOOGLE` to follow same convention with other providers.

Google-Plus provider wasn't followed naming convention and used `GOOGLE` identifier. But now Google-Plus should be replaced with Google provider and this change might be even better because there will be no need to change identifier from old Google-Plus to new Google provider.

Since issue #317 exist - nobody started to use this provider and this could be changed without breaking changes.