### PR TITLE
Drop support for PHP < 7.2

### DIFF
--- a/.github/workflows/monorepo-split.yml
+++ b/.github/workflows/monorepo-split.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Prepare repository
         run: git checkout "${GITHUB_REF:11}"
 
-      - name:  Set up PHP
+      - name: Set up PHP
         uses: shivammathur/setup-php@master
         with:
-          php-version: '7.3'
+          php-version: '7.4'
           coverage: none
 
       - name: Composer Install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         run: composer test:ci
 
       - name: Upload code coverage
-        if: matrix.php-versions == '7.3'
+        if: matrix.php-versions == '7.4'
         run: |
           wget https://scrutinizer-ci.com/ocular.phar
           php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Collection of all OAuth2 Providers for Laravel Socialite",
     "license": "MIT",
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Acclaim/composer.json
+++ b/src/Acclaim/composer.json
@@ -2,15 +2,18 @@
     "name": "socialiteproviders/acclaim",
     "description": "Acclaim OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Pavan Kumar",
-        "email": "katakampavan.btech@gmail.com"
-    }, {
-        "name": "Anton Komarev",
-        "email": "ell@cybercog.su"
-    }],
+    "authors": [
+        {
+            "name": "Pavan Kumar",
+            "email": "katakampavan.btech@gmail.com"
+        },
+        {
+            "name": "Anton Komarev",
+            "email": "ell@cybercog.su"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Admitad/composer.json
+++ b/src/Admitad/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/admitad",
     "description": "Admitad OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Nikolay Kirsh",
-        "email": "boston@hype.ru"
-    }],
+    "authors": [
+        {
+            "name": "Nikolay Kirsh",
+            "email": "boston@hype.ru"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Amazon/composer.json
+++ b/src/Amazon/composer.json
@@ -2,14 +2,17 @@
     "name": "socialiteproviders/amazon",
     "description": "Amazon OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "atymic",
-        "email": "atymicq@gmail.com",
-        "homepage": "https://atymic.dev"
-    }],
+    "authors": [
+        {
+            "name": "atymic",
+            "email": "atymicq@gmail.com",
+            "homepage": "https://atymic.dev"
+        }
+    ],
     "require": {
-        "php": ">=5.5.9",
-        "socialiteproviders/manager": "^2.0|^3.0"
+        "php": "^7.2",
+        "socialiteproviders/manager": "~2.0 || ~3.0",
+        "ext-json": "*"
     },
     "autoload": {
         "psr-4": {

--- a/src/AngelList/composer.json
+++ b/src/AngelList/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/angellist",
     "description": "AngelList OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/AppNet/composer.json
+++ b/src/AppNet/composer.json
@@ -2,15 +2,18 @@
     "name": "socialiteproviders/appnet",
     "description": "App.net OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "DraperStudio",
-        "email": "hello@draperstud.io"
-    }, {
-        "name": "Anton Komarev",
-        "email": "ell@cybercog.su"
-    }],
+    "authors": [
+        {
+            "name": "DraperStudio",
+            "email": "hello@draperstud.io"
+        },
+        {
+            "name": "Anton Komarev",
+            "email": "ell@cybercog.su"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Apple/composer.json
+++ b/src/Apple/composer.json
@@ -16,9 +16,11 @@
         }
     ],
     "require": {
+        "php": "^7.2",
+        "ext-json": "*",
         "firebase/php-jwt": "^5.2",
         "lcobucci/jwt": "^3.3",
-        "socialiteproviders/manager": "^2.0|^3.0"
+        "socialiteproviders/manager": "~2.0 || ~3.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/ArcGIS/composer.json
+++ b/src/ArcGIS/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/arcgis",
     "description": "ArcGIS Online OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "David Piesse",
-        "email": "piesse@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "David Piesse",
+            "email": "piesse@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Asana/composer.json
+++ b/src/Asana/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/asana",
     "description": "Asana OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Auth0/composer.json
+++ b/src/Auth0/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Aweber/composer.json
+++ b/src/Aweber/composer.json
@@ -2,15 +2,18 @@
     "name": "socialiteproviders/aweber",
     "description": "Aweber OAuth1 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Andrew Tsimerman",
-        "email": "tsimerandriy@gmail.com"
-    }, {
-        "name": "Anton Komarev",
-        "email": "a.komarev@cybercog.su"
-    }],
+    "authors": [
+        {
+            "name": "Andrew Tsimerman",
+            "email": "tsimerandriy@gmail.com"
+        },
+        {
+            "name": "Anton Komarev",
+            "email": "a.komarev@cybercog.su"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Azure/composer.json
+++ b/src/Azure/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/microsoft-azure",
     "description": "Microsoft Azure OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Chris Hemmings",
-        "email": "chris@hemmin.gs"
-    }],
+    "authors": [
+        {
+            "name": "Chris Hemmings",
+            "email": "chris@hemmin.gs"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Battlenet/composer.json
+++ b/src/Battlenet/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/battlenet",
     "description": "Battlenet OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Anand Capur",
-        "email": "github@anand.io"
-    }],
+    "authors": [
+        {
+            "name": "Anand Capur",
+            "email": "github@anand.io"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Bitbucket/composer.json
+++ b/src/Bitbucket/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/bitbucket",
     "description": "Bitbucket OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Anton Komarev",
-        "email": "ell@cybercog.su"
-    }],
+    "authors": [
+        {
+            "name": "Anton Komarev",
+            "email": "ell@cybercog.su"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Bitly/composer.json
+++ b/src/Bitly/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/bitly",
     "description": "Bitly OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Box/composer.json
+++ b/src/Box/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/box",
     "description": "Box OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Buffer/composer.json
+++ b/src/Buffer/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/buffer",
     "description": "Buffer OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/CampaignMonitor/composer.json
+++ b/src/CampaignMonitor/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/campaignmonitor",
     "description": "CampaignMonitor OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Cheddar/composer.json
+++ b/src/Cheddar/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/cheddar",
     "description": "Cheddar OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/ClaveUnica/composer.json
+++ b/src/ClaveUnica/composer.json
@@ -2,13 +2,16 @@
     "name": "socialiteproviders/claveunica",
     "description": "ClaveUnica OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Rodrigore",
-        "email": "rodrigopcg@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "Rodrigore",
+            "email": "rodrigopcg@gmail.com"
+        }
+    ],
     "require": {
-        "php": ">=5.5.9",
-        "socialiteproviders/manager": "^2.0"
+        "php": "^7.2",
+        "socialiteproviders/manager": "~2.0 || ~3.0",
+        "ext-json": "*"
     },
     "autoload": {
         "psr-4": {

--- a/src/Coinbase/composer.json
+++ b/src/Coinbase/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/coinbase",
     "description": "Coinbase OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/ConstantContact/composer.json
+++ b/src/ConstantContact/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/constantcontact",
     "description": "ConstantContact OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Coursera/composer.json
+++ b/src/Coursera/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/coursera",
     "description": "Coursera OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Dave Tosh",
-        "email": "dave@pedalred.com"
-    }],
+    "authors": [
+        {
+            "name": "Dave Tosh",
+            "email": "dave@pedalred.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Dailymile/composer.json
+++ b/src/Dailymile/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/dailymile",
     "description": "Dailymile OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Dailymotion/composer.json
+++ b/src/Dailymotion/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/dailymotion",
     "description": "Dailymotion OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Dataporten/composer.json
+++ b/src/Dataporten/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/dataporten",
     "description": "Dataporten OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Jørgen Birkhaug",
-        "email": "jorgen.birkhaug@uib.no"
-    }],
+    "authors": [
+        {
+            "name": "J\u00f8rgen Birkhaug",
+            "email": "jorgen.birkhaug@uib.no"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Deezer/composer.json
+++ b/src/Deezer/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/deezer",
     "description": "Deezer OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Deviantart/composer.json
+++ b/src/Deviantart/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/deviantart",
     "description": "deviantART OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/DigitalOcean/composer.json
+++ b/src/DigitalOcean/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/digitalocean",
     "description": "DigitalOcean OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Discogs/composer.json
+++ b/src/Discogs/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/discogs",
     "description": "Discogs OAuth1 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Blake Bengtson",
-        "email": "blake@bengtson.us"
-    }],
+    "authors": [
+        {
+            "name": "Blake Bengtson",
+            "email": "blake@bengtson.us"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Discord/composer.json
+++ b/src/Discord/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/discord",
     "description": "Discord OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Christopher Eklund",
-        "email": "eklundchristopher@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "Christopher Eklund",
+            "email": "eklundchristopher@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Disqus/composer.json
+++ b/src/Disqus/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/disqus",
     "description": "Disqus OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Douban/composer.json
+++ b/src/Douban/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/douban",
     "description": "douban.com OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "xyxu",
-        "email": "techxu@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "xyxu",
+            "email": "techxu@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Dribbble/composer.json
+++ b/src/Dribbble/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/dribbble",
     "description": "Dribbble OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Dropbox/composer.json
+++ b/src/Dropbox/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/dropbox",
     "description": "Dropbox OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Envato/composer.json
+++ b/src/Envato/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/envato",
     "description": "Envato OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Dennis Oderwald",
-        "email": "oderwald@comyo-media.de"
-    }],
+    "authors": [
+        {
+            "name": "Dennis Oderwald",
+            "email": "oderwald@comyo-media.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Etsy/composer.json
+++ b/src/Etsy/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/etsy",
     "description": "Etsy OAuth1 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Felipe Marques",
-        "email": "contato@felipemarques.com.br"
-    }],
+    "authors": [
+        {
+            "name": "Felipe Marques",
+            "email": "contato@felipemarques.com.br"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Eventbrite/composer.json
+++ b/src/Eventbrite/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/eventbrite",
     "description": "Eventbrite OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Everyplay/composer.json
+++ b/src/Everyplay/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/everyplay",
     "description": "Everyplay OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/EyeEm/composer.json
+++ b/src/EyeEm/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/eyeem",
     "description": "EyeEm OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Facebook/composer.json
+++ b/src/Facebook/composer.json
@@ -2,14 +2,16 @@
     "name": "socialiteproviders/facebook",
     "description": "Facebook (facebook.com) OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Oleksandr Prypkhan (Alex Wells)",
-        "email": "autaut03@googlemail.com"
-    }],
+    "authors": [
+        {
+            "name": "Oleksandr Prypkhan (Alex Wells)",
+            "email": "autaut03@googlemail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
-        "socialiteproviders/manager": "~3.0"
+        "socialiteproviders/manager": "~2.0 || ~3.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Faceit/composer.json
+++ b/src/Faceit/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/faceit",
     "description": "Faceit OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Dzmitry Bekish",
-        "email": "ya.sofwar@yandex.com"
-    }],
+    "authors": [
+        {
+            "name": "Dzmitry Bekish",
+            "email": "ya.sofwar@yandex.com"
+        }
+    ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Fitbit/composer.json
+++ b/src/Fitbit/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/fitbit",
     "description": "Fitbit OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Bryce Adams",
-        "email": "brycead@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "Bryce Adams",
+            "email": "brycead@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/FiveHundredPixel/composer.json
+++ b/src/FiveHundredPixel/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/500px",
     "description": "500px OAuth1 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Flattr/composer.json
+++ b/src/Flattr/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/flattr",
     "description": "Flattr OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Flexkids/composer.json
+++ b/src/Flexkids/composer.json
@@ -2,13 +2,16 @@
     "name": "socialiteproviders/flexkids",
     "description": "Flexkids OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Stephan Eizinga",
-        "email": "stephan.eizinga@flexkids.nl"
-    }],
+    "authors": [
+        {
+            "name": "Stephan Eizinga",
+            "email": "stephan.eizinga@flexkids.nl"
+        }
+    ],
     "require": {
-        "php": ">=5.5.9",
-        "socialiteproviders/manager": "~2.0 || ~3.0"
+        "php": "^7.2",
+        "socialiteproviders/manager": "~2.0 || ~3.0",
+        "ext-json": "*"
     },
     "autoload": {
         "psr-4": {

--- a/src/Flickr/composer.json
+++ b/src/Flickr/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/flickr",
     "description": "Flickr OAuth1 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Foursquare/composer.json
+++ b/src/Foursquare/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/foursquare",
     "description": "Foursquare OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/FranceConnect/composer.json
+++ b/src/FranceConnect/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/franceconnect",
     "description": "France-Connect OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Adil Kachbat",
-        "email": "contact@akachbat.com"
-    }],
+    "authors": [
+        {
+            "name": "Adil Kachbat",
+            "email": "contact@akachbat.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/GameWisp/composer.json
+++ b/src/GameWisp/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/gamewisp",
     "description": "GameWisp OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Eli Hooten",
-        "email": "eli@gamewisp.com"
-    }],
+    "authors": [
+        {
+            "name": "Eli Hooten",
+            "email": "eli@gamewisp.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/GarminConnect/composer.json
+++ b/src/GarminConnect/composer.json
@@ -2,13 +2,16 @@
     "name": "socialiteproviders/garmin-connect",
     "description": "Garmin Connect OAuth1 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Ubient",
-        "email": "claudio@ubient.net"
-    }],
+    "authors": [
+        {
+            "name": "Ubient",
+            "email": "claudio@ubient.net"
+        }
+    ],
     "require": {
-        "php": ">=5.5.9",
-        "socialiteproviders/manager": "^3.0"
+        "php": "^7.2",
+        "socialiteproviders/manager": "~2.0 || ~3.0",
+        "ext-json": "*"
     },
     "autoload": {
         "psr-4": {

--- a/src/GettyImages/composer.json
+++ b/src/GettyImages/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/gettyimages",
     "description": "Getty Images OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Bhuwan Bashel",
-        "email": "bhuwan_bibek@yahoo.com"
-    }],
+    "authors": [
+        {
+            "name": "Bhuwan Bashel",
+            "email": "bhuwan_bibek@yahoo.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/GitHub/composer.json
+++ b/src/GitHub/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/github",
     "description": "GitHub OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Anton Komarev",
-        "email": "ell@cybercog.su"
-    }],
+    "authors": [
+        {
+            "name": "Anton Komarev",
+            "email": "ell@cybercog.su"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/GitLab/composer.json
+++ b/src/GitLab/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/gitlab",
     "description": "GitLab OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Christoffer Martinsen",
-        "email": "christoffermartinsen@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "Christoffer Martinsen",
+            "email": "christoffermartinsen@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Gitee/composer.json
+++ b/src/Gitee/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/gitee",
     "description": "Gitee OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "mowangjuanzi",
-        "email": "baoguoxiao0538@hotmail.com"
-    }],
+    "authors": [
+        {
+            "name": "mowangjuanzi",
+            "email": "baoguoxiao0538@hotmail.com"
+        }
+    ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Goodreads/composer.json
+++ b/src/Goodreads/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/goodreads",
     "description": "Goodreads OAuth1 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Google/composer.json
+++ b/src/Google/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/google",
     "description": "Google OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "xstoop",
-        "email": "myenglishnameisx@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "xstoop",
+            "email": "myenglishnameisx@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Graph/composer.json
+++ b/src/Graph/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/microsoft-graph",
     "description": "Microsoft Graph OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Chris Edgerton",
-        "email": "cjedgerton@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "Chris Edgerton",
+            "email": "cjedgerton@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Harvest/composer.json
+++ b/src/Harvest/composer.json
@@ -2,14 +2,16 @@
     "name": "socialiteproviders/harvest",
     "description": "Harvest OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Jason Jozwiak",
-        "email": "jason.jozwiak@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "Jason Jozwiak",
+            "email": "jason.jozwiak@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
-        "socialiteproviders/manager": "^2.0 || ^3.3"
+        "socialiteproviders/manager": "~2.0 || ~3.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/HeadHunter/composer.json
+++ b/src/HeadHunter/composer.json
@@ -1,21 +1,21 @@
 {
-  "name": "socialiteproviders/headhunter",
-  "description": "HeadHunter OAuth2 Provider for Laravel Socialite",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Sergey Panteleev",
-      "email": "sergey@php.net"
+    "name": "socialiteproviders/headhunter",
+    "description": "HeadHunter OAuth2 Provider for Laravel Socialite",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Sergey Panteleev",
+            "email": "sergey@php.net"
+        }
+    ],
+    "require": {
+        "php": "^7.2",
+        "ext-json": "*",
+        "socialiteproviders/manager": "~2.0 || ~3.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialiteProviders\\HeadHunter\\": ""
+        }
     }
-  ],
-  "require": {
-    "php": "^5.6 || ^7.0",
-    "ext-json": "*",
-    "socialiteproviders/manager": "~2.0 || ~3.0"
-  },
-  "autoload": {
-    "psr-4": {
-      "SocialiteProviders\\HeadHunter\\": ""
-    }
-  }
 }

--- a/src/Heroku/composer.json
+++ b/src/Heroku/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/heroku",
     "description": "Heroku OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Hitbox/composer.json
+++ b/src/Hitbox/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/hitbox",
     "description": "Hitbox OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Jérôme Foray",
-        "email": "moi@foray-jero.me"
-    }],
+    "authors": [
+        {
+            "name": "J\u00e9r\u00f4me Foray",
+            "email": "moi@foray-jero.me"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/HubSpot/composer.json
+++ b/src/HubSpot/composer.json
@@ -2,14 +2,16 @@
     "name": "socialiteproviders/hubspot",
     "description": "HubSpot OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Steve Williamson",
-        "email": "steve@tappnetwork.com"
-    }],
+    "authors": [
+        {
+            "name": "Steve Williamson",
+            "email": "steve@tappnetwork.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
-        "socialiteproviders/manager": "~3.0"
+        "socialiteproviders/manager": "~2.0 || ~3.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/HumanApi/composer.json
+++ b/src/HumanApi/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/human-api",
     "description": "HumanApi OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/IFSP/composer.json
+++ b/src/IFSP/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/ifsp",
     "description": "IFSP OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Douglas Andrade",
-        "email": "douglas@ifsp.edu.br"
-    }],
+    "authors": [
+        {
+            "name": "Douglas Andrade",
+            "email": "douglas@ifsp.edu.br"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Imgur/composer.json
+++ b/src/Imgur/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/imgur",
     "description": "Imgur OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Instagram/composer.json
+++ b/src/Instagram/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/instagram",
     "description": "Instagram OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/InstagramBasic/composer.json
+++ b/src/InstagramBasic/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/instagram-basic",
     "description": "Instagram Basic Display OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Philipp Mochine",
-        "email": "support@avidofood.com"
-    }],
+    "authors": [
+        {
+            "name": "Philipp Mochine",
+            "email": "support@avidofood.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Intercom/composer.json
+++ b/src/Intercom/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/intercom",
     "description": "Intercom OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Bryce Adams",
-        "email": "bryce@metorik.com"
-    }],
+    "authors": [
+        {
+            "name": "Bryce Adams",
+            "email": "bryce@metorik.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Jawbone/composer.json
+++ b/src/Jawbone/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/jawbone",
     "description": "Jawbone OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Jira/composer.json
+++ b/src/Jira/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/jira",
     "description": "Jira OAuth1 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Julia Grishchenko",
-        "email": "yulia.grischenko@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "Julia Grishchenko",
+            "email": "yulia.grischenko@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Kakao/composer.json
+++ b/src/Kakao/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/kakao",
     "description": "Kakao OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Doojin So",
-        "email": "sodoojin@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "Doojin So",
+            "email": "sodoojin@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Keycloak/composer.json
+++ b/src/Keycloak/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/keycloak",
     "description": "Keycloak OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Oleg Kuchumov",
-        "email": "voenniy@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "Oleg Kuchumov",
+            "email": "voenniy@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/LaravelPassport/composer.json
+++ b/src/LaravelPassport/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/laravelpassport",
     "description": "LaravelPassport OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "recca0120",
-        "email": "recca0120@name.com"
-    }],
+    "authors": [
+        {
+            "name": "recca0120",
+            "email": "recca0120@name.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Line/composer.json
+++ b/src/Line/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/line",
     "description": "Line Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Sorrawut Kittikeereechaikun",
-        "email": "mix5003@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "Sorrawut Kittikeereechaikun",
+            "email": "mix5003@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/LinkedIn/composer.json
+++ b/src/LinkedIn/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/linkedin",
     "description": "LinkedIn OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Live/composer.json
+++ b/src/Live/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/microsoft-live",
     "description": "Microsoft Live OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/MailChimp/composer.json
+++ b/src/MailChimp/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/mailchimp",
     "description": "MailChimp OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Mailru/composer.json
+++ b/src/Mailru/composer.json
@@ -1,20 +1,21 @@
 {
-  "name": "socialiteproviders/mailru",
-  "description": "Mail.ru OAuth2 Provider for Laravel Socialite",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Sergey Panteleev",
-      "email": "sergey@php.net"
+    "name": "socialiteproviders/mailru",
+    "description": "Mail.ru OAuth2 Provider for Laravel Socialite",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Sergey Panteleev",
+            "email": "sergey@php.net"
+        }
+    ],
+    "require": {
+        "php": "^7.2",
+        "socialiteproviders/manager": "~2.0 || ~3.0",
+        "ext-json": "*"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialiteProviders\\Mailru\\": ""
+        }
     }
-  ],
-  "require": {
-    "php": "^5.6 || ^7.0",
-    "socialiteproviders/manager": "~2.0 || ~3.0"
-  },
-  "autoload": {
-    "psr-4": {
-      "SocialiteProviders\\Mailru\\": ""
-    }
-  }
 }

--- a/src/MakerLog/composer.json
+++ b/src/MakerLog/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/MasterChain/composer.json
+++ b/src/MasterChain/composer.json
@@ -4,11 +4,12 @@
     "license": "MIT",
     "authors": [
         {
-        "name": "Kevin Xu",
-        "email": "kevin830802@gmail.com"
-    }],
+            "name": "Kevin Xu",
+            "email": "kevin830802@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Mattermost/composer.json
+++ b/src/Mattermost/composer.json
@@ -2,14 +2,16 @@
     "name": "socialiteproviders/mattermost",
     "description": "Mattermost OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "takuya",
-        "email": "takuya.1st@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "takuya",
+            "email": "takuya.1st@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
-        "socialiteproviders/manager": ">=2.0"
+        "socialiteproviders/manager": "~2.0 || ~3.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/MediaCube/composer.json
+++ b/src/MediaCube/composer.json
@@ -1,20 +1,21 @@
 {
-  "name": "socialiteproviders/mediacube",
-  "description": "MediaCube OAuth2 Provider for Laravel Socialite.",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "kladislav",
-      "email": "kim@mediacube.network"
+    "name": "socialiteproviders/mediacube",
+    "description": "MediaCube OAuth2 Provider for Laravel Socialite.",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "kladislav",
+            "email": "kim@mediacube.network"
+        }
+    ],
+    "require": {
+        "php": "^7.2",
+        "socialiteproviders/manager": "~2.0 || ~3.0",
+        "ext-json": "*"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialProviders\\MediaCube\\": ""
+        }
     }
-  ],
-  "require": {
-    "php": ">=7.0",
-    "socialiteproviders/manager": "~2.0 || ~3.0"
-  },
-  "autoload": {
-    "psr-4": {
-      "SocialProviders\\MediaCube\\": ""
-    }
-  }
 }

--- a/src/Medium/composer.json
+++ b/src/Medium/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/medium",
     "description": "Medium OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Daniel Baron",
-        "email": "daniel.baron@gmx.net"
-    }],
+    "authors": [
+        {
+            "name": "Daniel Baron",
+            "email": "daniel.baron@gmx.net"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Meetup/composer.json
+++ b/src/Meetup/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/meetup",
     "description": "Meetup.com OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Andy Wendt",
-        "email": "andy@awendt.com"
-    }],
+    "authors": [
+        {
+            "name": "Andy Wendt",
+            "email": "andy@awendt.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Microsoft/composer.json
+++ b/src/Microsoft/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/microsoft",
     "description": "Microsoft OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Mixcloud/composer.json
+++ b/src/Mixcloud/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/mixcloud",
     "description": "Mixcloud OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Mixer/composer.json
+++ b/src/Mixer/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/mixer",
     "description": "Mixer OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Eli Hooten",
-        "email": "eli@gamewisp.com"
-    }],
+    "authors": [
+        {
+            "name": "Eli Hooten",
+            "email": "eli@gamewisp.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/MoiKrug/composer.json
+++ b/src/MoiKrug/composer.json
@@ -1,20 +1,21 @@
 {
-  "name": "socialiteproviders/moikrug",
-  "description": "MoiKrug.ru OAuth2 Provider for Laravel Socialite",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Sergey Panteleev",
-      "email": "sergey@php.net"
+    "name": "socialiteproviders/moikrug",
+    "description": "MoiKrug.ru OAuth2 Provider for Laravel Socialite",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Sergey Panteleev",
+            "email": "sergey@php.net"
+        }
+    ],
+    "require": {
+        "php": "^7.2",
+        "socialiteproviders/manager": "~2.0 || ~3.0",
+        "ext-json": "*"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialiteProviders\\MoiKrug\\": ""
+        }
     }
-  ],
-  "require": {
-    "php": "^5.6 || ^7.0",
-    "socialiteproviders/manager": "~2.0 || ~3.0"
-  },
-  "autoload": {
-    "psr-4": {
-      "SocialiteProviders\\MoiKrug\\": ""
-    }
-  }
 }

--- a/src/Mollie/composer.json
+++ b/src/Mollie/composer.json
@@ -3,7 +3,7 @@
     "description": "Mollie OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Naver/composer.json
+++ b/src/Naver/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/naver",
     "description": "Naver OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Doojin So",
-        "email": "sodoojin@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "Doojin So",
+            "email": "sodoojin@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Netlify/composer.json
+++ b/src/Netlify/composer.json
@@ -2,13 +2,16 @@
     "name": "socialiteproviders/netlify",
     "description": "Netlify OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Miguel Piedrafita",
-        "email": "soy@miguelpiedrafita.com"
-    }],
+    "authors": [
+        {
+            "name": "Miguel Piedrafita",
+            "email": "soy@miguelpiedrafita.com"
+        }
+    ],
     "require": {
-        "php": ">=5.5.9",
-        "socialiteproviders/manager": "^2.0|^3.0"
+        "php": "^7.2",
+        "socialiteproviders/manager": "~2.0 || ~3.0",
+        "ext-json": "*"
     },
     "autoload": {
         "psr-4": {

--- a/src/Nocks/composer.json
+++ b/src/Nocks/composer.json
@@ -2,14 +2,16 @@
     "name": "socialiteproviders/nocks",
     "description": "Nocks OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Paul Wijnberg",
-        "email": "contact@wijnberg.dev"
-    }],
+    "authors": [
+        {
+            "name": "Paul Wijnberg",
+            "email": "contact@wijnberg.dev"
+        }
+    ],
     "require": {
-        "php": ">=5.5.9",
+        "php": "^7.2",
         "ext-json": "*",
-        "socialiteproviders/manager": "^2.0|^3.0"
+        "socialiteproviders/manager": "~2.0 || ~3.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/OAuthgen/composer.json
+++ b/src/OAuthgen/composer.json
@@ -2,13 +2,16 @@
     "name": "socialiteproviders/oauthgen",
     "description": "OAuthgen OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Oxiqa",
-        "email": "ishan@oxiqa.com"
-    }],
+    "authors": [
+        {
+            "name": "Oxiqa",
+            "email": "ishan@oxiqa.com"
+        }
+    ],
     "require": {
-        "php": ">=5.5.9",
-        "socialiteproviders/manager": "^2.0"
+        "php": "^7.2",
+        "socialiteproviders/manager": "~2.0 || ~3.0",
+        "ext-json": "*"
     },
     "autoload": {
         "psr-4": {

--- a/src/OSChina/composer.json
+++ b/src/OSChina/composer.json
@@ -2,15 +2,18 @@
     "name": "socialiteproviders/oschina",
     "description": "OSChina OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "dingdayu",
-        "email": "614422099@qq.com"
-    }, {
-        "name": "Anton Komarev",
-        "email": "ell@cybercog.su"
-    }],
+    "authors": [
+        {
+            "name": "dingdayu",
+            "email": "614422099@qq.com"
+        },
+        {
+            "name": "Anton Komarev",
+            "email": "ell@cybercog.su"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Odnoklassniki/composer.json
+++ b/src/Odnoklassniki/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/odnoklassniki",
     "description": "Odnoklassniki OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Talgat Zheldibaev",
-        "email": "talgat06585@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "Talgat Zheldibaev",
+            "email": "talgat06585@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Okta/composer.json
+++ b/src/Okta/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/okta",
     "description": "Okta OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Chase Coney",
-        "email": "chase.coney@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "Chase Coney",
+            "email": "chase.coney@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Opskins/composer.json
+++ b/src/Opskins/composer.json
@@ -9,8 +9,9 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
-        "socialiteproviders/manager": "~2.0 || ~3.0"
+        "php": "^7.2",
+        "socialiteproviders/manager": "~2.0 || ~3.0",
+        "ext-json": "*"
     },
     "autoload": {
         "psr-4": {

--- a/src/Orcid/composer.json
+++ b/src/Orcid/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/orcid",
     "description": "ORCID OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Ben Cornwell",
-        "email": "ben@bencornwell.com"
-    }],
+    "authors": [
+        {
+            "name": "Ben Cornwell",
+            "email": "ben@bencornwell.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Patreon/composer.json
+++ b/src/Patreon/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/patreon",
     "description": "Patreon OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Pieter Maes",
-        "email": "maescool@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "Pieter Maes",
+            "email": "maescool@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/PayPal/composer.json
+++ b/src/PayPal/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/paypal",
     "description": "PayPal OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/PayPalSandbox/composer.json
+++ b/src/PayPalSandbox/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/paypal-sandbox",
     "description": "PayPal Sandbox OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Paymill/composer.json
+++ b/src/Paymill/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/paymill",
     "description": "Paymill OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/PeeringDB/composer.json
+++ b/src/PeeringDB/composer.json
@@ -2,13 +2,16 @@
     "name": "socialiteproviders/peeringdb",
     "description": "PeeringDB OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Barry O'Donovan",
-        "email": "barry@opensolutions.ie"
-    }],
+    "authors": [
+        {
+            "name": "Barry O'Donovan",
+            "email": "barry@opensolutions.ie"
+        }
+    ],
     "require": {
-        "php": ">=5.5.9",
-        "socialiteproviders/manager": "^2.0"
+        "php": "^7.2",
+        "socialiteproviders/manager": "~2.0 || ~3.0",
+        "ext-json": "*"
     },
     "autoload": {
         "psr-4": {

--- a/src/Pinterest/composer.json
+++ b/src/Pinterest/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/pinterest",
     "description": "Pinterest OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Michael Tournaud",
-        "email": "ollibrius@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "Michael Tournaud",
+            "email": "ollibrius@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Pipedrive/composer.json
+++ b/src/Pipedrive/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/pipedrive",
     "description": "Pipedrive OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Daniele Timo",
-        "email": "dani@danieletimo.com"
-    }],
+    "authors": [
+        {
+            "name": "Daniele Timo",
+            "email": "dani@danieletimo.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Podio/composer.json
+++ b/src/Podio/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/podio",
     "description": "Podio OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Procore/composer.json
+++ b/src/Procore/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/ProductHunt/composer.json
+++ b/src/ProductHunt/composer.json
@@ -1,19 +1,21 @@
 {
-  "name": "socialiteproviders/producthunt",
-  "description": "Product Hunt OAuth2 Provider for Laravel Socialite",
-  "license": "MIT",
-  "authors": [{
-    "name": "kylekatarnls",
-    "homepage": "https://github.com/kylekatarnls"
-  }],
-  "require": {
-    "php": "^5.6 || ^7.0",
+    "name": "socialiteproviders/producthunt",
+    "description": "Product Hunt OAuth2 Provider for Laravel Socialite",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "kylekatarnls",
+            "homepage": "https://github.com/kylekatarnls"
+        }
+    ],
+    "require": {
+        "php": "^7.2",
         "ext-json": "*",
-    "socialiteproviders/manager": "~2.0 || ~3.0"
-  },
-  "autoload": {
-    "psr-4": {
-      "SocialiteProviders\\AngelList\\": ""
+        "socialiteproviders/manager": "~2.0 || ~3.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialiteProviders\\AngelList\\": ""
+        }
     }
-  }
 }

--- a/src/ProjectV/composer.json
+++ b/src/ProjectV/composer.json
@@ -2,14 +2,16 @@
     "name": "socialiteproviders/projectv",
     "description": "Project V (v.enl.one) OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Lars vreezy Eschweiler",
-        "email": "vreezy117@googlemail.com"
-    }],
+    "authors": [
+        {
+            "name": "Lars vreezy Eschweiler",
+            "email": "vreezy117@googlemail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
-        "socialiteproviders/manager": "~3.0"
+        "socialiteproviders/manager": "~2.0 || ~3.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Pushbullet/composer.json
+++ b/src/Pushbullet/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/pushbullet",
     "description": "Pushbullet OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/QQ/composer.json
+++ b/src/QQ/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/qq",
     "description": "Qq.com OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "heui",
-        "email": "runphp@qq.com"
-    }],
+    "authors": [
+        {
+            "name": "heui",
+            "email": "runphp@qq.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/QuickBooks/composer.json
+++ b/src/QuickBooks/composer.json
@@ -17,8 +17,9 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.1",
-        "socialiteproviders/manager": "~2.0 || ~3.0"
+        "php": "^7.2",
+        "socialiteproviders/manager": "~2.0 || ~3.0",
+        "ext-json": "*"
     },
     "autoload": {
         "psr-4": {

--- a/src/Rdio/composer.json
+++ b/src/Rdio/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/rdio",
     "description": "Rdio OAuth1 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Readability/composer.json
+++ b/src/Readability/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/readability",
     "description": "Readability OAuth1 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Redbooth/composer.json
+++ b/src/Redbooth/composer.json
@@ -2,15 +2,18 @@
     "name": "socialiteproviders/redbooth",
     "description": "Redbooth OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Fruitcake",
-        "email": "info@fruitcake.nl"
-    }, {
-        "name": "Ivar Smits",
-        "email": "info@ivarsmits.nl"
-    }],
+    "authors": [
+        {
+            "name": "Fruitcake",
+            "email": "info@fruitcake.nl"
+        },
+        {
+            "name": "Ivar Smits",
+            "email": "info@ivarsmits.nl"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Reddit/composer.json
+++ b/src/Reddit/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/reddit",
     "description": "Reddit OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/RunKeeper/composer.json
+++ b/src/RunKeeper/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/runkeeper",
     "description": "RunKeeper OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/SURFconext/composer.json
+++ b/src/SURFconext/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/surfconext",
     "description": "SURFconext OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Jim Borst",
-        "email": "jim@blueberry.nl"
-    }],
+    "authors": [
+        {
+            "name": "Jim Borst",
+            "email": "jim@blueberry.nl"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Sage/composer.json
+++ b/src/Sage/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/SalesForce/composer.json
+++ b/src/SalesForce/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/salesforce",
     "description": "SalesForce OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Andy Wendt",
-        "email": "andy@awendt.com"
-    }],
+    "authors": [
+        {
+            "name": "Andy Wendt",
+            "email": "andy@awendt.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/SciStarter/composer.json
+++ b/src/SciStarter/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/scistarter",
     "description": "SciStarter OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Ryan Owens",
-        "email": "rowens@astrosociety.org"
-    }],
+    "authors": [
+        {
+            "name": "Ryan Owens",
+            "email": "rowens@astrosociety.org"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/SharePoint/composer.json
+++ b/src/SharePoint/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/sharepoint",
     "description": "SharePoint OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Promise Ekoriko",
-        "email": "promise@prodevel.co.uk"
-    }],
+    "authors": [
+        {
+            "name": "Promise Ekoriko",
+            "email": "promise@prodevel.co.uk"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Shopify/composer.json
+++ b/src/Shopify/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/shopify",
     "description": "Shopify OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "James Cullen",
-        "email": "hello@jamescullen.me"
-    }],
+    "authors": [
+        {
+            "name": "James Cullen",
+            "email": "hello@jamescullen.me"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Slack/composer.json
+++ b/src/Slack/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/slack",
     "description": "Slack OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Smashcast/composer.json
+++ b/src/Smashcast/composer.json
@@ -2,16 +2,18 @@
     "name": "socialiteproviders/smashcast",
     "description": "Smashcast OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Jérôme Foray",
-        "email": "moi@foray-jero.me"
-    },
-    {
-        "name": "Valentin Hutter",
-        "email": "contact@valentinhutter.ch"
-    }],
+    "authors": [
+        {
+            "name": "J\u00e9r\u00f4me Foray",
+            "email": "moi@foray-jero.me"
+        },
+        {
+            "name": "Valentin Hutter",
+            "email": "contact@valentinhutter.ch"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Snapchat/composer.json
+++ b/src/Snapchat/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/snapchat",
     "description": "Snapchat OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Oleksandr Alekseichuk",
-        "email": "avitlauak@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "Oleksandr Alekseichuk",
+            "email": "avitlauak@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/SoundCloud/composer.json
+++ b/src/SoundCloud/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/soundcloud",
     "description": "SoundCloud OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Spotify/composer.json
+++ b/src/Spotify/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/spotify",
     "description": "Spotify OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/StackExchange/composer.json
+++ b/src/StackExchange/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/stackexchange",
     "description": "StackExchange OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Andy Wendt",
-        "email": "andy@awendt.com"
-    }],
+    "authors": [
+        {
+            "name": "Andy Wendt",
+            "email": "andy@awendt.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Steam/composer.json
+++ b/src/Steam/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/steam",
     "description": "Steam OpenID Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Christopher Eklund",
-        "email": "eklundchristopher@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "Christopher Eklund",
+            "email": "eklundchristopher@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Steem/composer.json
+++ b/src/Steem/composer.json
@@ -2,14 +2,16 @@
     "name": "socialiteproviders/steem",
     "description": "Steem OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "frnxstd",
-        "email": "burak@myself.com"
-    }],
+    "authors": [
+        {
+            "name": "frnxstd",
+            "email": "burak@myself.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
-        "socialiteproviders/manager": "~3.0"
+        "socialiteproviders/manager": "~2.0 || ~3.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/StockTwits/composer.json
+++ b/src/StockTwits/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/stocktwits",
     "description": "StockTwits OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Strava/composer.json
+++ b/src/Strava/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/strava",
     "description": "Strava OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Stripe/composer.json
+++ b/src/Stripe/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/stripe",
     "description": "Stripe OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/TVShowTime/composer.json
+++ b/src/TVShowTime/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/tvshowtime",
     "description": "TVShowTime OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "HenokV",
-        "email": "me@henok.xyz"
-    }],
+    "authors": [
+        {
+            "name": "HenokV",
+            "email": "me@henok.xyz"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/TeamService/composer.json
+++ b/src/TeamService/composer.json
@@ -2,15 +2,18 @@
     "name": "socialiteproviders/microsoft-teamservice",
     "description": "Microsoft TeamService OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Te7a-Houdini",
-        "email": "ahmedabdelftah95165@gmail.com"
-    }, {
-        "name": "Anton Komarev",
-        "email": "ell@cybercog.su"
-    }],
+    "authors": [
+        {
+            "name": "Te7a-Houdini",
+            "email": "ahmedabdelftah95165@gmail.com"
+        },
+        {
+            "name": "Anton Komarev",
+            "email": "ell@cybercog.su"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Teamleader/composer.json
+++ b/src/Teamleader/composer.json
@@ -2,15 +2,18 @@
     "name": "socialiteproviders/teamleader",
     "description": "Teamleader OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "13°",
-        "email": "dev@13-grad.com"
-    }, {
-        "name": "Anton Komarev",
-        "email": "ell@cybercog.su"
-    }],
+    "authors": [
+        {
+            "name": "13\u00b0",
+            "email": "dev@13-grad.com"
+        },
+        {
+            "name": "Anton Komarev",
+            "email": "ell@cybercog.su"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Teamweek/composer.json
+++ b/src/Teamweek/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/teamweek",
     "description": "Teamweek OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Dees Oomens",
-        "email": "deesoomens@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "Dees Oomens",
+            "email": "deesoomens@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/ThirtySevenSignals/composer.json
+++ b/src/ThirtySevenSignals/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/37signals",
     "description": "37Signals OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Todoist/composer.json
+++ b/src/Todoist/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Trakt/composer.json
+++ b/src/Trakt/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/trakt",
     "description": "Trakt OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Dimitris Zavantias",
-        "email": "dzavantias@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "Dimitris Zavantias",
+            "email": "dzavantias@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Trello/composer.json
+++ b/src/Trello/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/trello",
     "description": "Trello OAuth1 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Tumblr/composer.json
+++ b/src/Tumblr/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/tumblr",
     "description": "Tumblr OAuth1 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/TwentyThreeAndMe/composer.json
+++ b/src/TwentyThreeAndMe/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/23andme",
     "description": "23andme OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Twitch/composer.json
+++ b/src/Twitch/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/twitch",
     "description": "Twitch OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Twitter/composer.json
+++ b/src/Twitter/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/twitter",
     "description": "Twitter OAuth1 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/UCL/composer.json
+++ b/src/UCL/composer.json
@@ -2,15 +2,19 @@
     "name": "socialiteproviders/ucl",
     "description": "UCL API OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Balázs Dura-Kovács"
-    }, {
-        "name": "Anton Komarev",
-        "email": "ell@cybercog.su"
-    }],
+    "authors": [
+        {
+            "name": "Bal\u00e1zs Dura-Kov\u00e1cs"
+        },
+        {
+            "name": "Anton Komarev",
+            "email": "ell@cybercog.su"
+        }
+    ],
     "require": {
-        "php": ">=7.0",
-        "socialiteproviders/manager": "^3.0"
+        "php": "^7.2",
+        "socialiteproviders/manager": "~2.0 || ~3.0",
+        "ext-json": "*"
     },
     "autoload": {
         "psr-4": {

--- a/src/UFS/composer.json
+++ b/src/UFS/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/ufs",
     "description": "UFS OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Claudson Martins",
-        "email": "claudson@outlook.com"
-    }],
+    "authors": [
+        {
+            "name": "Claudson Martins",
+            "email": "claudson@outlook.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Uber/composer.json
+++ b/src/Uber/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/uber",
     "description": "Uber OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Ufutx/composer.json
+++ b/src/Ufutx/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/ufutx-socialite",
     "description": "Ufutx OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "glore",
-        "email": "zeng.glore@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "glore",
+            "email": "zeng.glore@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Unsplash/composer.json
+++ b/src/Unsplash/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/unsplash",
     "description": "Unsplash OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Sercan Cakir",
-        "email": "srcnckr@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "Sercan Cakir",
+            "email": "srcnckr@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Untappd/composer.json
+++ b/src/Untappd/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/VKontakte/composer.json
+++ b/src/VKontakte/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/vkontakte",
     "description": "VKontakte OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Venmo/composer.json
+++ b/src/Venmo/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/venmo",
     "description": "Venmo OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Daniel Abernathy",
-        "email": "dabernathy89@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "Daniel Abernathy",
+            "email": "dabernathy89@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Vercel/composer.json
+++ b/src/Vercel/composer.json
@@ -2,14 +2,16 @@
     "name": "socialiteproviders/vercel",
     "description": "Vercel OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Miguel Piedrafita",
-        "email": "soy@miguelpiedrafita.com"
-    }],
+    "authors": [
+        {
+            "name": "Miguel Piedrafita",
+            "email": "soy@miguelpiedrafita.com"
+        }
+    ],
     "require": {
-        "php": ">=5.5.9",
+        "php": "^7.2",
         "ext-json": "*",
-        "socialiteproviders/manager": "^3.0"
+        "socialiteproviders/manager": "~2.0 || ~3.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/VersionOne/composer.json
+++ b/src/VersionOne/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/versionone",
     "description": "VersionOne OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Julia Grishchenko",
-        "email": "yulia.grischenko@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "Julia Grishchenko",
+            "email": "yulia.grischenko@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Vimeo/composer.json
+++ b/src/Vimeo/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/vimeo",
     "description": "Vimeo OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/WeChatServiceAccount/composer.json
+++ b/src/WeChatServiceAccount/composer.json
@@ -2,13 +2,16 @@
     "name": "socialiteproviders/wechat-service-account",
     "description": "WeChat Service Account OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "sink",
-        "email": "sinkcup@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "sink",
+            "email": "sinkcup@gmail.com"
+        }
+    ],
     "require": {
-        "php": ">=5.5.9",
-        "socialiteproviders/manager": "^3.3.6"
+        "php": "^7.2",
+        "socialiteproviders/manager": "~2.0 || ~3.0",
+        "ext-json": "*"
     },
     "autoload": {
         "psr-4": {

--- a/src/WeChatWeb/composer.json
+++ b/src/WeChatWeb/composer.json
@@ -2,13 +2,16 @@
     "name": "socialiteproviders/wechat-web",
     "description": "WeChat Web OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "sink",
-        "email": "sinkcup@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "sink",
+            "email": "sinkcup@gmail.com"
+        }
+    ],
     "require": {
-        "php": ">=5.5.9",
-        "socialiteproviders/manager": "^3.3.6"
+        "php": "^7.2",
+        "socialiteproviders/manager": "~2.0 || ~3.0",
+        "ext-json": "*"
     },
     "autoload": {
         "psr-4": {

--- a/src/Weibo/composer.json
+++ b/src/Weibo/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/weibo",
     "description": "weibo.com OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "xyxu",
-        "email": "techxu@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "xyxu",
+            "email": "techxu@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Weixin/composer.json
+++ b/src/Weixin/composer.json
@@ -2,15 +2,18 @@
     "name": "socialiteproviders/weixin",
     "description": "Weixin OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "xyxu",
-        "email": "techxu@gmail.com"
-    }, {
-        "name": "xiami",
-        "email": "jhdxr@php.net"
-    }],
+    "authors": [
+        {
+            "name": "xyxu",
+            "email": "techxu@gmail.com"
+        },
+        {
+            "name": "xiami",
+            "email": "jhdxr@php.net"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/WeixinWeb/composer.json
+++ b/src/WeixinWeb/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/weixin-web",
     "description": "Weixin-Web OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "xyxu",
-        "email": "techxu@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "xyxu",
+            "email": "techxu@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Withings/composer.json
+++ b/src/Withings/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/withings",
     "description": "Withings OAuth1 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Alexandre Levavasseur",
-        "email": "alexandre+github@13x.fr"
-    }],
+    "authors": [
+        {
+            "name": "Alexandre Levavasseur",
+            "email": "alexandre+github@13x.fr"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/WordPress/composer.json
+++ b/src/WordPress/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/wordpress",
     "description": "WordPress OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Andy Wendt",
-        "email": "andy@awendt.com"
-    }],
+    "authors": [
+        {
+            "name": "Andy Wendt",
+            "email": "andy@awendt.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Xero/composer.json
+++ b/src/Xero/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/xero",
     "description": "Xero OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Ryan Marshall",
-        "email": "ryan@schmoove.co.nz"
-    }],
+    "authors": [
+        {
+            "name": "Ryan Marshall",
+            "email": "ryan@schmoove.co.nz"
+        }
+    ],
     "require": {
-        "php": ">=5.5.9",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0",
         "firebase/php-jwt": "^5.2"

--- a/src/Xing/composer.json
+++ b/src/Xing/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/xing",
     "description": "Xing OAuth1 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Yahoo/composer.json
+++ b/src/Yahoo/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/yahoo",
     "description": "Yahoo OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Yammer/composer.json
+++ b/src/Yammer/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/yammer",
     "description": "Yammer OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Yandex/composer.json
+++ b/src/Yandex/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/yandex",
     "description": "Yandex OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Yiban/composer.json
+++ b/src/Yiban/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/yiban",
     "description": "yiban.cn OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "zhengAn,dingding",
-        "email": "568004158@qq.com"
-    }],
+    "authors": [
+        {
+            "name": "zhengAn,dingding",
+            "email": "568004158@qq.com"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/YouTube/composer.json
+++ b/src/YouTube/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/youtube",
     "description": "YouTube OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Zalo/composer.json
+++ b/src/Zalo/composer.json
@@ -2,14 +2,16 @@
     "name": "socialiteproviders/zalo",
     "description": "Zalo OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "tmtung144",
-        "email": "tmtung144@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "tmtung144",
+            "email": "tmtung144@gmail.com"
+        }
+    ],
     "require": {
-        "php": ">=5.5.9",
+        "php": "^7.2",
         "ext-json": "*",
-        "socialiteproviders/manager": "^2.0"
+        "socialiteproviders/manager": "~2.0 || ~3.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Zendesk/composer.json
+++ b/src/Zendesk/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/zendesk",
     "description": "Zendesk OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },

--- a/src/Zoho/composer.json
+++ b/src/Zoho/composer.json
@@ -2,13 +2,16 @@
     "name": "socialiteproviders/zoho",
     "description": "Zoho OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "glowlogix",
-        "email": "support@glowlogix.com"
-    }],
+    "authors": [
+        {
+            "name": "glowlogix",
+            "email": "support@glowlogix.com"
+        }
+    ],
     "require": {
-        "php": ">=5.5.9",
-        "socialiteproviders/manager": "~2.0 || ~3.0"
+        "php": "^7.2",
+        "socialiteproviders/manager": "~2.0 || ~3.0",
+        "ext-json": "*"
     },
     "autoload": {
         "psr-4": {

--- a/src/xREL/composer.json
+++ b/src/xREL/composer.json
@@ -2,12 +2,14 @@
     "name": "socialiteproviders/xrel",
     "description": "xREL.to OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
-    "authors": [{
-        "name": "Brian Faust",
-        "email": "hello@brianfaust.de"
-    }],
+    "authors": [
+        {
+            "name": "Brian Faust",
+            "email": "hello@brianfaust.de"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "socialiteproviders/manager": "~2.0 || ~3.0"
     },


### PR DESCRIPTION
This pull-request drops support for PHP < 7.2.
It has been discussed with @atymic already: https://github.com/SocialiteProviders/Providers/pull/453#issuecomment-657922181

---

**Notes:**
- we also ensure that the repository split and the ocular run only happen with PHP 7.4
- This PR closes #453 