### PR TITLE
Add tenant_id to config keys array for Microsoft Graph

### DIFF
--- a/src/Microsoft-Graph/Provider.php
+++ b/src/Microsoft-Graph/Provider.php
@@ -126,4 +126,12 @@ class Provider extends AbstractProvider
             'grant_type' => 'authorization_code',
         ]);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function additionalConfigKeys()
+    {
+        return ['tenant_id'];
+    }
 }


### PR DESCRIPTION
This PR adds support for using the `tenant_id` config key from within the `config/services.php` file, such as...

```
'graph' => [
    'client_id' => env('GRAPH_KEY'),
    'client_secret' => env('GRAPH_SECRET'),
    'tenant_id' => env('GRAPH_TENANT_ID'), // <-- Can now be declared here
    'redirect' => env('GRAPH_REDIRECT_URI'),
],
```

Currently, it is only possible to add the tenant id by chaining it as follows...

```
Socialite::with('graph')
    ->setTenantId(config('services.graph.tenant_id'))
    ->redirect();
```