### PR TITLE
Apple: Switch Query Encoding type to RFC3986

### DIFF
--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -30,7 +30,7 @@ class Provider extends AbstractProvider implements ProviderInterface
         'name',
         'email',
     ];
-    
+
     /**
      * {@inheritdoc}
      */

--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -30,6 +30,11 @@ class Provider extends AbstractProvider implements ProviderInterface
         'name',
         'email',
     ];
+    
+    /**
+     * {@inheritdoc}
+     */
+    protected $encodingType = PHP_QUERY_RFC3986;
 
     /**
      * The separating character for the requested scopes.


### PR DESCRIPTION
Hey there! 👋 

The current encoding used to generate URL by the Apple Provider make it fails on mobile.

The scopes should be separated with a space, and the default encoding will use a `+`.