### PR TITLE
fix: fix automatic splitting failure

### DIFF
--- a/.github/workflows/monorepo-split.yml
+++ b/.github/workflows/monorepo-split.yml
@@ -12,13 +12,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+
+      # Required due to GH detached head bug https://github.com/actions/checkout/issues/6
+      - name: Prepare repository
+        run: git checkout "${GITHUB_REF:11}"
+
+      - name:  Set up PHP
+        uses: shivammathur/setup-php@master
         with:
-            fetch-depth: 1
-      - name: composer-php
-        uses: nick-zh/composer@v0.2.0
-        with:
-          action: 'install'
-          options: '-o'
+          php-version: '7.3'
+          coverage: none
+
+      - name: Composer Install
+        run: composer install -vvv
 
       - name: Split
         run: ./vendor/bin/monorepo-builder split --max-processes 8
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_PUSH_TOKEN }}


### PR DESCRIPTION
After a ton of debugging, I finally figured out why the splitting doesn't work in actions. When actions checks out a branch, it ends up on a detached head version of that branch. Plenty of others have issues with this as well: https://github.com/actions/checkout/issues/6

I'm leaving this as a draft for the moment as currently you need to supply an access token that has write permissions to all of the target repos. If the deploy fails, it ends up in the logs (not good!).

I'll have a go at switching it to use an SSH key (but then the CI will have access to any private repos of the person who creates it) but ideally we'd have a better way to ensure it remains secret, so will look into that.

cc @m1guelpf 