### PR TITLE
[Microsoft] Get avatar.

### DIFF
--- a/src/Microsoft/MicrosoftAvatar.php
+++ b/src/Microsoft/MicrosoftAvatar.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace SocialiteProviders\Microsoft;
+
+use GuzzleHttp\Psr7\Response;
+
+class MicrosoftAvatar
+{
+    /**
+     * The Guzzle Response object.
+     *
+     * @var \GuzzleHttp\Psr7\Response
+     */
+    public $response;
+
+    /**
+     * Set the response of the avatar.
+     *
+     * @param string $response
+     *
+     * @return $this
+     */
+    public function setResponse(Response $response)
+    {
+        $this->response = $response;
+
+        return $this;
+    }
+
+    /**
+     * Return the content type of the avatar.
+     *
+     * @return string
+     */
+    public function getContentType(): string
+    {
+        return $this->response->getHeader('content-type')[0];
+    }
+
+    /**
+     * Return the avatar in binary.
+     *
+     * @return binary
+     */
+    public function getContents()
+    {
+        return $this->response->getBody()->getContents();
+    }
+
+    /**
+     * Return the data URI formatted image.
+     *
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return 'data:'.$this->getContentType().';base64,'.base64_encode($this->getContents());
+    }
+}

--- a/src/Microsoft/MicrosoftUser.php
+++ b/src/Microsoft/MicrosoftUser.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SocialiteProviders\Microsoft;
+
+use GuzzleHttp\Client;
+use SocialiteProviders\Manager\OAuth2\User;
+
+class MicrosoftUser extends User
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getAvatar()
+    {
+        $client = new Client();
+        $response = $client->get(
+            'https://graph.microsoft.com/v1.0/me/photo/$value',
+            [
+                'headers' => [
+                    'Accept'        => 'image/*',
+                    'Authorization' => 'Bearer '.$this->token,
+                ],
+            ]
+        );
+
+        return (new MicrosoftAvatar())->setResponse($response);
+    }
+}

--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -3,7 +3,7 @@
 namespace SocialiteProviders\Microsoft;
 
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
-use SocialiteProviders\Manager\OAuth2\User;
+use SocialiteProviders\Microsoft\MicrosoftUser as User;
 
 class Provider extends AbstractProvider
 {


### PR DESCRIPTION
The Microsoft Graph API does not provide a URL to the users avatar from what I can tell. Microsoft actually returns the full binary avatar at the endpoint 'https://graph.microsoft.com/v1.0/me/photo/$value'.

Docs: https://docs.microsoft.com/en-us/graph/api/profilephoto-get?view=graph-rest-1.0#get-the-photo

This change makes an additional request to get the binary data and save it as the 'avatar_base64' property. Since it doesn't look like any other providers return the actual avatar and just link to the avatar URL, I'm not sure how maintainers would prefer to name the property. The 'avatar' property is left null since there's no public avatar URL.