### PR TITLE
Use ::class notation.

### DIFF
--- a/src/Acclaim/AcclaimExtendSocialite.php
+++ b/src/Acclaim/AcclaimExtendSocialite.php
@@ -13,6 +13,6 @@ class AcclaimExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('acclaim', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('acclaim', Provider::class);
     }
 }

--- a/src/Admitad/AdmitadExtendSocialite.php
+++ b/src/Admitad/AdmitadExtendSocialite.php
@@ -11,6 +11,6 @@ class AdmitadExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('admitad', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('admitad', Provider::class);
     }
 }

--- a/src/Amazon/AmazonExtendSocialite.php
+++ b/src/Amazon/AmazonExtendSocialite.php
@@ -11,6 +11,6 @@ class AmazonExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('amazon', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('amazon', Provider::class);
     }
 }

--- a/src/AngelList/AngelListExtendSocialite.php
+++ b/src/AngelList/AngelListExtendSocialite.php
@@ -13,9 +13,6 @@ class AngelListExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'angellist',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('angellist', Provider::class);
     }
 }

--- a/src/AppNet/AppNetExtendSocialite.php
+++ b/src/AppNet/AppNetExtendSocialite.php
@@ -13,9 +13,6 @@ class AppNetExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'appnet',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('appnet', Provider::class);
     }
 }

--- a/src/Apple/AppleExtendSocialite.php
+++ b/src/Apple/AppleExtendSocialite.php
@@ -13,9 +13,6 @@ class AppleExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'apple',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('apple', Provider::class);
     }
 }

--- a/src/ArcGIS/ArcGISExtendSocialite.php
+++ b/src/ArcGIS/ArcGISExtendSocialite.php
@@ -13,9 +13,6 @@ class ArcGISExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'arcgis',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('arcgis', Provider::class);
     }
 }

--- a/src/Asana/AsanaExtendSocialite.php
+++ b/src/Asana/AsanaExtendSocialite.php
@@ -13,9 +13,6 @@ class AsanaExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'asana',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('asana', Provider::class);
     }
 }

--- a/src/Auth0/Auth0ExtendSocialite.php
+++ b/src/Auth0/Auth0ExtendSocialite.php
@@ -11,6 +11,6 @@ class Auth0ExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('auth0', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('auth0', Provider::class);
     }
 }

--- a/src/Aweber/AweberExtendSocialite.php
+++ b/src/Aweber/AweberExtendSocialite.php
@@ -13,10 +13,6 @@ class AweberExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'aweber',
-            __NAMESPACE__.'\Provider',
-            __NAMESPACE__.'\Server'
-        );
+        $socialiteWasCalled->extendSocialite('aweber', Provider::class, Server::class);
     }
 }

--- a/src/Azure/AzureExtendSocialite.php
+++ b/src/Azure/AzureExtendSocialite.php
@@ -11,9 +11,6 @@ class AzureExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'azure',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('azure', Provider::class);
     }
 }

--- a/src/Battlenet/BattlenetExtendSocialite.php
+++ b/src/Battlenet/BattlenetExtendSocialite.php
@@ -13,9 +13,6 @@ class BattlenetExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'battlenet',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('battlenet', Provider::class);
     }
 }

--- a/src/Bitbucket/BitbucketExtendSocialite.php
+++ b/src/Bitbucket/BitbucketExtendSocialite.php
@@ -13,9 +13,6 @@ class BitbucketExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'bitbucket',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('bitbucket', Provider::class);
     }
 }

--- a/src/Bitly/BitlyExtendSocialite.php
+++ b/src/Bitly/BitlyExtendSocialite.php
@@ -13,9 +13,6 @@ class BitlyExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'bitly',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('bitly', Provider::class);
     }
 }

--- a/src/Box/BoxExtendSocialite.php
+++ b/src/Box/BoxExtendSocialite.php
@@ -13,9 +13,6 @@ class BoxExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'box',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('box', Provider::class);
     }
 }

--- a/src/Buffer/BufferExtendSocialite.php
+++ b/src/Buffer/BufferExtendSocialite.php
@@ -13,9 +13,6 @@ class BufferExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'buffer',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('buffer', Provider::class);
     }
 }

--- a/src/CampaignMonitor/CampaignMonitorExtendSocialite.php
+++ b/src/CampaignMonitor/CampaignMonitorExtendSocialite.php
@@ -13,9 +13,6 @@ class CampaignMonitorExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'campaignmonitor',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('campaignmonitor', Provider::class);
     }
 }

--- a/src/Cheddar/CheddarExtendSocialite.php
+++ b/src/Cheddar/CheddarExtendSocialite.php
@@ -13,9 +13,6 @@ class CheddarExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'cheddar',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('cheddar', Provider::class);
     }
 }

--- a/src/ClaveUnica/ClaveUnicaExtendSocialite.php
+++ b/src/ClaveUnica/ClaveUnicaExtendSocialite.php
@@ -11,6 +11,6 @@ class ClaveUnicaExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('claveunica', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('claveunica', Provider::class);
     }
 }

--- a/src/Coinbase/CoinbaseExtendSocialite.php
+++ b/src/Coinbase/CoinbaseExtendSocialite.php
@@ -13,9 +13,6 @@ class CoinbaseExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'coinbase',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('coinbase', Provider::class);
     }
 }

--- a/src/ConstantContact/ConstantContactExtendSocialite.php
+++ b/src/ConstantContact/ConstantContactExtendSocialite.php
@@ -13,9 +13,6 @@ class ConstantContactExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'constantcontact',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('constantcontact', Provider::class);
     }
 }

--- a/src/Coursera/CourseraExtendSocialite.php
+++ b/src/Coursera/CourseraExtendSocialite.php
@@ -11,6 +11,6 @@ class CourseraExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('coursera', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('coursera', Provider::class);
     }
 }

--- a/src/Dailymile/DailymileExtendSocialite.php
+++ b/src/Dailymile/DailymileExtendSocialite.php
@@ -13,9 +13,6 @@ class DailymileExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'dailymile',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('dailymile', Provider::class);
     }
 }

--- a/src/Dailymotion/DailymotionExtendSocialite.php
+++ b/src/Dailymotion/DailymotionExtendSocialite.php
@@ -13,9 +13,6 @@ class DailymotionExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'dailymotion',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('dailymotion', Provider::class);
     }
 }

--- a/src/Dataporten/DataportenExtendSocialite.php
+++ b/src/Dataporten/DataportenExtendSocialite.php
@@ -11,6 +11,6 @@ class DataportenExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('dataporten', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('dataporten', Provider::class);
     }
 }

--- a/src/Deezer/DeezerExtendSocialite.php
+++ b/src/Deezer/DeezerExtendSocialite.php
@@ -13,9 +13,6 @@ class DeezerExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'deezer',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('deezer', Provider::class);
     }
 }

--- a/src/Deviantart/DeviantartExtendSocialite.php
+++ b/src/Deviantart/DeviantartExtendSocialite.php
@@ -13,9 +13,6 @@ class DeviantartExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'deviantart',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('deviantart', Provider::class);
     }
 }

--- a/src/DigitalOcean/DigitalOceanExtendSocialite.php
+++ b/src/DigitalOcean/DigitalOceanExtendSocialite.php
@@ -13,9 +13,6 @@ class DigitalOceanExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'digitalocean',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('digitalocean', Provider::class);
     }
 }

--- a/src/Discogs/DiscogsExtendSocialite.php
+++ b/src/Discogs/DiscogsExtendSocialite.php
@@ -11,10 +11,6 @@ class DiscogsExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'discogs',
-            __NAMESPACE__.'\Provider',
-            __NAMESPACE__.'\Server'
-        );
+        $socialiteWasCalled->extendSocialite('discogs', Provider::class, Server::class);
     }
 }

--- a/src/Discord/DiscordExtendSocialite.php
+++ b/src/Discord/DiscordExtendSocialite.php
@@ -13,6 +13,6 @@ class DiscordExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('discord', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('discord', Provider::class);
     }
 }

--- a/src/Disqus/DisqusExtendSocialite.php
+++ b/src/Disqus/DisqusExtendSocialite.php
@@ -13,9 +13,6 @@ class DisqusExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'disqus',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('disqus', Provider::class);
     }
 }

--- a/src/Douban/DoubanExtendSocialite.php
+++ b/src/Douban/DoubanExtendSocialite.php
@@ -8,6 +8,6 @@ class DoubanExtendSocialite
 {
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('douban', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('douban', Provider::class);
     }
 }

--- a/src/Dribbble/DribbbleExtendSocialite.php
+++ b/src/Dribbble/DribbbleExtendSocialite.php
@@ -13,9 +13,6 @@ class DribbbleExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'dribbble',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('dribbble', Provider::class);
     }
 }

--- a/src/Dropbox/DropboxExtendSocialite.php
+++ b/src/Dropbox/DropboxExtendSocialite.php
@@ -13,9 +13,6 @@ class DropboxExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'dropbox',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('dropbox', Provider::class);
     }
 }

--- a/src/Envato/EnvatoExtendSocialite.php
+++ b/src/Envato/EnvatoExtendSocialite.php
@@ -11,6 +11,6 @@ class EnvatoExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('envato', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('envato', Provider::class);
     }
 }

--- a/src/Etsy/EtsyExtendSocialite.php
+++ b/src/Etsy/EtsyExtendSocialite.php
@@ -11,10 +11,6 @@ class EtsyExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'etsy',
-            __NAMESPACE__.'\Provider',
-            __NAMESPACE__.'\Server'
-        );
+        $socialiteWasCalled->extendSocialite('etsy', Provider::class, Server::class);
     }
 }

--- a/src/Eventbrite/EventbriteExtendSocialite.php
+++ b/src/Eventbrite/EventbriteExtendSocialite.php
@@ -13,9 +13,6 @@ class EventbriteExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'eventbrite',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('eventbrite', Provider::class);
     }
 }

--- a/src/Everyplay/EveryplayExtendSocialite.php
+++ b/src/Everyplay/EveryplayExtendSocialite.php
@@ -13,9 +13,6 @@ class EveryplayExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'everyplay',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('everyplay', Provider::class);
     }
 }

--- a/src/EyeEm/EyeEmExtendSocialite.php
+++ b/src/EyeEm/EyeEmExtendSocialite.php
@@ -13,9 +13,6 @@ class EyeEmExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'eyeem',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('eyeem', Provider::class);
     }
 }

--- a/src/Facebook/FacebookExtendSocialite.php
+++ b/src/Facebook/FacebookExtendSocialite.php
@@ -13,9 +13,6 @@ class FacebookExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'facebook',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('facebook', Provider::class);
     }
 }

--- a/src/Faceit/FaceitExtendSocialite.php
+++ b/src/Faceit/FaceitExtendSocialite.php
@@ -8,6 +8,6 @@ class FaceitExtendSocialite
 {
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('faceit', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('faceit', Provider::class);
     }
 }

--- a/src/Fitbit/FitbitExtendSocialite.php
+++ b/src/Fitbit/FitbitExtendSocialite.php
@@ -11,6 +11,6 @@ class FitbitExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('fitbit', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('fitbit', Provider::class);
     }
 }

--- a/src/FiveHundredPixel/FiveHundredPixelExtendSocialite.php
+++ b/src/FiveHundredPixel/FiveHundredPixelExtendSocialite.php
@@ -13,10 +13,6 @@ class FiveHundredPixelExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            '500px',
-            __NAMESPACE__.'\Provider',
-            __NAMESPACE__.'\Server'
-        );
+        $socialiteWasCalled->extendSocialite('500px', Provider::class, Server::class);
     }
 }

--- a/src/Flattr/FlattrExtendSocialite.php
+++ b/src/Flattr/FlattrExtendSocialite.php
@@ -13,9 +13,6 @@ class FlattrExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'flattr',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('flattr', Provider::class);
     }
 }

--- a/src/Flexkids/FlexkidsExtendSocialite.php
+++ b/src/Flexkids/FlexkidsExtendSocialite.php
@@ -11,6 +11,6 @@ class FlexkidsExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('flexkids', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('flexkids', Provider::class);
     }
 }

--- a/src/Flickr/FlickrExtendSocialite.php
+++ b/src/Flickr/FlickrExtendSocialite.php
@@ -13,10 +13,6 @@ class FlickrExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'flickr',
-            __NAMESPACE__.'\Provider',
-            __NAMESPACE__.'\Server'
-        );
+        $socialiteWasCalled->extendSocialite('flickr', Provider::class, Server::class);
     }
 }

--- a/src/Foursquare/FoursquareExtendSocialite.php
+++ b/src/Foursquare/FoursquareExtendSocialite.php
@@ -13,9 +13,6 @@ class FoursquareExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'foursquare',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('foursquare', Provider::class);
     }
 }

--- a/src/FranceConnect/FranceConnectExtendSocialite.php
+++ b/src/FranceConnect/FranceConnectExtendSocialite.php
@@ -13,9 +13,6 @@ class FranceConnectExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'franceconnect',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('franceconnect', Provider::class);
     }
 }

--- a/src/GameWisp/GameWispExtendSocialite.php
+++ b/src/GameWisp/GameWispExtendSocialite.php
@@ -13,9 +13,6 @@ class GameWispExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'gamewisp',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('gamewisp', Provider::class);
     }
 }

--- a/src/GarminConnect/GarminConnectExtendSocialite.php
+++ b/src/GarminConnect/GarminConnectExtendSocialite.php
@@ -11,10 +11,6 @@ class GarminConnectExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'garmin-connect',
-            __NAMESPACE__.'\Provider',
-            __NAMESPACE__.'\Server'
-        );
+        $socialiteWasCalled->extendSocialite('garmin-connect', Provider::class, Server::class);
     }
 }

--- a/src/GettyImages/GettyImagesExtendSocialite.php
+++ b/src/GettyImages/GettyImagesExtendSocialite.php
@@ -11,9 +11,6 @@ class GettyImagesExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'gettyimages',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('gettyimages', Provider::class);
     }
 }

--- a/src/GitHub/GitHubExtendSocialite.php
+++ b/src/GitHub/GitHubExtendSocialite.php
@@ -11,6 +11,6 @@ class GitHubExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('github', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('github', Provider::class);
     }
 }

--- a/src/GitLab/GitLabExtendSocialite.php
+++ b/src/GitLab/GitLabExtendSocialite.php
@@ -11,6 +11,6 @@ class GitLabExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('gitlab', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('gitlab', Provider::class);
     }
 }

--- a/src/Gitee/GiteeExtendSocialite.php
+++ b/src/Gitee/GiteeExtendSocialite.php
@@ -11,6 +11,6 @@ class GiteeExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('gitee', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('gitee', Provider::class);
     }
 }

--- a/src/Goodreads/GoodreadsExtendSocialite.php
+++ b/src/Goodreads/GoodreadsExtendSocialite.php
@@ -13,10 +13,6 @@ class GoodreadsExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'goodreads',
-            __NAMESPACE__.'\Provider',
-            __NAMESPACE__.'\Server'
-        );
+        $socialiteWasCalled->extendSocialite('goodreads', Provider::class, Server::class);
     }
 }

--- a/src/Google/GoogleExtendSocialite.php
+++ b/src/Google/GoogleExtendSocialite.php
@@ -13,9 +13,6 @@ class GoogleExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'google',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('google', Provider::class);
     }
 }

--- a/src/Graph/GraphExtendSocialite.php
+++ b/src/Graph/GraphExtendSocialite.php
@@ -11,9 +11,6 @@ class GraphExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'graph',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('graph', Provider::class);
     }
 }

--- a/src/Harvest/HarvestExtendSocialite.php
+++ b/src/Harvest/HarvestExtendSocialite.php
@@ -11,6 +11,6 @@ class HarvestExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('harvest', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('harvest', Provider::class);
     }
 }

--- a/src/HeadHunter/HeadHunterExtendSocialite.php
+++ b/src/HeadHunter/HeadHunterExtendSocialite.php
@@ -11,6 +11,6 @@ class HeadHunterExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('headhunter', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('headhunter', Provider::class);
     }
 }

--- a/src/Heroku/HerokuExtendSocialite.php
+++ b/src/Heroku/HerokuExtendSocialite.php
@@ -13,9 +13,6 @@ class HerokuExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'heroku',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('heroku', Provider::class);
     }
 }

--- a/src/Hitbox/HitboxExtendSocialite.php
+++ b/src/Hitbox/HitboxExtendSocialite.php
@@ -11,6 +11,6 @@ class HitboxExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('hitbox', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('hitbox', Provider::class);
     }
 }

--- a/src/HubSpot/HubSpotExtendSocialite.php
+++ b/src/HubSpot/HubSpotExtendSocialite.php
@@ -13,9 +13,6 @@ class HubSpotExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'hubspot',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('hubspot', Provider::class);
     }
 }

--- a/src/HumanApi/HumanApiExtendSocialite.php
+++ b/src/HumanApi/HumanApiExtendSocialite.php
@@ -13,9 +13,6 @@ class HumanApiExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'humanapi',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('humanapi', Provider::class);
     }
 }

--- a/src/IFSP/IFSPExtendSocialite.php
+++ b/src/IFSP/IFSPExtendSocialite.php
@@ -11,6 +11,6 @@ class IFSPExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('ifsp', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('ifsp', Provider::class);
     }
 }

--- a/src/Imgur/ImgurExtendSocialite.php
+++ b/src/Imgur/ImgurExtendSocialite.php
@@ -13,9 +13,6 @@ class ImgurExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'imgur',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('imgur', Provider::class);
     }
 }

--- a/src/Instagram/InstagramExtendSocialite.php
+++ b/src/Instagram/InstagramExtendSocialite.php
@@ -13,9 +13,6 @@ class InstagramExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'instagram',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('instagram', Provider::class);
     }
 }

--- a/src/InstagramBasic/InstagramBasicExtendSocialite.php
+++ b/src/InstagramBasic/InstagramBasicExtendSocialite.php
@@ -13,9 +13,6 @@ class InstagramBasicExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'instagrambasic',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('instagrambasic', Provider::class);
     }
 }

--- a/src/Intercom/IntercomExtendSocialite.php
+++ b/src/Intercom/IntercomExtendSocialite.php
@@ -11,6 +11,6 @@ class IntercomExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('intercom', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('intercom', Provider::class);
     }
 }

--- a/src/Jawbone/JawboneExtendSocialite.php
+++ b/src/Jawbone/JawboneExtendSocialite.php
@@ -13,9 +13,6 @@ class JawboneExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'jawbone',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('jawbone', Provider::class);
     }
 }

--- a/src/Jira/JiraExtendSocialite.php
+++ b/src/Jira/JiraExtendSocialite.php
@@ -11,10 +11,6 @@ class JiraExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'jira',
-            __NAMESPACE__.'\Provider',
-            __NAMESPACE__.'\Server'
-        );
+        $socialiteWasCalled->extendSocialite('jira', Provider::class, Server::class);
     }
 }

--- a/src/Keycloak/KeycloakExtendSocialite.php
+++ b/src/Keycloak/KeycloakExtendSocialite.php
@@ -13,9 +13,6 @@ class KeycloakExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'keycloak',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('keycloak', Provider::class);
     }
 }

--- a/src/LaravelPassport/LaravelPassportExtendSocialite.php
+++ b/src/LaravelPassport/LaravelPassportExtendSocialite.php
@@ -11,6 +11,6 @@ class LaravelPassportExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('laravelpassport', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('laravelpassport', Provider::class);
     }
 }

--- a/src/Line/LineExtendSocialite.php
+++ b/src/Line/LineExtendSocialite.php
@@ -13,9 +13,6 @@ class LineExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'line',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('line', Provider::class);
     }
 }

--- a/src/LinkedIn/LinkedInExtendSocialite.php
+++ b/src/LinkedIn/LinkedInExtendSocialite.php
@@ -13,9 +13,6 @@ class LinkedInExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'linkedin',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('linkedin', Provider::class);
     }
 }

--- a/src/Live/LiveExtendSocialite.php
+++ b/src/Live/LiveExtendSocialite.php
@@ -13,9 +13,6 @@ class LiveExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'live',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('live', Provider::class);
     }
 }

--- a/src/MailChimp/MailChimpExtendSocialite.php
+++ b/src/MailChimp/MailChimpExtendSocialite.php
@@ -13,9 +13,6 @@ class MailChimpExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'mailchimp',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('mailchimp', Provider::class);
     }
 }

--- a/src/Mailru/MailruExtendSocialite.php
+++ b/src/Mailru/MailruExtendSocialite.php
@@ -11,6 +11,6 @@ class MailruExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('mailru', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('mailru', Provider::class);
     }
 }

--- a/src/MakerLog/MakerLogExtendSocialite.php
+++ b/src/MakerLog/MakerLogExtendSocialite.php
@@ -13,9 +13,6 @@ class MakerLogExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'makerlog',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('makerlog', Provider::class);
     }
 }

--- a/src/MasterChain/MasterChainExtendSocialite.php
+++ b/src/MasterChain/MasterChainExtendSocialite.php
@@ -13,9 +13,6 @@ class MasterChainExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'masterchain',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('masterchain', Provider::class);
     }
 }

--- a/src/Mattermost/MattermostExtendSocialite.php
+++ b/src/Mattermost/MattermostExtendSocialite.php
@@ -11,9 +11,6 @@ class MattermostExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'mattermost',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('mattermost', Provider::class);
     }
 }

--- a/src/MediaCube/MediaCubeExtendSocialite.php
+++ b/src/MediaCube/MediaCubeExtendSocialite.php
@@ -13,9 +13,6 @@ class MediaCubeExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'mediacube',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('mediacube', Provider::class);
     }
 }

--- a/src/Medium/MediumExtendSocialite.php
+++ b/src/Medium/MediumExtendSocialite.php
@@ -13,9 +13,6 @@ class MediumExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'medium',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('medium', Provider::class);
     }
 }

--- a/src/Meetup/MeetupExtendSocialite.php
+++ b/src/Meetup/MeetupExtendSocialite.php
@@ -8,6 +8,6 @@ class MeetupExtendSocialite
 {
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('meetup', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('meetup', Provider::class);
     }
 }

--- a/src/Microsoft/MicrosoftExtendSocialite.php
+++ b/src/Microsoft/MicrosoftExtendSocialite.php
@@ -13,9 +13,6 @@ class MicrosoftExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'microsoft',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('microsoft', Provider::class);
     }
 }

--- a/src/Mixcloud/MixcloudExtendSocialite.php
+++ b/src/Mixcloud/MixcloudExtendSocialite.php
@@ -13,9 +13,6 @@ class MixcloudExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'mixcloud',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('mixcloud', Provider::class);
     }
 }

--- a/src/Mixer/MixerExtendSocialite.php
+++ b/src/Mixer/MixerExtendSocialite.php
@@ -13,9 +13,6 @@ class MixerExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'mixer',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('mixer', Provider::class);
     }
 }

--- a/src/MoiKrug/MoiKrugExtendSocialite.php
+++ b/src/MoiKrug/MoiKrugExtendSocialite.php
@@ -11,6 +11,6 @@ class MoiKrugExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('moikrug', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('moikrug', Provider::class);
     }
 }

--- a/src/Mollie/MollieExtendSocialite.php
+++ b/src/Mollie/MollieExtendSocialite.php
@@ -13,9 +13,6 @@ class MollieExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'mollie',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('mollie', Provider::class);
     }
 }

--- a/src/Netlify/NetlifyExtendSocialite.php
+++ b/src/Netlify/NetlifyExtendSocialite.php
@@ -11,6 +11,6 @@ class NetlifyExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('netlify', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('netlify', Provider::class);
     }
 }

--- a/src/Nocks/NocksExtendSocialite.php
+++ b/src/Nocks/NocksExtendSocialite.php
@@ -11,6 +11,6 @@ class NocksExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('nocks', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('nocks', Provider::class);
     }
 }

--- a/src/OAuthgen/OAuthgenExtendSocialite.php
+++ b/src/OAuthgen/OAuthgenExtendSocialite.php
@@ -11,6 +11,6 @@ class OAuthgenExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('oauthgen', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('oauthgen', Provider::class);
     }
 }

--- a/src/OSChina/OSChinaExtendSocialite.php
+++ b/src/OSChina/OSChinaExtendSocialite.php
@@ -11,6 +11,6 @@ class OSChinaExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('oschina', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('oschina', Provider::class);
     }
 }

--- a/src/Odnoklassniki/OdnoklassnikiExtendSocialite.php
+++ b/src/Odnoklassniki/OdnoklassnikiExtendSocialite.php
@@ -13,9 +13,6 @@ class OdnoklassnikiExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'odnoklassniki',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('odnoklassniki', Provider::class);
     }
 }

--- a/src/Okta/OktaExtendSocialite.php
+++ b/src/Okta/OktaExtendSocialite.php
@@ -11,6 +11,6 @@ class OktaExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('okta', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('okta', Provider::class);
     }
 }

--- a/src/Opskins/OpskinsExtendSocialite.php
+++ b/src/Opskins/OpskinsExtendSocialite.php
@@ -11,6 +11,6 @@ class OpskinsExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('opskins', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('opskins', Provider::class);
     }
 }

--- a/src/Orcid/OrcidExtendSocialite.php
+++ b/src/Orcid/OrcidExtendSocialite.php
@@ -13,9 +13,6 @@ class OrcidExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'orcid',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('orcid', Provider::class);
     }
 }

--- a/src/Patreon/PatreonExtendSocialite.php
+++ b/src/Patreon/PatreonExtendSocialite.php
@@ -13,9 +13,6 @@ class PatreonExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'patreon',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('patreon', Provider::class);
     }
 }

--- a/src/PayPal/PayPalExtendSocialite.php
+++ b/src/PayPal/PayPalExtendSocialite.php
@@ -13,9 +13,6 @@ class PayPalExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'paypal',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('paypal', Provider::class);
     }
 }

--- a/src/PayPalSandbox/PayPalSandboxExtendSocialite.php
+++ b/src/PayPalSandbox/PayPalSandboxExtendSocialite.php
@@ -13,9 +13,6 @@ class PayPalSandboxExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'paypal_sandbox',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('paypal_sandbox', Provider::class);
     }
 }

--- a/src/Paymill/PaymillExtendSocialite.php
+++ b/src/Paymill/PaymillExtendSocialite.php
@@ -13,9 +13,6 @@ class PaymillExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'paymill',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('paymill', Provider::class);
     }
 }

--- a/src/PeeringDB/PeeringDBExtendSocialite.php
+++ b/src/PeeringDB/PeeringDBExtendSocialite.php
@@ -11,6 +11,6 @@ class PeeringDBExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('peeringdb', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('peeringdb', Provider::class);
     }
 }

--- a/src/Pinterest/PinterestExtendSocialite.php
+++ b/src/Pinterest/PinterestExtendSocialite.php
@@ -11,9 +11,6 @@ class PinterestExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'pinterest',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('pinterest', Provider::class);
     }
 }

--- a/src/Pipedrive/PipedriveExtendSocialite.php
+++ b/src/Pipedrive/PipedriveExtendSocialite.php
@@ -11,6 +11,6 @@ class PipedriveExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('pipedrive', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('pipedrive', Provider::class);
     }
 }

--- a/src/Podio/PodioExtendSocialite.php
+++ b/src/Podio/PodioExtendSocialite.php
@@ -13,9 +13,6 @@ class PodioExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'podio',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('podio', Provider::class);
     }
 }

--- a/src/Procore/ProcoreExtendSocialite.php
+++ b/src/Procore/ProcoreExtendSocialite.php
@@ -13,9 +13,6 @@ class ProcoreExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'procore',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('procore', Provider::class);
     }
 }

--- a/src/ProductHunt/ProductHuntExtendSocialite.php
+++ b/src/ProductHunt/ProductHuntExtendSocialite.php
@@ -13,9 +13,6 @@ class ProductHuntExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'producthunt',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('producthunt', Provider::class);
     }
 }

--- a/src/ProjectV/ProjectVExtendSocialite.php
+++ b/src/ProjectV/ProjectVExtendSocialite.php
@@ -13,9 +13,6 @@ class ProjectVExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'projectv',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('projectv', Provider::class);
     }
 }

--- a/src/Pushbullet/PushbulletExtendSocialite.php
+++ b/src/Pushbullet/PushbulletExtendSocialite.php
@@ -13,9 +13,6 @@ class PushbulletExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'pushbullet',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('pushbullet', Provider::class);
     }
 }

--- a/src/QQ/QqExtendSocialite.php
+++ b/src/QQ/QqExtendSocialite.php
@@ -8,6 +8,6 @@ class QqExtendSocialite
 {
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('qq', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('qq', Provider::class);
     }
 }

--- a/src/QuickBooks/QuickBooksExtendSocialite.php
+++ b/src/QuickBooks/QuickBooksExtendSocialite.php
@@ -13,6 +13,6 @@ class QuickBooksExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('quickbooks', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('quickbooks', Provider::class);
     }
 }

--- a/src/Rdio/RdioExtendSocialite.php
+++ b/src/Rdio/RdioExtendSocialite.php
@@ -13,10 +13,6 @@ class RdioExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'rdio',
-            __NAMESPACE__.'\Provider',
-            __NAMESPACE__.'\Server'
-        );
+        $socialiteWasCalled->extendSocialite('rdio', Provider::class, Server::class);
     }
 }

--- a/src/Readability/ReadabilityExtendSocialite.php
+++ b/src/Readability/ReadabilityExtendSocialite.php
@@ -13,10 +13,6 @@ class ReadabilityExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'readability',
-            __NAMESPACE__.'\Provider',
-            __NAMESPACE__.'\Server'
-        );
+        $socialiteWasCalled->extendSocialite('readability', Provider::class, Server::class);
     }
 }

--- a/src/Redbooth/RedBoothExtendSocialite.php
+++ b/src/Redbooth/RedBoothExtendSocialite.php
@@ -11,6 +11,6 @@ class RedBoothExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('redbooth', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('redbooth', Provider::class);
     }
 }

--- a/src/Reddit/RedditExtendSocialite.php
+++ b/src/Reddit/RedditExtendSocialite.php
@@ -13,9 +13,6 @@ class RedditExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'reddit',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('reddit', Provider::class);
     }
 }

--- a/src/RunKeeper/RunKeeperExtendSocialite.php
+++ b/src/RunKeeper/RunKeeperExtendSocialite.php
@@ -13,9 +13,6 @@ class RunKeeperExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'runkeeper',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('runkeeper', Provider::class);
     }
 }

--- a/src/SURFconext/SURFconextExtendSocialite.php
+++ b/src/SURFconext/SURFconextExtendSocialite.php
@@ -13,9 +13,6 @@ class SURFconextExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'surfconext',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('surfconext', Provider::class);
     }
 }

--- a/src/Sage/SageExtendSocialite.php
+++ b/src/Sage/SageExtendSocialite.php
@@ -11,6 +11,6 @@ class SageExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('sage', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('sage', Provider::class);
     }
 }

--- a/src/SalesForce/SalesForceExtendSocialite.php
+++ b/src/SalesForce/SalesForceExtendSocialite.php
@@ -15,7 +15,7 @@ class SalesForceExtendSocialite
     {
         $socialiteWasCalled->extendSocialite(
             Provider::PROVIDER_NAME,
-            __NAMESPACE__.'\Provider'
+            Provider::class
         );
     }
 }

--- a/src/SciStarter/SciStarterExtendSocialite.php
+++ b/src/SciStarter/SciStarterExtendSocialite.php
@@ -11,6 +11,6 @@ class SciStarterExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('scistarter', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('scistarter', Provider::class);
     }
 }

--- a/src/SharePoint/SharePointExtendSocialite.php
+++ b/src/SharePoint/SharePointExtendSocialite.php
@@ -11,6 +11,6 @@ class SharePointExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('sharepoint', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('sharepoint', Provider::class);
     }
 }

--- a/src/Shopify/ShopifyExtendSocialite.php
+++ b/src/Shopify/ShopifyExtendSocialite.php
@@ -11,6 +11,6 @@ class ShopifyExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('shopify', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('shopify', Provider::class);
     }
 }

--- a/src/Slack/SlackExtendSocialite.php
+++ b/src/Slack/SlackExtendSocialite.php
@@ -13,9 +13,6 @@ class SlackExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'slack',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('slack', Provider::class);
     }
 }

--- a/src/Smashcast/SmashcastExtendSocialite.php
+++ b/src/Smashcast/SmashcastExtendSocialite.php
@@ -11,6 +11,6 @@ class SmashcastExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('hitbox', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('hitbox', Provider::class);
     }
 }

--- a/src/Snapchat/SnapchatExtendSocialite.php
+++ b/src/Snapchat/SnapchatExtendSocialite.php
@@ -11,6 +11,6 @@ class SnapchatExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('snapchat', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('snapchat', Provider::class);
     }
 }

--- a/src/SoundCloud/SoundCloudExtendSocialite.php
+++ b/src/SoundCloud/SoundCloudExtendSocialite.php
@@ -13,9 +13,6 @@ class SoundCloudExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'soundcloud',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('soundcloud', Provider::class);
     }
 }

--- a/src/Spotify/SpotifyExtendSocialite.php
+++ b/src/Spotify/SpotifyExtendSocialite.php
@@ -13,9 +13,6 @@ class SpotifyExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'spotify',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('spotify', Provider::class);
     }
 }

--- a/src/StackExchange/StackExchangeExtendSocialite.php
+++ b/src/StackExchange/StackExchangeExtendSocialite.php
@@ -8,6 +8,6 @@ class StackExchangeExtendSocialite
 {
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('stackexchange', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('stackexchange', Provider::class);
     }
 }

--- a/src/Steam/SteamExtendSocialite.php
+++ b/src/Steam/SteamExtendSocialite.php
@@ -13,6 +13,6 @@ class SteamExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('steam', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('steam', Provider::class);
     }
 }

--- a/src/Steem/SteemExtendSocialite.php
+++ b/src/Steem/SteemExtendSocialite.php
@@ -13,6 +13,6 @@ class SteemExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('steem', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('steem', Provider::class);
     }
 }

--- a/src/StockTwits/StockTwitsExtendSocialite.php
+++ b/src/StockTwits/StockTwitsExtendSocialite.php
@@ -13,9 +13,6 @@ class StockTwitsExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'stocktwits',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('stocktwits', Provider::class);
     }
 }

--- a/src/Strava/StravaExtendSocialite.php
+++ b/src/Strava/StravaExtendSocialite.php
@@ -13,9 +13,6 @@ class StravaExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'strava',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('strava', Provider::class);
     }
 }

--- a/src/Stripe/StripeExtendSocialite.php
+++ b/src/Stripe/StripeExtendSocialite.php
@@ -13,9 +13,6 @@ class StripeExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'stripe',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('stripe', Provider::class);
     }
 }

--- a/src/TVShowTime/TVShowTimeExtendSocialite.php
+++ b/src/TVShowTime/TVShowTimeExtendSocialite.php
@@ -11,6 +11,6 @@ class TVShowTimeExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('tvshowtime', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('tvshowtime', Provider::class);
     }
 }

--- a/src/TeamService/TeamServiceExtendSocialite.php
+++ b/src/TeamService/TeamServiceExtendSocialite.php
@@ -11,6 +11,6 @@ class TeamServiceExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('teamservice', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('teamservice', Provider::class);
     }
 }

--- a/src/Teamleader/TeamleaderExtendSocialite.php
+++ b/src/Teamleader/TeamleaderExtendSocialite.php
@@ -11,6 +11,6 @@ class TeamleaderExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('teamleader', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('teamleader', Provider::class);
     }
 }

--- a/src/Teamweek/TeamweekExtendSocialite.php
+++ b/src/Teamweek/TeamweekExtendSocialite.php
@@ -15,6 +15,6 @@ class TeamweekExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('teamweek', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('teamweek', Provider::class);
     }
 }

--- a/src/ThirtySevenSignals/ThirtySevenSignalsExtendSocialite.php
+++ b/src/ThirtySevenSignals/ThirtySevenSignalsExtendSocialite.php
@@ -13,9 +13,6 @@ class ThirtySevenSignalsExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            '37signals',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('37signals', Provider::class);
     }
 }

--- a/src/Todoist/TodoistExtendSocialite.php
+++ b/src/Todoist/TodoistExtendSocialite.php
@@ -11,6 +11,6 @@ class TodoistExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('todoist', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('todoist', Provider::class);
     }
 }

--- a/src/Trakt/TraktExtendSocialite.php
+++ b/src/Trakt/TraktExtendSocialite.php
@@ -11,6 +11,6 @@ class TraktExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('trakt', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('trakt', Provider::class);
     }
 }

--- a/src/Trello/TrelloExtendSocialite.php
+++ b/src/Trello/TrelloExtendSocialite.php
@@ -13,10 +13,6 @@ class TrelloExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'trello',
-            __NAMESPACE__.'\Provider',
-            __NAMESPACE__.'\Server'
-        );
+        $socialiteWasCalled->extendSocialite('trello', Provider::class, Server::class);
     }
 }

--- a/src/Tumblr/TumblrExtendSocialite.php
+++ b/src/Tumblr/TumblrExtendSocialite.php
@@ -15,7 +15,7 @@ class TumblrExtendSocialite
     {
         $socialiteWasCalled->extendSocialite(
             'tumblr',
-            __NAMESPACE__.'\Provider',
+            Provider::class,
             \SocialiteProviders\Tumblr\Server::class
         );
     }

--- a/src/TwentyThreeAndMe/TwentyThreeAndMeExtendSocialite.php
+++ b/src/TwentyThreeAndMe/TwentyThreeAndMeExtendSocialite.php
@@ -13,9 +13,6 @@ class TwentyThreeAndMeExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            '23andme',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('23andme', Provider::class);
     }
 }

--- a/src/Twitch/TwitchExtendSocialite.php
+++ b/src/Twitch/TwitchExtendSocialite.php
@@ -13,9 +13,6 @@ class TwitchExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'twitch',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('twitch', Provider::class);
     }
 }

--- a/src/Twitter/TwitterExtendSocialite.php
+++ b/src/Twitter/TwitterExtendSocialite.php
@@ -11,10 +11,6 @@ class TwitterExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'twitter',
-            __NAMESPACE__.'\Provider',
-            __NAMESPACE__.'\Server'
-        );
+        $socialiteWasCalled->extendSocialite('twitter', Provider::class, Server::class);
     }
 }

--- a/src/UCL/UCLExtendSocialite.php
+++ b/src/UCL/UCLExtendSocialite.php
@@ -11,6 +11,6 @@ class UCLExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('uclapi', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('uclapi', Provider::class);
     }
 }

--- a/src/UFS/UFSExtendSocialite.php
+++ b/src/UFS/UFSExtendSocialite.php
@@ -11,6 +11,6 @@ class UFSExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('ufs', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('ufs', Provider::class);
     }
 }

--- a/src/Uber/UberExtendSocialite.php
+++ b/src/Uber/UberExtendSocialite.php
@@ -13,9 +13,6 @@ class UberExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'uber',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('uber', Provider::class);
     }
 }

--- a/src/Ufutx/UfutxExtendSocialite.php
+++ b/src/Ufutx/UfutxExtendSocialite.php
@@ -13,9 +13,6 @@ class UfutxExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'ufutx',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('ufutx', Provider::class);
     }
 }

--- a/src/Unsplash/UnsplashExtendSocialite.php
+++ b/src/Unsplash/UnsplashExtendSocialite.php
@@ -13,9 +13,6 @@ class UnsplashExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'unsplash',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('unsplash', Provider::class);
     }
 }

--- a/src/Untappd/UntappdExtendSocialite.php
+++ b/src/Untappd/UntappdExtendSocialite.php
@@ -13,9 +13,6 @@ class UntappdExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'untappd',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('untappd', Provider::class);
     }
 }

--- a/src/VKontakte/VKontakteExtendSocialite.php
+++ b/src/VKontakte/VKontakteExtendSocialite.php
@@ -13,9 +13,6 @@ class VKontakteExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'vkontakte',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('vkontakte', Provider::class);
     }
 }

--- a/src/Venmo/VenmoExtendSocialite.php
+++ b/src/Venmo/VenmoExtendSocialite.php
@@ -11,6 +11,6 @@ class VenmoExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('venmo', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('venmo', Provider::class);
     }
 }

--- a/src/Vercel/VercelExtendSocialite.php
+++ b/src/Vercel/VercelExtendSocialite.php
@@ -11,6 +11,6 @@ class VercelExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('vercel', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('vercel', Provider::class);
     }
 }

--- a/src/VersionOne/VersionOneExtendSocialite.php
+++ b/src/VersionOne/VersionOneExtendSocialite.php
@@ -11,6 +11,6 @@ class VersionOneExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('versionone', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('versionone', Provider::class);
     }
 }

--- a/src/Vimeo/VimeoExtendSocialite.php
+++ b/src/Vimeo/VimeoExtendSocialite.php
@@ -13,9 +13,6 @@ class VimeoExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'vimeo',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('vimeo', Provider::class);
     }
 }

--- a/src/WeChatServiceAccount/WeChatServiceAccountExtendSocialite.php
+++ b/src/WeChatServiceAccount/WeChatServiceAccountExtendSocialite.php
@@ -11,6 +11,6 @@ class WeChatServiceAccountExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('wechat_service_account', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('wechat_service_account', Provider::class);
     }
 }

--- a/src/WeChatWeb/WeChatWebExtendSocialite.php
+++ b/src/WeChatWeb/WeChatWebExtendSocialite.php
@@ -11,6 +11,6 @@ class WeChatWebExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('wechat_web', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('wechat_web', Provider::class);
     }
 }

--- a/src/Weibo/WeiboExtendSocialite.php
+++ b/src/Weibo/WeiboExtendSocialite.php
@@ -8,6 +8,6 @@ class WeiboExtendSocialite
 {
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('weibo', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('weibo', Provider::class);
     }
 }

--- a/src/Weixin/WeixinExtendSocialite.php
+++ b/src/Weixin/WeixinExtendSocialite.php
@@ -13,9 +13,6 @@ class WeixinExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'weixin',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('weixin', Provider::class);
     }
 }

--- a/src/WeixinWeb/WeixinWebExtendSocialite.php
+++ b/src/WeixinWeb/WeixinWebExtendSocialite.php
@@ -13,9 +13,6 @@ class WeixinWebExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'weixinweb',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('weixinweb', Provider::class);
     }
 }

--- a/src/Withings/WithingsExtendSocialite.php
+++ b/src/Withings/WithingsExtendSocialite.php
@@ -13,10 +13,6 @@ class WithingsExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'withings',
-            __NAMESPACE__.'\Provider',
-            __NAMESPACE__.'\Server'
-        );
+        $socialiteWasCalled->extendSocialite('withings', Provider::class, Server::class);
     }
 }

--- a/src/WordPress/WordPressExtendSocialite.php
+++ b/src/WordPress/WordPressExtendSocialite.php
@@ -8,6 +8,6 @@ class WordPressExtendSocialite
 {
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('wordpress', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('wordpress', Provider::class);
     }
 }

--- a/src/Xero/XeroExtendSocialite.php
+++ b/src/Xero/XeroExtendSocialite.php
@@ -11,6 +11,6 @@ class XeroExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('xero', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('xero', Provider::class);
     }
 }

--- a/src/Xing/XingExtendSocialite.php
+++ b/src/Xing/XingExtendSocialite.php
@@ -13,10 +13,6 @@ class XingExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'xing',
-            __NAMESPACE__.'\Provider',
-            __NAMESPACE__.'\Server'
-        );
+        $socialiteWasCalled->extendSocialite('xing', Provider::class, Server::class);
     }
 }

--- a/src/Yahoo/YahooExtendSocialite.php
+++ b/src/Yahoo/YahooExtendSocialite.php
@@ -11,6 +11,6 @@ class YahooExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('yahoo', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('yahoo', Provider::class);
     }
 }

--- a/src/Yammer/YammerExtendSocialite.php
+++ b/src/Yammer/YammerExtendSocialite.php
@@ -13,9 +13,6 @@ class YammerExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'yammer',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('yammer', Provider::class);
     }
 }

--- a/src/Yandex/YandexExtendSocialite.php
+++ b/src/Yandex/YandexExtendSocialite.php
@@ -13,9 +13,6 @@ class YandexExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'yandex',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('yandex', Provider::class);
     }
 }

--- a/src/Yiban/YibanExtendSocialite.php
+++ b/src/Yiban/YibanExtendSocialite.php
@@ -8,6 +8,6 @@ class YibanExtendSocialite
 {
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('yiban', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('yiban', Provider::class);
     }
 }

--- a/src/YouTube/YouTubeExtendSocialite.php
+++ b/src/YouTube/YouTubeExtendSocialite.php
@@ -13,9 +13,6 @@ class YouTubeExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'youtube',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('youtube', Provider::class);
     }
 }

--- a/src/Zalo/ZaloExtendSocialite.php
+++ b/src/Zalo/ZaloExtendSocialite.php
@@ -11,6 +11,6 @@ class ZaloExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('zalo', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('zalo', Provider::class);
     }
 }

--- a/src/Zendesk/ZendeskExtendSocialite.php
+++ b/src/Zendesk/ZendeskExtendSocialite.php
@@ -13,9 +13,6 @@ class ZendeskExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite(
-            'zendesk',
-            __NAMESPACE__.'\Provider'
-        );
+        $socialiteWasCalled->extendSocialite('zendesk', Provider::class);
     }
 }

--- a/src/Zoho/ZohoExtendSocialite.php
+++ b/src/Zoho/ZohoExtendSocialite.php
@@ -11,6 +11,6 @@ class ZohoExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('zoho', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('zoho', Provider::class);
     }
 }

--- a/src/xREL/xRELExtendSocialite.php
+++ b/src/xREL/xRELExtendSocialite.php
@@ -13,6 +13,6 @@ class xRELExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('xrel', __NAMESPACE__.'\Provider');
+        $socialiteWasCalled->extendSocialite('xrel', Provider::class);
     }
 }


### PR DESCRIPTION
There is no need to concatenate `__NAMESPACE__` with the class name as a string when we can just use the `::class` notation