### PR TITLE
Migrate to Yahoo Oauth 2.0 API

### DIFF
--- a/src/Yahoo/Provider.php
+++ b/src/Yahoo/Provider.php
@@ -23,6 +23,9 @@ class Provider extends AbstractProvider
      */
     protected function getAuthUrl($state)
     {
+        $this->scopes(['openid2']);
+        $parse_url = parse_url($this->redirectUrl);
+        $this->with(['openid2_realm' => $parse_url['scheme'] . '://' . $parse_url['host']]);
         return $this->buildAuthUrlFromBase('https://api.login.yahoo.com/oauth2/request_auth', $state);
     }
 
@@ -39,13 +42,13 @@ class Provider extends AbstractProvider
      */
     protected function getUserByToken($token)
     {
-        $response = $this->getHttpClient()->get('https://social.yahooapis.com/v1/user/'.$this->xoauth_yahoo_guid.'/profile?format=json', [
+        $response = $this->getHttpClient()->get('https://api.login.yahoo.com/openid/v1/userinfo', [
             'headers' => [
                 'Authorization' => 'Bearer '.$token,
             ],
         ]);
 
-        return json_decode($response->getBody(), true)['profile'];
+        return json_decode($response->getBody(), true);
     }
 
     /**
@@ -57,11 +60,11 @@ class Provider extends AbstractProvider
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([
-            'id'       => $user['guid'],
+            'id'       => $user['sub'],
             'nickname' => $user['nickname'],
-            'name'     => trim(sprintf('%s %s', Arr::get($user, 'givenName'), Arr::get($user, 'familyName'))),
-            'email'    => Arr::get($user, 'emails.0.handle'),
-            'avatar'   => Arr::get($user, 'image.imageUrl'),
+            'name'     => trim(sprintf('%s %s', Arr::get($user, 'given_name'), Arr::get($user, 'family_name'))),
+            'email'    => Arr::get($user, 'email'),
+            'avatar'   => Arr::get($user, 'picture'),
         ]);
     }
 

--- a/src/Yahoo/Provider.php
+++ b/src/Yahoo/Provider.php
@@ -24,7 +24,7 @@ class Provider extends AbstractProvider
     protected function getAuthUrl($state)
     {
         $parseUrl = parse_url($this->redirectUrl);
-        $this->with(['openid2_realm' => $parseUrl['scheme'] . '://' . $parseUrl['host']]);
+        $this->with(['openid2_realm' => $parseUrl['scheme'].'://'.$parseUrl['host']]);
         return $this->buildAuthUrlFromBase('https://api.login.yahoo.com/oauth2/request_auth', $state);
     }
 

--- a/src/Yahoo/Provider.php
+++ b/src/Yahoo/Provider.php
@@ -60,7 +60,7 @@ class Provider extends AbstractProvider
     {
         return (new User())->setRaw($user)->map([
             'id'       => $user['sub'],
-            'nickname' => $user['nickname'],
+            'nickname' => $user['nickname'] || $user['sub'],
             'name'     => trim(sprintf('%s %s', Arr::get($user, 'given_name'), Arr::get($user, 'family_name'))),
             'email'    => Arr::get($user, 'email'),
             'avatar'   => Arr::get($user, 'picture'),

--- a/src/Yahoo/Provider.php
+++ b/src/Yahoo/Provider.php
@@ -60,8 +60,8 @@ class Provider extends AbstractProvider
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([
-            'id'       => $user['sub'],
-            'nickname' => $user['nickname'] || $user['sub'],
+            'id'       => Arr::get($user, 'sub'),
+            'nickname' => Arr::get($user, 'nickname', Arr::get($user, 'sub')),
             'name'     => trim(sprintf('%s %s', Arr::get($user, 'given_name'), Arr::get($user, 'family_name'))),
             'email'    => Arr::get($user, 'email'),
             'avatar'   => Arr::get($user, 'picture'),

--- a/src/Yahoo/Provider.php
+++ b/src/Yahoo/Provider.php
@@ -16,11 +16,15 @@ class Provider extends AbstractProvider
     /**
      * {@inheritdoc}
      */
+    protected $scopes = ['openid2'];
+
+    /**
+     * {@inheritdoc}
+     */
     protected function getAuthUrl($state)
     {
-        $this->scopes(['openid2']);
-        $parse_url = parse_url($this->redirectUrl);
-        $this->with(['openid2_realm' => $parse_url['scheme'] . '://' . $parse_url['host']]);
+        $parseUrl = parse_url($this->redirectUrl);
+        $this->with(['openid2_realm' => $parseUrl['scheme'] . '://' . $parseUrl['host']]);
         return $this->buildAuthUrlFromBase('https://api.login.yahoo.com/oauth2/request_auth', $state);
     }
 

--- a/src/Yahoo/Provider.php
+++ b/src/Yahoo/Provider.php
@@ -14,11 +14,6 @@ class Provider extends AbstractProvider
     const IDENTIFIER = 'YAHOO';
 
     /**
-     * @var string
-     */
-    protected $xoauth_yahoo_guid;
-
-    /**
      * {@inheritdoc}
      */
     protected function getAuthUrl($state)
@@ -83,8 +78,6 @@ class Provider extends AbstractProvider
      */
     protected function parseAccessToken($body)
     {
-        $this->xoauth_yahoo_guid = Arr::get($body, 'xoauth_yahoo_guid');
-
         return Arr::get($body, 'access_token');
     }
 }

--- a/src/Yahoo/Provider.php
+++ b/src/Yahoo/Provider.php
@@ -25,6 +25,7 @@ class Provider extends AbstractProvider
     {
         $parseUrl = parse_url($this->redirectUrl);
         $this->with(['openid2_realm' => $parseUrl['scheme'].'://'.$parseUrl['host']]);
+
         return $this->buildAuthUrlFromBase('https://api.login.yahoo.com/oauth2/request_auth', $state);
     }
 


### PR DESCRIPTION
Since OpenID2 will be EOLed on 6/30/20,
We need to migrate from OpenID2 to OpenID Connect API
https://developer.yahoo.com/oauth2/guide/OpenID2/

SocDir (Social Directory Web Service) also EOL date is June 30, #2020
https://developer.yahoo.com/oauth/social-directory-eol/