### PR TITLE
Fix quickbooks provider scopes

### DIFF
--- a/src/QuickBooks/Provider.php
+++ b/src/QuickBooks/Provider.php
@@ -26,7 +26,12 @@ class Provider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
-    protected $scopes = ['com.intuit.quickbooks.accounting openid profile email phone address'];
+    protected $scopes = ['openid', 'profile', 'email'];
+
+    /**
+    * {@inheritdoc}
+    */
+    protected $scopeSeparator = ' ';
 
     /**
      * {@inheritdoc}
@@ -71,9 +76,9 @@ class Provider extends AbstractProvider implements ProviderInterface
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([
-            'id'       => $user['sub'],
-            'name'     => trim(sprintf('%s %s', $user['givenName'], $user['familyName'])),
-            'email'    => $user['email'],
+            'id'    => $user['sub'],
+            'name'  => trim(sprintf('%s %s', $user['givenName'], $user['familyName'])),
+            'email' => $user['email'],
         ]);
     }
 

--- a/src/QuickBooks/Provider.php
+++ b/src/QuickBooks/Provider.php
@@ -29,8 +29,8 @@ class Provider extends AbstractProvider implements ProviderInterface
     protected $scopes = ['openid', 'profile', 'email'];
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $scopeSeparator = ' ';
 
     /**

--- a/src/QuickBooks/composer.json
+++ b/src/QuickBooks/composer.json
@@ -10,6 +10,10 @@
         {
             "name": "Luke Curtis",
             "email": "lukesimoncurtis@gmail.com"
+        },
+        {
+            "name": "Illimar Tambek",
+            "email": "illimar@hey.com"
         }
     ],
     "require": {


### PR DESCRIPTION
This PR fixes Quickbooks provider scopes by defining the scopes as an array of strings instead of one long string and by defining the `scopeSeparator`. 

The current implementation is broken because the default `scopeSeparator` is a comma, which triggers an `invalid_scope` error with QuickBooks when trying to customize scopes with `->scopes()` or `->setScopes()`.

In addition, it removes the extra scopes (`com.intuit.quickbooks.accounting`, `phone`, `address`) that are not relevant to getting basic user details. The idea is to keep the default scopes to a minimum while still being useful. This follows the example of the core Socialite providers as well as most of the other extra providers in this repo.

Finally, there are a few code style tweaks as well.