### PR TITLE
Fix Keycloak provider 

### DIFF
--- a/src/Keycloak/Provider.php
+++ b/src/Keycloak/Provider.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\Keycloak;
 
+use Illuminate\Support\Arr;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -61,10 +62,10 @@ class Provider extends AbstractProvider
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([
-            'id'        => Arr::get($user['sub']),
-            'nickname'  => Arr::get($user['preferred_username']),
-            'name'      => Arr::get($user['given_name']),
-            'email'     => Arr::get($user['email']),
+            'id'        => Arr::get($user, 'sub'),
+            'nickname'  => Arr::get($user, 'preferred_username'),
+            'name'      => Arr::get($user, 'given_name'),
+            'email'     => Arr::get($user, 'email'),
         ]);
     }
 


### PR DESCRIPTION
Fix `Arr::get()` usage.

Actually this provider is not working, when getting `user`

![image](https://user-images.githubusercontent.com/118955/82768406-2e7a1800-9e05-11ea-9b88-2a058520f185.png)
