### PR TITLE
Refactor SocialiteProviders\Apple\Provider::mapUserToObject()

### DIFF
--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -195,8 +195,10 @@ class Provider extends AbstractProvider
      */
     protected function mapUserToObject(array $user)
     {
-        if (request()->filled('user')) {
-            $userRequest = json_decode(request('user'), true);
+        $value = trim((string) request('user'));
+
+        if ($value !== '') {
+            $userRequest = json_decode($value, true);
 
             if (array_key_exists('name', $userRequest)) {
                 $user['name'] = $userRequest['name'];


### PR DESCRIPTION
Replace the call to `filled()` with a simpler non-empty string check as it's only available in Laravel>=5.5 and throws a `BadMethodCallException` in Laravel 5.4

This is necessary because this library has a dependency to socialiteproviders/manager which allows installation in Laravel 5.4 in the latest version

