### PR TITLE
Always use https

### DIFF
--- a/src/DigitalOcean/Provider.php
+++ b/src/DigitalOcean/Provider.php
@@ -56,7 +56,7 @@ class Provider extends AbstractProvider
         return (new User())->setRaw($user)->map([
             'id'     => $user['uuid'], 'nickname' => null, 'name' => null,
             'email'  => $user['email'],
-            'avatar' => 'http://www.gravatar.com/avatar/'.md5($user['email']),
+            'avatar' => 'https://www.gravatar.com/avatar/'.md5($user['email']),
         ]);
     }
 

--- a/src/Goodreads/Server.php
+++ b/src/Goodreads/Server.php
@@ -22,7 +22,7 @@ class Server extends BaseServer
      */
     public function urlTemporaryCredentials()
     {
-        return 'http://www.goodreads.com/oauth/request_token';
+        return 'https://www.goodreads.com/oauth/request_token';
     }
 
     /**
@@ -38,7 +38,7 @@ class Server extends BaseServer
      */
     public function urlTokenCredentials()
     {
-        return 'http://www.goodreads.com/oauth/access_token';
+        return 'https://www.goodreads.com/oauth/access_token';
     }
 
     /**
@@ -46,7 +46,7 @@ class Server extends BaseServer
      */
     public function urlUserDetails()
     {
-        return 'http://www.goodreads.com/api/auth_user';
+        return 'https://www.goodreads.com/api/auth_user';
     }
 
     /**

--- a/src/Jira/Server.php
+++ b/src/Jira/Server.php
@@ -12,7 +12,7 @@ use SocialiteProviders\Manager\OAuth1\Server as BaseServer;
 
 class Server extends BaseServer
 {
-    const JIRA_BASE_URL = 'http://example.jira.com';
+    const JIRA_BASE_URL = 'https://example.jira.com';
 
     private $jiraBaseUrl;
     private $jiraCertPath;

--- a/src/Meetup/Provider.php
+++ b/src/Meetup/Provider.php
@@ -38,7 +38,7 @@ class Provider extends AbstractProvider
      */
     protected function getUserByToken($token)
     {
-        // http://www.meetup.com/meetup_api/auth/#oauth2-resources
+        // https://www.meetup.com/meetup_api/auth/#oauth2-resources
         $response = $this->getHttpClient()->get(
             'https://api.meetup.com/'.$this->version.'/member/self?access_token='.$token,
             [
@@ -67,7 +67,7 @@ class Provider extends AbstractProvider
      */
     protected function getTokenFields($code)
     {
-        // see http://www.meetup.com/meetup_api/auth/#oauth2server-access
+        // see https://www.meetup.com/meetup_api/auth/#oauth2server-access
         return array_merge(parent::getTokenFields($code), [
             'grant_type' => 'authorization_code',
         ]);

--- a/src/Netlify/Provider.php
+++ b/src/Netlify/Provider.php
@@ -22,7 +22,7 @@ class Provider extends AbstractProvider
      */
     protected function getAuthUrl($state)
     {
-        return $this->buildAuthUrlFromBase('http://app.netlify.com/authorize', $state);
+        return $this->buildAuthUrlFromBase('https://app.netlify.com/authorize', $state);
     }
 
     /**

--- a/src/Okta/Provider.php
+++ b/src/Okta/Provider.php
@@ -16,7 +16,7 @@ class Provider extends AbstractProvider
     /**
      * Scopes defintions.
      *
-     * @see http://developer.okta.com/docs/api/resources/oidc.html#scopes
+     * @see https://developer.okta.com/docs/reference/api/oidc/#scopes
      */
     const SCOPE_OPENID = 'openid';
     const SCOPE_PROFILE = 'profile';

--- a/src/Opskins/Provider.php
+++ b/src/Opskins/Provider.php
@@ -58,7 +58,7 @@ class Provider extends AbstractProvider
      */
     protected function getUserByToken($token)
     {
-        $response = $this->getHttpClient()->get('http://api.opskins.com/IUser/GetProfile/v1/', [
+        $response = $this->getHttpClient()->get('https://api.opskins.com/IUser/GetProfile/v1/', [
             'headers' => [
                 'Authorization' => 'Bearer '.$token,
             ],

--- a/src/PeeringDB/Provider.php
+++ b/src/PeeringDB/Provider.php
@@ -15,7 +15,7 @@ class Provider extends AbstractProvider
     /**
      * Scopes defintions.
      *
-     * @see http://developer.okta.com/docs/api/resources/oidc.html#scopes
+     * @see https://developer.okta.com/docs/reference/api/oidc/#scopes
      */
     const SCOPE_PROFILE = 'profile';
     const SCOPE_EMAIL = 'email';

--- a/src/Rdio/Server.php
+++ b/src/Rdio/Server.php
@@ -15,7 +15,7 @@ class Server extends BaseServer
      */
     public function urlTemporaryCredentials()
     {
-        return 'http://api.rdio.com/oauth/request_token';
+        return 'https://api.rdio.com/oauth/request_token';
     }
 
     /**
@@ -31,7 +31,7 @@ class Server extends BaseServer
      */
     public function urlTokenCredentials()
     {
-        return 'http://api.rdio.com/oauth/access_token';
+        return 'https://api.rdio.com/oauth/access_token';
     }
 
     /**
@@ -39,7 +39,7 @@ class Server extends BaseServer
      */
     public function urlUserDetails()
     {
-        return 'http://api.rdio.com/1/';
+        return 'https://api.rdio.com/1/';
     }
 
     /**

--- a/src/Steam/Provider.php
+++ b/src/Steam/Provider.php
@@ -39,7 +39,7 @@ class Provider extends AbstractProvider
     /**
      * @var string
      */
-    const STEAM_INFO_URL = 'http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=%s&steamids=%s';
+    const STEAM_INFO_URL = 'https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=%s&steamids=%s';
 
     /**
      * @var string
@@ -59,7 +59,7 @@ class Provider extends AbstractProvider
     /**
      * @var string
      */
-    const OPENID_NS = 'http://specs.openid.net/auth/2.0';
+    const OPENID_NS = 'https://specs.openid.net/auth/2.0';
 
     /**
      * @var string
@@ -152,8 +152,8 @@ class Provider extends AbstractProvider
             'openid.mode'       => 'checkid_setup',
             'openid.return_to'  => $this->redirectUrl,
             'openid.realm'      => sprintf('%s://%s', $this->request->getScheme(), $realm),
-            'openid.identity'   => 'http://specs.openid.net/auth/2.0/identifier_select',
-            'openid.claimed_id' => 'http://specs.openid.net/auth/2.0/identifier_select',
+            'openid.identity'   => 'https://specs.openid.net/auth/2.0/identifier_select',
+            'openid.claimed_id' => 'https://specs.openid.net/auth/2.0/identifier_select',
         ];
 
         return self::OPENID_URL.'?'.http_build_query($params, '', '&');

--- a/src/Withings/Server.php
+++ b/src/Withings/Server.php
@@ -139,7 +139,7 @@ class Server extends BaseServer
         if (!$this->cachedUserDetailsResponse || $force) {
 
             // The user-endpoint
-            $endpoint = 'http://wbsapi.withings.net/user';
+            $endpoint = 'https://wbsapi.withings.net/user';
 
             // Parse the parameters
             $parameters = $this->getOauthParameters($endpoint, $tokenCredentials, [


### PR DESCRIPTION
Some provided URLs are not secure.
This PR ensures that all URLs use `https`.

This PR also updates some links to the provider documentation.