### PR TITLE
Fix parse xml for Naver user

### DIFF
--- a/src/Naver/NaverProvider.php
+++ b/src/Naver/NaverProvider.php
@@ -80,7 +80,7 @@ class NaverProvider extends AbstractProvider
             'headers' => ['Authorization' => 'Bearer '.$token],
         ]);
 
-        return $this->parseXML($response->getBody()->getContents())['response'];
+        return $this->parseXML($response->getBody())['response'];
     }
 
     /**


### PR DESCRIPTION
closed #339 

In this PR changed to call the `__toString` method of the` GuzzleHttp \ Psr7 \ Stream` class when reading XML of Naver user information response.   

This will reread the stream from the beginning.