### PR TITLE
Ability to use proxies when requesting

### DIFF
--- a/src/Steam/Provider.php
+++ b/src/Steam/Provider.php
@@ -205,7 +205,7 @@ class Provider extends AbstractProvider
     {
         return [
             RequestOptions::FORM_PARAMS => $this->getParams(),
-            RequestOptions::PROXY => $this->getConfig('proxy')
+            RequestOptions::PROXY       => $this->getConfig('proxy')
         ];
     }
 

--- a/src/Steam/Provider.php
+++ b/src/Steam/Provider.php
@@ -205,6 +205,7 @@ class Provider extends AbstractProvider
     {
         return [
             RequestOptions::FORM_PARAMS => $this->getParams(),
+            RequestOptions::PROXY => $this->getConfig('proxy')
         ];
     }
 
@@ -298,6 +299,6 @@ class Provider extends AbstractProvider
 
     public static function additionalConfigKeys()
     {
-        return ['api_key', 'realm', 'https'];
+        return ['api_key', 'realm', 'https', 'proxy'];
     }
 }

--- a/src/Steam/Provider.php
+++ b/src/Steam/Provider.php
@@ -205,7 +205,7 @@ class Provider extends AbstractProvider
     {
         return [
             RequestOptions::FORM_PARAMS => $this->getParams(),
-            RequestOptions::PROXY       => $this->getConfig('proxy')
+            RequestOptions::PROXY       => $this->getConfig('proxy'),
         ];
     }
 


### PR DESCRIPTION
With a heavy load, steam bans IP for a while.

