### PR TITLE
Ensure the syntax is compatible with PHP < 7.

### DIFF
--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -21,7 +21,7 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     const IDENTIFIER = 'APPLE';
 
-    private const URL = 'https://appleid.apple.com';
+    const URL = 'https://appleid.apple.com';
 
     /**
      * {@inheritdoc}
@@ -196,15 +196,17 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     protected function mapUserToObject(array $user)
     {
+        $fullName = '';
+
         if (request()->filled('user')) {
             $userRequest = json_decode(request('user'), true);
 
             if (array_key_exists('name', $userRequest)) {
                 $user['name'] = $userRequest['name'];
                 $fullName = trim(
-                    ($user['name']['firstName'] ?? '')
+                    Arr::get($user, 'name.firstName', '')
                     .' '
-                    .($user['name']['lastName'] ?? '')
+                    .Arr::get($user, 'name.lastName', '')
                 );
             }
         }
@@ -213,8 +215,8 @@ class Provider extends AbstractProvider implements ProviderInterface
             ->setRaw($user)
             ->map([
                 'id'    => $user['sub'],
-                'name'  => $fullName ?? null,
-                'email' => $user['email'] ?? null,
+                'name'  => $fullName !== '' ? $fullName : null,
+                'email' => Arr::get($user, 'email'),
             ]);
     }
 }

--- a/src/InstagramBasic/Provider.php
+++ b/src/InstagramBasic/Provider.php
@@ -10,7 +10,7 @@ class Provider extends AbstractProvider
     /**
      * Unique Provider Identifier.
      */
-    public const IDENTIFIER = 'INSTAGRAMBASIC';
+    const IDENTIFIER = 'INSTAGRAMBASIC';
 
     /**
      * The user fields being requested.

--- a/src/Line/Provider.php
+++ b/src/Line/Provider.php
@@ -88,7 +88,7 @@ class Provider extends AbstractProvider
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([
-            'id'       =>  Arr::get($user, 'userId', Arr::get($user, 'sub')),
+            'id'       => Arr::get($user, 'userId', Arr::get($user, 'sub')),
             'nickname' => null,
             'name'     => Arr::get($user, 'displayName', Arr::get($user, 'name')),
             'avatar'   => Arr::get($user, 'pictureUrl', Arr::get($user, 'picture')),

--- a/src/Line/Provider.php
+++ b/src/Line/Provider.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\Line;
 
+use Illuminate\Support\Arr;
 use Laravel\Socialite\Two\InvalidStateException;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
@@ -87,11 +88,11 @@ class Provider extends AbstractProvider
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([
-            'id'       => $user['userId'] ?? $user['sub'] ?? null,
+            'id'       =>  Arr::get($user, 'userId', Arr::get($user, 'sub')),
             'nickname' => null,
-            'name'     => $user['displayName'] ?? $user['name'] ?? null,
-            'avatar'   => $user['pictureUrl'] ?? $user['picture'] ?? null,
-            'email'    => $user['email'] ?? null,
+            'name'     => Arr::get($user, 'displayName', Arr::get($user, 'name')),
+            'avatar'   => Arr::get($user, 'pictureUrl', Arr::get($user, 'picture')),
+            'email'    => Arr::get($user, 'email'),
         ]);
     }
 

--- a/src/Microsoft/MicrosoftAvatar.php
+++ b/src/Microsoft/MicrosoftAvatar.php
@@ -32,7 +32,7 @@ class MicrosoftAvatar
      *
      * @return string
      */
-    public function getContentType(): string
+    public function getContentType()
     {
         return $this->response->getHeader('content-type')[0];
     }
@@ -52,7 +52,7 @@ class MicrosoftAvatar
      *
      * @return string
      */
-    public function __toString(): string
+    public function __toString()
     {
         return 'data:'.$this->getContentType().';base64,'.base64_encode($this->getContents());
     }

--- a/src/Steam/Provider.php
+++ b/src/Steam/Provider.php
@@ -85,7 +85,7 @@ class Provider extends AbstractProvider
     public function user()
     {
         if (!$this->validate()) {
-            $error = $this->getParams()['openid.error'] ?? 'unknown error';
+            $error = Arr::get($this->getParams(), 'openid.error', 'unknown error');
 
             throw new OpenIDValidationException('Failed to validate OpenID login: '.$error);
         }


### PR DESCRIPTION
Some part of the code introduce PHP 7 or PHP 7.1 new syntax, which breaks the compatibility.

This PR ensures that PHP versions < 7 are supported, as stated in the composer.json files.