### PR TITLE
[steam] Fix "realm and return_to do not match" when using HTTP

### DIFF
--- a/src/Steam/Provider.php
+++ b/src/Steam/Provider.php
@@ -140,11 +140,17 @@ class Provider extends AbstractProvider
     {
         $realm = $this->getConfig('realm', $this->request->server('HTTP_HOST'));
 
+        if ($this->request->secure()) {
+            $realm = sprintf('https://%s', $realm);
+        } else {
+            $realm = sprintf('http://%s', $realm);
+        }
+
         $params = [
             'openid.ns'         => self::OPENID_NS,
             'openid.mode'       => 'checkid_setup',
             'openid.return_to'  => $this->redirectUrl,
-            'openid.realm'      => sprintf('https://%s', $realm),
+            'openid.realm'      => $realm,
             'openid.identity'   => 'http://specs.openid.net/auth/2.0/identifier_select',
             'openid.claimed_id' => 'http://specs.openid.net/auth/2.0/identifier_select',
         ];

--- a/src/Steam/Provider.php
+++ b/src/Steam/Provider.php
@@ -146,17 +146,11 @@ class Provider extends AbstractProvider
     {
         $realm = $this->getConfig('realm', $this->request->server('HTTP_HOST'));
 
-        if ($this->request->secure()) {
-            $realm = sprintf('https://%s', $realm);
-        } else {
-            $realm = sprintf('http://%s', $realm);
-        }
-
         $params = [
             'openid.ns'         => self::OPENID_NS,
             'openid.mode'       => 'checkid_setup',
             'openid.return_to'  => $this->redirectUrl,
-            'openid.realm'      => $realm,
+            'openid.realm'      => sprintf('%s://%s', $this->request->getScheme(), $realm),
             'openid.identity'   => 'http://specs.openid.net/auth/2.0/identifier_select',
             'openid.claimed_id' => 'http://specs.openid.net/auth/2.0/identifier_select',
         ];

--- a/src/Steam/Provider.php
+++ b/src/Steam/Provider.php
@@ -86,6 +86,7 @@ class Provider extends AbstractProvider
     {
         if (!$this->validate()) {
             $error = $this->getParams()['openid.error'] ?? 'unknown error';
+
             throw new OpenIDValidationException('Failed to validate OpenID login: '.$error);
         }
 

--- a/src/Steam/Provider.php
+++ b/src/Steam/Provider.php
@@ -86,7 +86,7 @@ class Provider extends AbstractProvider
     {
         if (!$this->validate()) {
             $error = $this->getParams()['openid.error'] ?? 'unknown error';
-            throw new OpenIDValidationException('Failed to validate OpenID login: ' . $error);
+            throw new OpenIDValidationException('Failed to validate OpenID login: '.$error);
         }
 
         return $this->mapUserToObject($this->getUserByToken($this->steamId));
@@ -234,7 +234,7 @@ class Provider extends AbstractProvider
             'openid.sig'          => $this->request->get(self::OPENID_SIG),
             'openid.ns'           => self::OPENID_NS,
             'openid.mode'         => 'check_authentication',
-            'openid.error'      => $this->request->get(self::OPENID_ERROR),
+            'openid.error'       => $this->request->get(self::OPENID_ERROR),
         ];
 
         $signedParams = explode(',', $this->request->get(self::OPENID_SIGNED));

--- a/src/Steam/Provider.php
+++ b/src/Steam/Provider.php
@@ -62,6 +62,11 @@ class Provider extends AbstractProvider
     const OPENID_NS = 'http://specs.openid.net/auth/2.0';
 
     /**
+     * @var string
+     */
+    const OPENID_ERROR = 'openid_error';
+
+    /**
      * {@inheritdoc}
      */
     protected $stateless = true;
@@ -80,7 +85,8 @@ class Provider extends AbstractProvider
     public function user()
     {
         if (!$this->validate()) {
-            throw new OpenIDValidationException('Failed to validate openID login');
+            $error = $this->getParams()['openid.error'] ?? 'unknown error';
+            throw new OpenIDValidationException('Failed to validate OpenID login: ' . $error);
         }
 
         return $this->mapUserToObject($this->getUserByToken($this->steamId));
@@ -228,6 +234,7 @@ class Provider extends AbstractProvider
             'openid.sig'          => $this->request->get(self::OPENID_SIG),
             'openid.ns'           => self::OPENID_NS,
             'openid.mode'         => 'check_authentication',
+            'openid.error'      => $this->request->get(self::OPENID_ERROR),
         ];
 
         $signedParams = explode(',', $this->request->get(self::OPENID_SIGNED));

--- a/src/Steam/Provider.php
+++ b/src/Steam/Provider.php
@@ -228,7 +228,7 @@ class Provider extends AbstractProvider
             'openid.sig'          => $this->request->get(self::OPENID_SIG),
             'openid.ns'           => self::OPENID_NS,
             'openid.mode'         => 'check_authentication',
-            'openid.error'       => $this->request->get(self::OPENID_ERROR),
+            'openid.error'        => $this->request->get(self::OPENID_ERROR),
         ];
 
         $signedParams = explode(',', $this->request->get(self::OPENID_SIGNED));


### PR DESCRIPTION
Currently when not using HTTPS (for example in dev environment) Steam provides the error "realm and return_to do not match" causing OpenIDValidationException to be thrown.

This PR stops the hardcoding of HTTPS for the 'realm' parameter, and instead uses HTTPS when the original request was made using HTTPS.

This PR also adds the error from Steam into the OpenIDValidationException message.

Thanks!