### PR TITLE
Some array keys may be undefined for Microsoft Graph

### DIFF
--- a/src/Microsoft-Graph/Provider.php
+++ b/src/Microsoft-Graph/Provider.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\Graph;
 
+use Illuminate\Support\Arr;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -96,24 +97,25 @@ class Provider extends AbstractProvider
      */
     protected function mapUserToObject(array $user)
     {
-        /*
-            Mapping default Laravel user keys and the keys that are nested in $user->user in response. Modify as needed.
-        */
+        // Mapping default Laravel user keys to the keys that are nested in the
+        // response from the provider.
         return (new User())->setRaw($user)->map([
-            'id'                => $user['id'],
-            'name'              => $user['displayName'],
-            'email'             => $user['mail'],
+            'id' => $user['id'],
+            'name' => $user['displayName'],
+            'email' => $user['mail'],
 
-            'businessPhones'    => $user['businessPhones'],
-            'displayName'       => $user['displayName'],
-            'givenName'         => $user['givenName'],
-            'jobTitle'          => $user['jobTitle'],
-            'mail'              => $user['mail'],
-            'mobilePhone'       => $user['mobilePhone'],
-            'officeLocation'    => $user['officeLocation'],
-            'preferredLanguage' => $user['preferredLanguage'],
-            'surname'           => $user['surname'],
-            'userPrincipalName' => $user['userPrincipalName'],
+            // The following values are not always required by the provider. We
+            // cannot guarantee they will exist in the $user array.
+            'businessPhones' => Arr::get($user, 'businessPhones'),
+            'displayName' => Arr::get($user, 'displayName'),
+            'givenName' => Arr::get($user, 'givenName'),
+            'jobTitle' => Arr::get($user, 'jobTitle'),
+            'mail' => Arr::get($user, 'mail'),
+            'mobilePhone' => Arr::get($user, 'mobilePhone'),
+            'officeLocation' => Arr::get($user, 'officeLocation'),
+            'preferredLanguage' => Arr::get($user, 'preferredLanguage'),
+            'surname' => Arr::get($user, 'surname'),
+            'userPrincipalName' => Arr::get($user, 'userPrincipalName'),
         ]);
     }
 


### PR DESCRIPTION
This was originally proposed in the read-only split of the Microsoft Graph repo [here](https://github.com/SocialiteProviders/Microsoft-Graph/pull/3), but the user who created the PR no longer exists.

From that PR...

> For example, Outlook user is not obligated to fill out the given name field, in that case we don't get response with givenName value therefore givenName index is undefined.
> 
> Similar situation was with Github provider, following commit [laravel/socialite@38c15dc](https://github.com/laravel/socialite/commit/38c15dc9ec9cd0132e45b3228e20eed8832bf9f3) set null as email index value if email is undefined.

In addition to that PR, I have changed from `array_get` to `Arr::get()` because the global array helpers are deprecated in 5.8 and will be removed in 6.0