### PR TITLE
Remove useless inherit docblock

### DIFF
--- a/src/ArcGIS/Provider.php
+++ b/src/ArcGIS/Provider.php
@@ -12,7 +12,6 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'ARCGIS';
 
-
     protected function getBaseUrl()
     {
         $port = is_null($this->getServerPort()) ? '' : ':'.$this->getServerPort();
@@ -82,18 +81,15 @@ class Provider extends AbstractProvider
         ]);
     }
 
-
     protected function getServerHost()
     {
         return $this->getConfig('arcgis_host', 'www.arcgis.com');
     }
 
-
     protected function getServerPort()
     {
         return $this->getConfig('arcgis_port', null);
     }
-
 
     protected function getServerDirectory()
     {

--- a/src/ArcGIS/Provider.php
+++ b/src/ArcGIS/Provider.php
@@ -12,9 +12,7 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'ARCGIS';
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function getBaseUrl()
     {
         $port = is_null($this->getServerPort()) ? '' : ':'.$this->getServerPort();
@@ -84,25 +82,19 @@ class Provider extends AbstractProvider
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function getServerHost()
     {
         return $this->getConfig('arcgis_host', 'www.arcgis.com');
     }
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function getServerPort()
     {
         return $this->getConfig('arcgis_port', null);
     }
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function getServerDirectory()
     {
         return $this->getConfig('arcgis_directory', null);

--- a/src/Auth0/Provider.php
+++ b/src/Auth0/Provider.php
@@ -24,9 +24,7 @@ class Provider extends AbstractProvider
 
     protected $scopeSeparator = ' ';
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function getAuth0Url()
     {
         return $this->getConfig('base_url');

--- a/src/Auth0/Provider.php
+++ b/src/Auth0/Provider.php
@@ -24,7 +24,6 @@ class Provider extends AbstractProvider
 
     protected $scopeSeparator = ' ';
 
-
     protected function getAuth0Url()
     {
         return $this->getConfig('base_url');

--- a/src/Aweber/Provider.php
+++ b/src/Aweber/Provider.php
@@ -12,7 +12,6 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'AWEBER';
 
-
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user['extra'])->map([

--- a/src/Aweber/Provider.php
+++ b/src/Aweber/Provider.php
@@ -12,9 +12,7 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'AWEBER';
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user['extra'])->map([

--- a/src/Battlenet/Provider.php
+++ b/src/Battlenet/Provider.php
@@ -78,9 +78,7 @@ class Provider extends AbstractProvider
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function getRegion()
     {
         if (self::$region) {

--- a/src/Battlenet/Provider.php
+++ b/src/Battlenet/Provider.php
@@ -78,7 +78,6 @@ class Provider extends AbstractProvider
         ]);
     }
 
-
     protected function getRegion()
     {
         if (self::$region) {

--- a/src/Douban/Provider.php
+++ b/src/Douban/Provider.php
@@ -63,9 +63,6 @@ class Provider extends AbstractProvider
         ]);
     }
 
-    /**
-     * {@inheritdoc}.
-     */
     public function getAccessToken($code)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [

--- a/src/Etsy/Provider.php
+++ b/src/Etsy/Provider.php
@@ -12,7 +12,6 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'ETSY';
 
-
     protected function mapUserToObject(array $user)
     {
         return (new User())->map([

--- a/src/Etsy/Provider.php
+++ b/src/Etsy/Provider.php
@@ -12,9 +12,7 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'ETSY';
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function mapUserToObject(array $user)
     {
         return (new User())->map([

--- a/src/FiveHundredPixel/Provider.php
+++ b/src/FiveHundredPixel/Provider.php
@@ -12,9 +12,7 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'FIVEHUNDREDPIXEL';
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user['extra'])->map([

--- a/src/FiveHundredPixel/Provider.php
+++ b/src/FiveHundredPixel/Provider.php
@@ -12,7 +12,6 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'FIVEHUNDREDPIXEL';
 
-
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user['extra'])->map([

--- a/src/Flickr/Provider.php
+++ b/src/Flickr/Provider.php
@@ -12,7 +12,6 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'FLICKR';
 
-
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user['extra'])->map([

--- a/src/Flickr/Provider.php
+++ b/src/Flickr/Provider.php
@@ -12,9 +12,7 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'FLICKR';
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user['extra'])->map([

--- a/src/GettyImages/Provider.php
+++ b/src/GettyImages/Provider.php
@@ -22,8 +22,6 @@ class Provider extends AbstractProvider
      */
     protected $scopeSeparator = ' ';
 
-
-
     /**
      * {@inheritdoc}
      */
@@ -42,7 +40,6 @@ class Provider extends AbstractProvider
     {
         return 'https://api.gettyimages.com/oauth2/token';
     }
-
 
     public function getAccessToken($code)
     {

--- a/src/GettyImages/Provider.php
+++ b/src/GettyImages/Provider.php
@@ -22,9 +22,7 @@ class Provider extends AbstractProvider
      */
     protected $scopeSeparator = ' ';
 
-    /**
-     * {@inheritdoc}
-     */
+
 
     /**
      * {@inheritdoc}
@@ -45,9 +43,7 @@ class Provider extends AbstractProvider
         return 'https://api.gettyimages.com/oauth2/token';
     }
 
-    /**
-     * {@inheritdoc}
-     */
+
     public function getAccessToken($code)
     {
         $response = $this->getHttpClient()->post(

--- a/src/GitLab/Provider.php
+++ b/src/GitLab/Provider.php
@@ -76,7 +76,6 @@ class Provider extends AbstractProvider
         ]);
     }
 
-
     protected function getInstanceUri()
     {
         return $this->getConfig('instance_uri', 'https://gitlab.com/');

--- a/src/GitLab/Provider.php
+++ b/src/GitLab/Provider.php
@@ -76,9 +76,7 @@ class Provider extends AbstractProvider
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function getInstanceUri()
     {
         return $this->getConfig('instance_uri', 'https://gitlab.com/');

--- a/src/Goodreads/Provider.php
+++ b/src/Goodreads/Provider.php
@@ -12,7 +12,6 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'GOODREADS';
 
-
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user['extra'])->map([

--- a/src/Goodreads/Provider.php
+++ b/src/Goodreads/Provider.php
@@ -12,9 +12,7 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'GOODREADS';
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user['extra'])->map([

--- a/src/Instagram/Provider.php
+++ b/src/Instagram/Provider.php
@@ -78,7 +78,6 @@ class Provider extends AbstractProvider
         ]);
     }
 
-
     public function getAccessToken($code)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [

--- a/src/Instagram/Provider.php
+++ b/src/Instagram/Provider.php
@@ -78,9 +78,7 @@ class Provider extends AbstractProvider
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
+
     public function getAccessToken($code)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [

--- a/src/InstagramBasic/Provider.php
+++ b/src/InstagramBasic/Provider.php
@@ -93,7 +93,6 @@ class Provider extends AbstractProvider
         ];
     }
 
-
     public function getAccessToken($code)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [

--- a/src/InstagramBasic/Provider.php
+++ b/src/InstagramBasic/Provider.php
@@ -93,9 +93,7 @@ class Provider extends AbstractProvider
         ];
     }
 
-    /**
-     * {@inheritdoc}
-     */
+
     public function getAccessToken($code)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [

--- a/src/Jira/Provider.php
+++ b/src/Jira/Provider.php
@@ -13,9 +13,7 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'JIRA';
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function mapUserToObject(array $user)
     {
         $userObject = new User();

--- a/src/Jira/Provider.php
+++ b/src/Jira/Provider.php
@@ -13,7 +13,6 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'JIRA';
 
-
     protected function mapUserToObject(array $user)
     {
         $userObject = new User();

--- a/src/Keycloak/Provider.php
+++ b/src/Keycloak/Provider.php
@@ -18,7 +18,6 @@ class Provider extends AbstractProvider
         return ['base_url', 'realms'];
     }
 
-
     protected function getBaseUrl()
     {
         return rtrim(rtrim($this->getConfig('base_url'), '/').'/realms/'.$this->getConfig('realms', 'master'), '/');

--- a/src/Keycloak/Provider.php
+++ b/src/Keycloak/Provider.php
@@ -18,9 +18,7 @@ class Provider extends AbstractProvider
         return ['base_url', 'realms'];
     }
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function getBaseUrl()
     {
         return rtrim(rtrim($this->getConfig('base_url'), '/').'/realms/'.$this->getConfig('realms', 'master'), '/');

--- a/src/LaravelPassport/Provider.php
+++ b/src/LaravelPassport/Provider.php
@@ -117,9 +117,7 @@ class Provider extends AbstractProvider
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function getLaravelPassportUrl($type)
     {
         return rtrim($this->getConfig('host'), '/').'/'.ltrim(($this->getConfig($type, Arr::get([
@@ -129,9 +127,7 @@ class Provider extends AbstractProvider
         ], $type))), '/');
     }
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function getUserData($user, $key)
     {
         return Arr::get($user, $this->getConfig('user_'.$key, $key));

--- a/src/LaravelPassport/Provider.php
+++ b/src/LaravelPassport/Provider.php
@@ -117,7 +117,6 @@ class Provider extends AbstractProvider
         ]);
     }
 
-
     protected function getLaravelPassportUrl($type)
     {
         return rtrim($this->getConfig('host'), '/').'/'.ltrim(($this->getConfig($type, Arr::get([
@@ -126,7 +125,6 @@ class Provider extends AbstractProvider
             'userinfo_uri'  => 'api/user',
         ], $type))), '/');
     }
-
 
     protected function getUserData($user, $key)
     {

--- a/src/LinkedIn/Provider.php
+++ b/src/LinkedIn/Provider.php
@@ -144,9 +144,7 @@ class Provider extends AbstractProvider
         return (new User())->setRaw($user)->map($user);
     }
 
-    /**
-     * {@inheritdoc}
-     */
+
     public function getAccessToken($code)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [

--- a/src/LinkedIn/Provider.php
+++ b/src/LinkedIn/Provider.php
@@ -144,7 +144,6 @@ class Provider extends AbstractProvider
         return (new User())->setRaw($user)->map($user);
     }
 
-
     public function getAccessToken($code)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [

--- a/src/MakerLog/Provider.php
+++ b/src/MakerLog/Provider.php
@@ -51,9 +51,7 @@ class Provider extends AbstractProvider
         return $this->baseUrl().'/oauth/token/';
     }
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function getEmailUrl()
     {
         return $this->baseUrl().'/accounts/read_email/';

--- a/src/MakerLog/Provider.php
+++ b/src/MakerLog/Provider.php
@@ -51,7 +51,6 @@ class Provider extends AbstractProvider
         return $this->baseUrl().'/oauth/token/';
     }
 
-
     protected function getEmailUrl()
     {
         return $this->baseUrl().'/accounts/read_email/';

--- a/src/Mattermost/Provider.php
+++ b/src/Mattermost/Provider.php
@@ -103,9 +103,7 @@ class Provider extends AbstractProvider
         return parent::getTokenFields($code) + ['grant_type' => 'authorization_code'];
     }
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function getInstanceUri()
     {
         $uri = $this->getConfig('instance_uri', null);

--- a/src/Mattermost/Provider.php
+++ b/src/Mattermost/Provider.php
@@ -103,7 +103,6 @@ class Provider extends AbstractProvider
         return parent::getTokenFields($code) + ['grant_type' => 'authorization_code'];
     }
 
-
     protected function getInstanceUri()
     {
         $uri = $this->getConfig('instance_uri', null);

--- a/src/Mollie/Provider.php
+++ b/src/Mollie/Provider.php
@@ -41,9 +41,7 @@ class Provider extends AbstractProvider
         return 'https://api.mollie.com/oauth2/tokens';
     }
 
-    /**
-     * {@inheritdoc}
-     */
+
     public function getAccessToken($code)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
@@ -56,9 +54,7 @@ class Provider extends AbstractProvider
         return $this->parseAccessToken($response->getBody());
     }
 
-    /**
-     * {@inheritdoc}
-     */
+
     public function getRefreshTokenResponse($refreshToken)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
@@ -81,9 +77,7 @@ class Provider extends AbstractProvider
         return json_decode($response->getBody(), true);
     }
 
-    /**
-     * {@inheritdoc}
-     */
+
     public function getRefreshTokenFields($refreshToken)
     {
         return [

--- a/src/Mollie/Provider.php
+++ b/src/Mollie/Provider.php
@@ -41,7 +41,6 @@ class Provider extends AbstractProvider
         return 'https://api.mollie.com/oauth2/tokens';
     }
 
-
     public function getAccessToken($code)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
@@ -53,7 +52,6 @@ class Provider extends AbstractProvider
 
         return $this->parseAccessToken($response->getBody());
     }
-
 
     public function getRefreshTokenResponse($refreshToken)
     {
@@ -76,7 +74,6 @@ class Provider extends AbstractProvider
 
         return json_decode($response->getBody(), true);
     }
-
 
     public function getRefreshTokenFields($refreshToken)
     {

--- a/src/Nocks/Provider.php
+++ b/src/Nocks/Provider.php
@@ -86,7 +86,6 @@ class Provider extends AbstractProvider
         ]);
     }
 
-
     protected function getWebsiteUrl()
     {
         if ($this->getConfig('test')) {
@@ -95,7 +94,6 @@ class Provider extends AbstractProvider
 
         return 'https://www.nocks.com/';
     }
-
 
     protected function getApiUrl()
     {

--- a/src/Nocks/Provider.php
+++ b/src/Nocks/Provider.php
@@ -86,9 +86,7 @@ class Provider extends AbstractProvider
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function getWebsiteUrl()
     {
         if ($this->getConfig('test')) {
@@ -98,9 +96,7 @@ class Provider extends AbstractProvider
         return 'https://www.nocks.com/';
     }
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function getApiUrl()
     {
         if ($this->getConfig('test')) {

--- a/src/Okta/Provider.php
+++ b/src/Okta/Provider.php
@@ -39,9 +39,7 @@ class Provider extends AbstractProvider
      */
     protected $scopeSeparator = ' ';
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function getOktaUrl()
     {
         return $this->getConfig('base_url');

--- a/src/Okta/Provider.php
+++ b/src/Okta/Provider.php
@@ -39,7 +39,6 @@ class Provider extends AbstractProvider
      */
     protected $scopeSeparator = ' ';
 
-
     protected function getOktaUrl()
     {
         return $this->getConfig('base_url');

--- a/src/PayPal/Provider.php
+++ b/src/PayPal/Provider.php
@@ -70,9 +70,7 @@ class Provider extends AbstractProvider
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
+
     public function getAccessToken($code)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [

--- a/src/PayPal/Provider.php
+++ b/src/PayPal/Provider.php
@@ -70,7 +70,6 @@ class Provider extends AbstractProvider
         ]);
     }
 
-
     public function getAccessToken($code)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [

--- a/src/PayPalSandbox/Provider.php
+++ b/src/PayPalSandbox/Provider.php
@@ -70,9 +70,7 @@ class Provider extends AbstractProvider
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
+
     public function getAccessToken($code)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [

--- a/src/PayPalSandbox/Provider.php
+++ b/src/PayPalSandbox/Provider.php
@@ -70,7 +70,6 @@ class Provider extends AbstractProvider
         ]);
     }
 
-
     public function getAccessToken($code)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [

--- a/src/Procore/Provider.php
+++ b/src/Procore/Provider.php
@@ -51,7 +51,6 @@ class Provider extends AbstractProvider
         return json_decode($response->getBody(), true);
     }
 
-
     public function getRefreshTokenFields($refreshToken)
     {
         return [

--- a/src/Procore/Provider.php
+++ b/src/Procore/Provider.php
@@ -51,9 +51,7 @@ class Provider extends AbstractProvider
         return json_decode($response->getBody(), true);
     }
 
-    /**
-     * {@inheritdoc}
-     */
+
     public function getRefreshTokenFields($refreshToken)
     {
         return [

--- a/src/Rdio/Provider.php
+++ b/src/Rdio/Provider.php
@@ -12,7 +12,6 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'RDIO';
 
-
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user['extra'])->map([

--- a/src/Rdio/Provider.php
+++ b/src/Rdio/Provider.php
@@ -12,9 +12,7 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'RDIO';
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user['extra'])->map([

--- a/src/Readability/Provider.php
+++ b/src/Readability/Provider.php
@@ -12,7 +12,6 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'READABILITY';
 
-
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user['extra'])->map([

--- a/src/Readability/Provider.php
+++ b/src/Readability/Provider.php
@@ -12,9 +12,7 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'READABILITY';
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user['extra'])->map([

--- a/src/Reddit/Provider.php
+++ b/src/Reddit/Provider.php
@@ -107,9 +107,7 @@ class Provider extends AbstractProvider
         ];
     }
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function getUserAgent()
     {
         return implode(':', [

--- a/src/Reddit/Provider.php
+++ b/src/Reddit/Provider.php
@@ -107,7 +107,6 @@ class Provider extends AbstractProvider
         ];
     }
 
-
     protected function getUserAgent()
     {
         return implode(':', [

--- a/src/Teamweek/Provider.php
+++ b/src/Teamweek/Provider.php
@@ -84,7 +84,6 @@ class Provider extends AbstractProvider
         ]);
     }
 
-
     protected function getInstanceUri()
     {
         return $this->getConfig('instance_uri', 'https://teamweek.com');

--- a/src/Teamweek/Provider.php
+++ b/src/Teamweek/Provider.php
@@ -84,9 +84,7 @@ class Provider extends AbstractProvider
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function getInstanceUri()
     {
         return $this->getConfig('instance_uri', 'https://teamweek.com');

--- a/src/Trello/Provider.php
+++ b/src/Trello/Provider.php
@@ -12,7 +12,6 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'TRELLO';
 
-
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user['extra'])->map([

--- a/src/Trello/Provider.php
+++ b/src/Trello/Provider.php
@@ -12,9 +12,7 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'TRELLO';
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user['extra'])->map([

--- a/src/Tumblr/Provider.php
+++ b/src/Tumblr/Provider.php
@@ -12,9 +12,7 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'TUMBLR';
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user['extra'])->map([

--- a/src/Tumblr/Provider.php
+++ b/src/Tumblr/Provider.php
@@ -12,7 +12,6 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'TUMBLR';
 
-
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user['extra'])->map([

--- a/src/Twitter/Provider.php
+++ b/src/Twitter/Provider.php
@@ -12,7 +12,6 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'TWITTER';
 
-
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user['extra'])->map([

--- a/src/Twitter/Provider.php
+++ b/src/Twitter/Provider.php
@@ -12,9 +12,7 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'TWITTER';
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user['extra'])->map([

--- a/src/Ufutx/Provider.php
+++ b/src/Ufutx/Provider.php
@@ -71,7 +71,6 @@ class Provider extends AbstractProvider
         ]);
     }
 
-
     protected function getInstanceUri()
     {
         return $this->getConfig('instance_uri', 'https://account.ufutx.com/');

--- a/src/Ufutx/Provider.php
+++ b/src/Ufutx/Provider.php
@@ -71,9 +71,7 @@ class Provider extends AbstractProvider
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function getInstanceUri()
     {
         return $this->getConfig('instance_uri', 'https://account.ufutx.com/');

--- a/src/Weibo/Provider.php
+++ b/src/Weibo/Provider.php
@@ -64,9 +64,6 @@ class Provider extends AbstractProvider
         ]);
     }
 
-    /**
-     * {@inheritdoc}.
-     */
     public function getAccessToken($code)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [

--- a/src/Withings/Provider.php
+++ b/src/Withings/Provider.php
@@ -12,7 +12,6 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'WITHINGS';
 
-
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user['extra'])->map([

--- a/src/Withings/Provider.php
+++ b/src/Withings/Provider.php
@@ -12,9 +12,7 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'WITHINGS';
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user['extra'])->map([

--- a/src/Xing/Provider.php
+++ b/src/Xing/Provider.php
@@ -12,9 +12,7 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'XING';
 
-    /**
-     * {@inheritdoc}
-     */
+
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user['extra'])->map([

--- a/src/Xing/Provider.php
+++ b/src/Xing/Provider.php
@@ -12,7 +12,6 @@ class Provider extends AbstractProvider
      */
     const IDENTIFIER = 'XING';
 
-
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user['extra'])->map([


### PR DESCRIPTION
`{@inheritdoc}` is only useful if we actually inherit the docblock of the method defined in the parent class.

If the method is not defined in the parent class, there is no reason to keep this useless docblock.