### PR TITLE
Ensure that ext-json is also loaded.

### DIFF
--- a/src/Mailru/composer.json
+++ b/src/Mailru/composer.json
@@ -10,6 +10,7 @@
   ],
   "require": {
     "php": "^5.6 || ^7.0",
+    "ext-json": "*",
     "socialiteproviders/manager": "~2.0 || ~3.0"
   },
   "autoload": {

--- a/src/MoiKrug/composer.json
+++ b/src/MoiKrug/composer.json
@@ -10,6 +10,7 @@
   ],
   "require": {
     "php": "^5.6 || ^7.0",
+    "ext-json": "*",
     "socialiteproviders/manager": "~2.0 || ~3.0"
   },
   "autoload": {

--- a/src/Wonderlist/composer.json
+++ b/src/Wonderlist/composer.json
@@ -8,6 +8,7 @@
     }],
     "require": {
         "php": "^5.6 || ^7.0",
+        "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },
     "autoload": {


### PR DESCRIPTION
Ensure that `ext-json` is also loaded.

---


Despire the merge of https://github.com/SocialiteProviders/Generators/pull/24 some `composer.json` files still miss this requirement.
