### PR TITLE
Microsoft: use configured tenant in getTokenUrl method

### DIFF
--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -41,7 +41,7 @@ class Provider extends AbstractProvider
      */
     protected function getTokenUrl()
     {
-        return 'https://login.microsoftonline.com/common/oauth2/v2.0/token';
+        return 'https://login.microsoftonline.com/'.($this->config['tenant'] ?: 'common').'/oauth2/v2.0/token';
     }
 
     /**

--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -30,7 +30,10 @@ class Provider extends AbstractProvider
     {
         return
             $this->buildAuthUrlFromBase(
-                'https://login.microsoftonline.com/'.($this->config['tenant'] ?: 'common').'/oauth2/v2.0/authorize',
+                sprintf(
+                    'https://login.microsoftonline.com/%s/oauth2/v2.0/authorize',
+                    $this->config['tenant'] ?: 'common'
+                ),
                 $state
             );
     }
@@ -41,7 +44,7 @@ class Provider extends AbstractProvider
      */
     protected function getTokenUrl()
     {
-        return 'https://login.microsoftonline.com/'.($this->config['tenant'] ?: 'common').'/oauth2/v2.0/token';
+        return sprintf('https://login.microsoftonline.com/%s/oauth2/v2.0/token', $this->config['tenant'] ?: 'common');
     }
 
     /**


### PR DESCRIPTION
Currently the `getTokenUrl` method is hardcoded to use the `common` tenant instead of the one configured by the user. This caused the token retrieval to fail for me, as I restricted my app to only personal accounts which requires you to use the `consumer` 'tenant'. Respecting the configured tenant fixes this.