### PR TITLE
Instagram Basic: remove default fields/scopes

### DIFF
--- a/src/InstagramBasic/Provider.php
+++ b/src/InstagramBasic/Provider.php
@@ -17,12 +17,12 @@ class Provider extends AbstractProvider
      *
      * @var array
      */
-    protected $fields = ['account_type', 'id', 'media_count', 'username'];
+    protected $fields = ['account_type', 'id', 'username'];
 
     /**
      * {@inheritdoc}
      */
-    protected $scopes = ['user_profile', 'user_media'];
+    protected $scopes = ['user_profile'];
 
     /**
      * {@inheritdoc}
@@ -75,7 +75,6 @@ class Provider extends AbstractProvider
             'email'        => null,
             'avatar'       => null,
             'account_type' => $user['account_type'],
-            'media_count'  => $user['media_count'],
         ]);
     }
 

--- a/src/InstagramBasic/Provider.php
+++ b/src/InstagramBasic/Provider.php
@@ -75,6 +75,7 @@ class Provider extends AbstractProvider
             'email'        => null,
             'avatar'       => null,
             'account_type' => $user['account_type'],
+            'media_count'  => $user['media_count'] ?? null,
         ]);
     }
 


### PR DESCRIPTION
The new Instagram Basic Display API is a bit of a pain - it effectively has two scopes, *both* of which require manual review from the Facebook team. Manual review requires a screencast that shows exactly how you intend to use the data from the API, as well as a sandbox app that the review team can test your integration with.

The first scope is `user_profile` which is just what it sounds like, and the second scope is `user_media`, which gives you access to the user's media.

As it is now, the provider uses both scopes and would therefore require your app to use both parts of the API and expose them to users so they appear in the review screencast and sandbox app.

My suggestion here is that out of the box we use the bare minimum scope so we don't force people to go through app review for API features they don't intend to use.

---

If you wanted to continue using the `user_media` scope, it would be an opt-in action like `Socialite::driver('instagrambasic')->scopes('user_media')->redirect();`.