### PR TITLE
Fix POST key naming issue

### DIFF
--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -3,6 +3,7 @@
 namespace SocialiteProviders\Apple;
 
 use Firebase\JWT\JWK;
+use GuzzleHttp\ClientInterface;
 use Illuminate\Http\Response;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Cache;
@@ -84,9 +85,11 @@ class Provider extends AbstractProvider
      */
     public function getAccessTokenResponse($code)
     {
+        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
+
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             'headers'        => ['Authorization' => 'Basic '.base64_encode($this->clientId.':'.$this->clientSecret)],
-            'form_params'    => $this->getTokenFields($code),
+            $postKey    => $this->getTokenFields($code),
         ]);
 
         return json_decode($response->getBody(), true);

--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -89,7 +89,7 @@ class Provider extends AbstractProvider
 
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             'headers'        => ['Authorization' => 'Basic '.base64_encode($this->clientId.':'.$this->clientSecret)],
-            $postKey    => $this->getTokenFields($code),
+            $postKey         => $this->getTokenFields($code),
         ]);
 
         return json_decode($response->getBody(), true);

--- a/src/Azure/Provider.php
+++ b/src/Azure/Provider.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\Azure;
 
+use GuzzleHttp\ClientInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -47,8 +48,10 @@ class Provider extends AbstractProvider
 
     public function getAccessToken($code)
     {
+        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
+
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
-            'form_params' => $this->getTokenFields($code),
+            $postKey => $this->getTokenFields($code),
         ]);
 
         $this->credentialsResponseBody = json_decode($response->getBody(), true);

--- a/src/Douban/Provider.php
+++ b/src/Douban/Provider.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\Douban;
 
+use GuzzleHttp\ClientInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -65,8 +66,10 @@ class Provider extends AbstractProvider
 
     public function getAccessToken($code)
     {
+        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
+
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
-            'form_params' => $this->getTokenFields($code),
+            $postKey => $this->getTokenFields($code),
         ]);
 
         $this->credentialsResponseBody = json_decode($response->getBody(), true);

--- a/src/GettyImages/Provider.php
+++ b/src/GettyImages/Provider.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\GettyImages;
 
+use GuzzleHttp\ClientInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -38,6 +39,8 @@ class Provider extends AbstractProvider
 
     public function getAccessToken($code)
     {
+        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
+
         $response = $this->getHttpClient()->post(
             $this->getTokenUrl(),
             [
@@ -46,7 +49,7 @@ class Provider extends AbstractProvider
                         $this->clientId.':'.$this->clientSecret
                     ),
                 ],
-                'body'    => $this->getTokenFields($code),
+                $postKey    => $this->getTokenFields($code),
             ]
         );
 

--- a/src/Instagram/Provider.php
+++ b/src/Instagram/Provider.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\Instagram;
 
+use GuzzleHttp\ClientInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -80,8 +81,10 @@ class Provider extends AbstractProvider
 
     public function getAccessToken($code)
     {
+        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
+
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
-            'form_params' => $this->getTokenFields($code),
+            $postKey => $this->getTokenFields($code),
         ]);
 
         $this->credentialsResponseBody = json_decode($response->getBody(), true);

--- a/src/InstagramBasic/Provider.php
+++ b/src/InstagramBasic/Provider.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\InstagramBasic;
 
+use GuzzleHttp\ClientInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -95,8 +96,10 @@ class Provider extends AbstractProvider
 
     public function getAccessToken($code)
     {
+        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
+
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
-            'form_params' => $this->getTokenFields($code),
+            $postKey => $this->getTokenFields($code),
         ]);
 
         $this->credentialsResponseBody = json_decode($response->getBody(), true);

--- a/src/Jira/Server.php
+++ b/src/Jira/Server.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\Jira;
 
+use GuzzleHttp\ClientInterface;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use League\OAuth1\Client\Credentials\ClientCredentialsInterface;
@@ -79,8 +80,10 @@ class Server extends BaseServer
 
         $headers = $this->getHeaders($temporaryCredentials, 'POST', $uri, $bodyParameters);
 
+        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
+
         try {
-            $response = $client->post($uri, ['headers' => $headers], ['body' => $bodyParameters]);
+            $response = $client->post($uri, ['headers' => $headers], [$postKey => $bodyParameters]);
         } catch (BadResponseException $e) {
             return $this->handleTokenCredentialsBadResponse($e);
         }

--- a/src/Kakao/KakaoProvider.php
+++ b/src/Kakao/KakaoProvider.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\Kakao;
 
+use GuzzleHttp\ClientInterface;
 use Illuminate\Support\Arr;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
@@ -44,8 +45,10 @@ class KakaoProvider extends AbstractProvider
      */
     public function getAccessToken($code)
     {
+        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
+
         $response = $this->getHttpClient()->request('POST', $this->getTokenUrl(), [
-            'form_params' => $this->getTokenFields($code),
+            $postKey => $this->getTokenFields($code),
         ]);
 
         $this->credentialsResponseBody = json_decode($response->getBody(), true);

--- a/src/LinkedIn/Provider.php
+++ b/src/LinkedIn/Provider.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\LinkedIn;
 
+use GuzzleHttp\ClientInterface;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
@@ -146,8 +147,10 @@ class Provider extends AbstractProvider
 
     public function getAccessToken($code)
     {
+        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
+
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
-            'form_params' => $this->getTokenFields($code),
+            $postKey => $this->getTokenFields($code),
         ]);
 
         $this->credentialsResponseBody = json_decode($response->getBody(), true);

--- a/src/Mollie/Provider.php
+++ b/src/Mollie/Provider.php
@@ -50,7 +50,7 @@ class Provider extends AbstractProvider
     public function getAccessToken($code)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
-            'headers'     => ['Authorization' => 'Basic '.base64_encode($this->clientId.':'.$this->clientSecret)],
+            'headers'          => ['Authorization' => 'Basic '.base64_encode($this->clientId.':'.$this->clientSecret)],
             self::getPostKey() => $this->getTokenFields($code),
         ]);
 
@@ -62,7 +62,7 @@ class Provider extends AbstractProvider
     public function getRefreshTokenResponse($refreshToken)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
-            'headers'     => ['Accept' => 'application/json'],
+            'headers'          => ['Accept' => 'application/json'],
             self::getPostKey() => $this->getRefreshTokenFields($refreshToken),
         ]);
 

--- a/src/Mollie/Provider.php
+++ b/src/Mollie/Provider.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\Mollie;
 
+use GuzzleHttp\ClientInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -41,11 +42,16 @@ class Provider extends AbstractProvider
         return 'https://api.mollie.com/oauth2/tokens';
     }
 
+    protected static function getPostKey()
+    {
+        return  (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
+    }
+
     public function getAccessToken($code)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             'headers'     => ['Authorization' => 'Basic '.base64_encode($this->clientId.':'.$this->clientSecret)],
-            'form_params' => $this->getTokenFields($code),
+            self::getPostKey() => $this->getTokenFields($code),
         ]);
 
         $this->credentialsResponseBody = json_decode($response->getBody(), true);
@@ -57,7 +63,7 @@ class Provider extends AbstractProvider
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             'headers'     => ['Accept' => 'application/json'],
-            'form_params' => $this->getRefreshTokenFields($refreshToken),
+            self::getPostKey() => $this->getRefreshTokenFields($refreshToken),
         ]);
 
         return json_decode($response->getBody(), true);

--- a/src/Naver/NaverProvider.php
+++ b/src/Naver/NaverProvider.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\Naver;
 
+use GuzzleHttp\ClientInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -43,9 +44,11 @@ class NaverProvider extends AbstractProvider
      */
     public function getAccessToken($code)
     {
+        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
+
         $response = $this->getHttpClient()->request('POST', $this->getTokenUrl(), [
             'headers'     => ['Accept' => 'application/json'],
-            'form_params' => $this->getTokenFields($code),
+            $postKey => $this->getTokenFields($code),
         ]);
 
         $this->credentialsResponseBody = json_decode($response->getBody(), true);

--- a/src/Naver/NaverProvider.php
+++ b/src/Naver/NaverProvider.php
@@ -48,7 +48,7 @@ class NaverProvider extends AbstractProvider
 
         $response = $this->getHttpClient()->request('POST', $this->getTokenUrl(), [
             'headers'     => ['Accept' => 'application/json'],
-            $postKey => $this->getTokenFields($code),
+            $postKey      => $this->getTokenFields($code),
         ]);
 
         $this->credentialsResponseBody = json_decode($response->getBody(), true);

--- a/src/Orcid/Provider.php
+++ b/src/Orcid/Provider.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\Orcid;
 
+use GuzzleHttp\ClientInterface;
 use Illuminate\Support\Arr;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
@@ -193,9 +194,11 @@ class Provider extends AbstractProvider
         $s = $this->scopes[0];
         $data = "client_id={$this->clientId}&client_secret={$this->clientSecret}&grant_type=client_credentials&scope={$s}";
 
+        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
+
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             'headers' => ['Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded'],
-            'body'    => $data,
+            $postKey    => $data,
         ]);
 
         return json_decode($response->getBody(), true)['access_token'];

--- a/src/Orcid/Provider.php
+++ b/src/Orcid/Provider.php
@@ -197,7 +197,7 @@ class Provider extends AbstractProvider
         $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
 
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
-            'headers' => ['Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded'],
+            'headers'   => ['Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded'],
             $postKey    => $data,
         ]);
 

--- a/src/PayPal/Provider.php
+++ b/src/PayPal/Provider.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\PayPal;
 
+use GuzzleHttp\ClientInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -72,10 +73,12 @@ class Provider extends AbstractProvider
 
     public function getAccessToken($code)
     {
+        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
+
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             'headers'     => ['Accept' => 'application/json'],
             'auth'        => [$this->clientId, $this->clientSecret],
-            'form_params' => $this->getTokenFields($code),
+            $postKey => $this->getTokenFields($code),
         ]);
 
         $this->credentialsResponseBody = json_decode($response->getBody(), true);

--- a/src/PayPal/Provider.php
+++ b/src/PayPal/Provider.php
@@ -78,7 +78,7 @@ class Provider extends AbstractProvider
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             'headers'     => ['Accept' => 'application/json'],
             'auth'        => [$this->clientId, $this->clientSecret],
-            $postKey => $this->getTokenFields($code),
+            $postKey      => $this->getTokenFields($code),
         ]);
 
         $this->credentialsResponseBody = json_decode($response->getBody(), true);

--- a/src/PayPalSandbox/Provider.php
+++ b/src/PayPalSandbox/Provider.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\PayPalSandbox;
 
+use GuzzleHttp\ClientInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -72,10 +73,12 @@ class Provider extends AbstractProvider
 
     public function getAccessToken($code)
     {
+        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
+
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             'headers'     => ['Accept' => 'application/json'],
             'auth'        => [$this->clientId, $this->clientSecret],
-            'form_params' => $this->getTokenFields($code),
+            $postKey => $this->getTokenFields($code),
         ]);
 
         $this->credentialsResponseBody = json_decode($response->getBody(), true);

--- a/src/PayPalSandbox/Provider.php
+++ b/src/PayPalSandbox/Provider.php
@@ -78,7 +78,7 @@ class Provider extends AbstractProvider
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             'headers'     => ['Accept' => 'application/json'],
             'auth'        => [$this->clientId, $this->clientSecret],
-            $postKey => $this->getTokenFields($code),
+            $postKey      => $this->getTokenFields($code),
         ]);
 
         $this->credentialsResponseBody = json_decode($response->getBody(), true);

--- a/src/Procore/Provider.php
+++ b/src/Procore/Provider.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\Procore;
 
+use GuzzleHttp\ClientInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -38,9 +39,11 @@ class Provider extends AbstractProvider
 
     public function getRefreshTokenResponse($refreshToken)
     {
+        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
+
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             'headers'     => ['Accept' => 'application/json'],
-            'form_params' => $this->getRefreshTokenFields($refreshToken),
+            $postKey => $this->getRefreshTokenFields($refreshToken),
         ]);
 
         return json_decode($response->getBody(), true);

--- a/src/Procore/Provider.php
+++ b/src/Procore/Provider.php
@@ -43,7 +43,7 @@ class Provider extends AbstractProvider
 
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             'headers'     => ['Accept' => 'application/json'],
-            $postKey => $this->getRefreshTokenFields($refreshToken),
+            $postKey      => $this->getRefreshTokenFields($refreshToken),
         ]);
 
         return json_decode($response->getBody(), true);

--- a/src/Reddit/Provider.php
+++ b/src/Reddit/Provider.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\Reddit;
 
+use GuzzleHttp\ClientInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -82,13 +83,15 @@ class Provider extends AbstractProvider
      */
     public function getAccessTokenResponse($code)
     {
+        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
+
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             'headers' => [
                 'Accept'     => 'application/json',
                 'User-Agent' => $this->getUserAgent(),
             ],
             'auth'        => [$this->clientId, $this->clientSecret],
-            'form_params' => $this->getTokenFields($code),
+            $postKey => $this->getTokenFields($code),
         ]);
 
         $this->credentialsResponseBody = json_decode($response->getBody(), true);

--- a/src/Reddit/Provider.php
+++ b/src/Reddit/Provider.php
@@ -91,7 +91,7 @@ class Provider extends AbstractProvider
                 'User-Agent' => $this->getUserAgent(),
             ],
             'auth'        => [$this->clientId, $this->clientSecret],
-            $postKey => $this->getTokenFields($code),
+            $postKey      => $this->getTokenFields($code),
         ]);
 
         $this->credentialsResponseBody = json_decode($response->getBody(), true);

--- a/src/StackExchange/Provider.php
+++ b/src/StackExchange/Provider.php
@@ -64,7 +64,7 @@ class Provider extends AbstractProvider
 
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             'headers'     => ['Accept' => 'application/json'],
-            $postKey => $this->getTokenFields($code),
+            $postKey      => $this->getTokenFields($code),
         ]);
 
         parse_str($response->getBody()->getContents(), $data);

--- a/src/StackExchange/Provider.php
+++ b/src/StackExchange/Provider.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\StackExchange;
 
+use GuzzleHttp\ClientInterface;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -59,9 +60,11 @@ class Provider extends AbstractProvider
      */
     public function getAccessTokenResponse($code)
     {
+        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
+
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             'headers'     => ['Accept' => 'application/json'],
-            'form_params' => $this->getTokenFields($code),
+            $postKey => $this->getTokenFields($code),
         ]);
 
         parse_str($response->getBody()->getContents(), $data);

--- a/src/VersionOne/Provider.php
+++ b/src/VersionOne/Provider.php
@@ -3,6 +3,7 @@
 namespace SocialiteProviders\VersionOne;
 
 use Guzzle\Http\Exception\BadResponseException;
+use GuzzleHttp\ClientInterface;
 use Illuminate\Support\Arr;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
@@ -42,11 +43,13 @@ class Provider extends AbstractProvider
      */
     public function getAccessToken($code)
     {
+        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
+
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             'headers' => [
                 'Content-Type' => 'application/x-www-form-urlencoded',
             ],
-            'form_params' => $this->getTokenFields($code),
+            $postKey => $this->getTokenFields($code),
         ]);
 
         $this->credentialsResponseBody = json_decode($response->getBody(), true);
@@ -66,13 +69,15 @@ class Provider extends AbstractProvider
                 'where'  => ['IsSelf' => 'true'],
             ]);
 
+            $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
+
             $requestOptions = [
                 'headers' => [
                     'Content-Type'  => 'application/json',
                     'Accept'        => 'application/json',
                     'Authorization' => 'Bearer '.$token,
                 ],
-                'body' => $data,
+                $postKey => $data,
             ];
 
             $response = $this->getHttpClient()->post(


### PR DESCRIPTION
As mentioned in https://github.com/SocialiteProviders/Providers/issues/480#issuecomment-668102861 - we should always check the version of Guzzle that is used, as the body can be passed either in `body`, either in `form_params`.

Not doing so would make some providers unusable with some versions of Guzzle.