### PR TITLE
[Passport] Make getUserByToken always returns an array

### DIFF
--- a/src/LaravelPassport/Provider.php
+++ b/src/LaravelPassport/Provider.php
@@ -79,7 +79,7 @@ class Provider extends AbstractProvider
             ],
         ]);
 
-        return json_decode($response->getBody(), true);
+        return (array) json_decode($response->getBody(), true);
     }
 
     /**


### PR DESCRIPTION
When using socialite to get a user from a token, there is an assumption that the token is *always* valid.

In fact, baked into Socialite, the `userFromToken` call is expected to return an instance of `\Laravel\Socialite\Two\User`.

However, if the Passport token you have for the user is no longer valid (for example, the token has expired or been revoked) then the call to the `/api/user` endpoint will actually redirect you to a login form due to the Passport auth driver on your authentication application.

The current implementation of `getUserByToken` will subsequently return `null` if it does not get JSON returned and this will cause Socialite to blow up internally when it receives `null` instead of an array when it calls `mapUserToObject`.

By simply casting the result to an array, we will at least provide the required type to `mapUserToObject`, which in turn will just hydrate an empty `\Laravel\Socialite\User`.

For example, using an invalid token would now do this:

    // $token = ...retrieve token from however you have stored it
    dd(Socialite::driver('laravelpassport')->userFromToken($token));
    SocialiteProviders\Manager\OAuth2\User {
      +accessTokenResponseBody: null
      +token: "invalid-token."
      +refreshToken: null
      +expiresIn: null
      +id: null
      +nickname: null
      +name: null
      +email: null
      +avatar: null
      +user: []
    }