### PR TITLE
Update to new Discord domain

### DIFF
--- a/src/Discord/Provider.php
+++ b/src/Discord/Provider.php
@@ -31,7 +31,7 @@ class Provider extends AbstractProvider
     protected function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase(
-            'https://discordapp.com/api/oauth2/authorize',
+            'https://discord.com/api/oauth2/authorize',
             $state
         );
     }
@@ -41,7 +41,7 @@ class Provider extends AbstractProvider
      */
     protected function getTokenUrl()
     {
-        return 'https://discordapp.com/api/oauth2/token';
+        return 'https://discord.com/api/oauth2/token';
     }
 
     /**
@@ -50,7 +50,7 @@ class Provider extends AbstractProvider
     protected function getUserByToken($token)
     {
         $response = $this->getHttpClient()->get(
-            'https://discordapp.com/api/users/@me',
+            'https://discord.com/api/users/@me',
             [
                 'headers' => [
                     'Authorization' => 'Bearer '.$token,


### PR DESCRIPTION
Although Discord said the discordapp.com domain will stick around for a while, developers should start updating the domain to discord.com instead of discordapp.com

