### PR TITLE
Remove deprecated Laravel helper methods

### DIFF
--- a/src/Flickr/Server.php
+++ b/src/Flickr/Server.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\Flickr;
 
+use Illuminate\Support\Arr;
 use League\OAuth1\Client\Credentials\TokenCredentials;
 use SocialiteProviders\Manager\OAuth1\Server as BaseServer;
 use SocialiteProviders\Manager\OAuth1\User;
@@ -51,7 +52,7 @@ class Server extends BaseServer
         $user = new User();
         $user->id = $data['id'];
         $user->nickname = $data['username']['_content'];
-        $user->name = array_get($data, 'realname._content');
+        $user->name = Arr::get($data, 'realname._content');
         $user->extra = array_diff_key($data, array_flip([
             'id', 'username', 'realname',
         ]));

--- a/src/Google/Provider.php
+++ b/src/Google/Provider.php
@@ -67,7 +67,7 @@ class Provider extends AbstractProvider implements ProviderInterface
     {
         return (new User())->setRaw($user)->map([
             'id' => $user['sub'],
-            'nickname' => array_get($user, 'name'),
+            'nickname' => Arr::get($user, 'name'),
             'name' => $user['name'],
             'email' => $user['email'],
             'avatar' => $user['picture'],

--- a/src/Kakao/KakaoProvider.php
+++ b/src/Kakao/KakaoProvider.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\Kakao;
 
+use Illuminate\Support\Arr;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -92,15 +93,15 @@ class KakaoProvider extends AbstractProvider
      */
     protected function mapUserToObject(array $user)
     {
-        $is_email_valid = array_get($user, 'kakao_account.is_email_valid');
-        $is_email_verified = array_get($user, 'kakao_account.is_email_verified');
+        $is_email_valid = Arr::get($user, 'kakao_account.is_email_valid');
+        $is_email_verified = Arr::get($user, 'kakao_account.is_email_verified');
 
         return (new User())->setRaw($user)->map([
             'id'        => $user['id'],
             'nickname'  => $user['properties']['nickname'],
             'name'      => $user['properties']['nickname'],
-            'email'     => $is_email_valid && $is_email_verified ? array_get($user, 'kakao_account.email') : null,
-            'avatar'    => array_get($user, 'properties.profile_image'),
+            'email'     => $is_email_valid && $is_email_verified ? Arr::get($user, 'kakao_account.email') : null,
+            'avatar'    => Arr::get($user, 'properties.profile_image'),
         ]);
     }
 }

--- a/src/Okta/Provider.php
+++ b/src/Okta/Provider.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\Okta;
 
+use Illuminate\Support\Arr;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -90,16 +91,16 @@ class Provider extends AbstractProvider
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([
-            'id'             => array_get($user, 'sub'),
-            'email'          => array_get($user, 'email'),
-            'email_verified' => array_get($user, 'email_verified', false),
-            'nickname'       => array_get($user, 'nickname'),
-            'name'           => array_get($user, 'name'),
-            'first_name'     => array_get($user, 'given_name'),
-            'last_name'      => array_get($user, 'family_name'),
-            'profileUrl'     => array_get($user, 'profile'),
-            'address'        => array_get($user, 'address'),
-            'phone'          => array_get($user, 'phone'),
+            'id'             => Arr::get($user, 'sub'),
+            'email'          => Arr::get($user, 'email'),
+            'email_verified' => Arr::get($user, 'email_verified', false),
+            'nickname'       => Arr::get($user, 'nickname'),
+            'name'           => Arr::get($user, 'name'),
+            'first_name'     => Arr::get($user, 'given_name'),
+            'last_name'      => Arr::get($user, 'family_name'),
+            'profileUrl'     => Arr::get($user, 'profile'),
+            'address'        => Arr::get($user, 'address'),
+            'phone'          => Arr::get($user, 'phone'),
         ]);
     }
 

--- a/src/Orcid/Provider.php
+++ b/src/Orcid/Provider.php
@@ -182,7 +182,7 @@ class Provider extends AbstractProvider
             env( 'ORCID_UID_FIELDNAME', 'id' ) => $user['orcid-identifier']['path'], 
             'nickname' => $user["person"]["name"]["given-names"]["value"],
             'name' => sprintf( "%s %s", $user["person"]["name"]["given-names"]["value"], $user["person"]["name"]["family-name"]["value"] ),
-            'email' => array_get($user, 'email'),
+            'email' => Arr::get($user, 'email'),
         ]);
     }
 

--- a/src/Steem/Provider.php
+++ b/src/Steem/Provider.php
@@ -82,11 +82,11 @@ class Provider extends AbstractProvider
         return (new User())->setRaw($user)->map([
             'id'          => $user['user'],
             'nickname'    => $user['user'],
-            'name'        => array_get($metadata, 'profile.name', $user['user']),
-            'about'       => array_get($metadata, 'profile.about'),
-            'location'    => array_get($metadata, 'profile.location'),
-            'avatar'      => array_get($metadata, 'profile.profile_image'),
-            'cover_image' => array_get($metadata, 'profile.cover_image'),
+            'name'        => Arr::get($metadata, 'profile.name', $user['user']),
+            'about'       => Arr::get($metadata, 'profile.about'),
+            'location'    => Arr::get($metadata, 'profile.location'),
+            'avatar'      => Arr::get($metadata, 'profile.profile_image'),
+            'cover_image' => Arr::get($metadata, 'profile.cover_image'),
         ]);
     }
 

--- a/src/Twitch/Provider.php
+++ b/src/Twitch/Provider.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\Twitch;
 
+use Illuminate\Support\Arr;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -67,7 +68,7 @@ class Provider extends AbstractProvider
             'id'       => $user['id'],
             'nickname' => $user['display_name'],
             'name'     => $user['display_name'],
-            'email'    => array_get($user, 'email'),
+            'email'    => Arr::get($user, 'email'),
             'avatar'   => $user['profile_image_url'],
         ]);
     }

--- a/src/Untappd/Provider.php
+++ b/src/Untappd/Provider.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\Untappd;
 
+use Illuminate\Support\Arr;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -42,7 +43,7 @@ class Provider extends AbstractProvider
             ],
         ]);
 
-        return array_get(json_decode($response->getBody()->getContents(), true), 'response.user');
+        return Arr::get(json_decode($response->getBody()->getContents(), true), 'response.user');
     }
 
     /**
@@ -53,10 +54,10 @@ class Provider extends AbstractProvider
         return (new User())->setRaw($user)->map([
             'id'              => $user['id'],
             'nickname'        => $user['user_name'],
-            'name'            => array_get($user, 'first_name').' '.array_get($user, 'last_name'),
-            'email'           => array_get($user, 'settings.email_address'),
-            'avatar'          => array_get($user, 'user_avatar'),
-            'avatar_original' => array_get($user, 'user_avatar_hd'),
+            'name'            => Arr::get($user, 'first_name').' '.Arr::get($user, 'last_name'),
+            'email'           => Arr::get($user, 'settings.email_address'),
+            'avatar'          => Arr::get($user, 'user_avatar'),
+            'avatar_original' => Arr::get($user, 'user_avatar_hd'),
         ]);
     }
 


### PR DESCRIPTION
`array_get` helper method is deprecated and will be removed in Laravel 5.9.

This PR replaces it with `Illuminate\Support\Arr::get`.