### PR TITLE
Typo in ALL providers

### DIFF
--- a/src/Acclaim/README.md
+++ b/src/Acclaim/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('acclaim')->redirect();
+return Socialite::driver('acclaim')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Admitad/README.md
+++ b/src/Admitad/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('admitad')->redirect();
+return Socialite::driver('admitad')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Amazon/README.md
+++ b/src/Amazon/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('amazon')->redirect();
+return Socialite::driver('amazon')->redirect();
 ```
 
 ### Returned User fields

--- a/src/AngelList/README.md
+++ b/src/AngelList/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('angellist')->redirect();
+return Socialite::driver('angellist')->redirect();
 ```
 
 

--- a/src/AppNet/README.md
+++ b/src/AppNet/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('appnet')->redirect();
+return Socialite::driver('appnet')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Apple/README.md
+++ b/src/Apple/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('apple')->redirect();
+return Socialite::driver('apple')->redirect();
 ```
 
 ### Returned User fields

--- a/src/ArcGIS/README.md
+++ b/src/ArcGIS/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('arcgis')->redirect();
+return Socialite::driver('arcgis')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Asana/README.md
+++ b/src/Asana/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('asana')->redirect();
+return Socialite::driver('asana')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Auth0/README.md
+++ b/src/Auth0/README.md
@@ -47,7 +47,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('auth0')->redirect();
+return Socialite::driver('auth0')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Aweber/README.md
+++ b/src/Aweber/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('aweber')->redirect();
+return Socialite::driver('aweber')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Azure/README.md
+++ b/src/Azure/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('azure')->redirect();
+return Socialite::driver('azure')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Battlenet/README.md
+++ b/src/Battlenet/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('battlenet')->redirect();
+return Socialite::driver('battlenet')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Binance/README.md
+++ b/src/Binance/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('binance')->redirect();
+return Socialite::driver('binance')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Bitbucket/README.md
+++ b/src/Bitbucket/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('bitbucket')->redirect();
+return Socialite::driver('bitbucket')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Bitly/README.md
+++ b/src/Bitly/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('bitly')->redirect();
+return Socialite::driver('bitly')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Box/README.md
+++ b/src/Box/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('box')->redirect();
+return Socialite::driver('box')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Buffer/README.md
+++ b/src/Buffer/README.md
@@ -44,7 +44,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('buffer')->redirect();
+return Socialite::driver('buffer')->redirect();
 ```
 
 ### Returned User fields

--- a/src/CampaignMonitor/README.md
+++ b/src/CampaignMonitor/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('campaignmonitor')->redirect();
+return Socialite::driver('campaignmonitor')->redirect();
 ```

--- a/src/Cheddar/README.md
+++ b/src/Cheddar/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('cheddar')->redirect();
+return Socialite::driver('cheddar')->redirect();
 ```
 
 ### Returned User fields

--- a/src/ClaveUnica/README.md
+++ b/src/ClaveUnica/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('claveunica')->redirect();
+return Socialite::driver('claveunica')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Coinbase/README.md
+++ b/src/Coinbase/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('coinbase')->redirect();
+return Socialite::driver('coinbase')->redirect();
 ```
 
 ### Returned User fields

--- a/src/ConstantContact/README.md
+++ b/src/ConstantContact/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('constantcontact')->redirect();
+return Socialite::driver('constantcontact')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Coursera/README.md
+++ b/src/Coursera/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('coursera')->redirect();
+return Socialite::driver('coursera')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Dailymotion/README.md
+++ b/src/Dailymotion/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('dailymotion')->redirect();
+return Socialite::driver('dailymotion')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Dataporten/README.md
+++ b/src/Dataporten/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('dataporten')->redirect();
+return Socialite::driver('dataporten')->redirect();
 ```

--- a/src/Deezer/README.md
+++ b/src/Deezer/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('deezer')->redirect();
+return Socialite::driver('deezer')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Deviantart/README.md
+++ b/src/Deviantart/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('deviantart')->redirect();
+return Socialite::driver('deviantart')->redirect();
 ```
 
 ### Returned User fields

--- a/src/DigitalOcean/README.md
+++ b/src/DigitalOcean/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('digitalocean')->redirect();
+return Socialite::driver('digitalocean')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Discogs/README.md
+++ b/src/Discogs/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('discogs')->redirect();
+return Socialite::driver('discogs')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Discord/README.md
+++ b/src/Discord/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('discord')->redirect();
+return Socialite::driver('discord')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Disqus/README.md
+++ b/src/Disqus/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('disqus')->redirect();
+return Socialite::driver('disqus')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Douban/README.md
+++ b/src/Douban/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('douban')->redirect();
+return Socialite::driver('douban')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Dribbble/README.md
+++ b/src/Dribbble/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('dribbble')->redirect();
+return Socialite::driver('dribbble')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Dropbox/README.md
+++ b/src/Dropbox/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('dropbox')->redirect();
+return Socialite::driver('dropbox')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Envato/README.md
+++ b/src/Envato/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('envato')->redirect();
+return Socialite::driver('envato')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Etsy/README.md
+++ b/src/Etsy/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('etsy')->redirect();
+return Socialite::driver('etsy')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Eventbrite/README.md
+++ b/src/Eventbrite/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('eventbrite')->redirect();
+return Socialite::driver('eventbrite')->redirect();
 ```
 
 ### Returned User fields

--- a/src/EyeEm/README.md
+++ b/src/EyeEm/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('eyeem')->redirect();
+return Socialite::driver('eyeem')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Facebook/README.md
+++ b/src/Facebook/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('facebook')->redirect();
+return Socialite::driver('facebook')->redirect();
 ```

--- a/src/Faceit/README.md
+++ b/src/Faceit/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('faceit')->redirect();
+return Socialite::driver('faceit')->redirect();
 ```

--- a/src/Fitbit/README.md
+++ b/src/Fitbit/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('fitbit')->redirect();
+return Socialite::driver('fitbit')->redirect();
 ```
 
 ### Returned User fields

--- a/src/FiveHundredPixel/README.md
+++ b/src/FiveHundredPixel/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('500px')->redirect();
+return Socialite::driver('500px')->redirect();
 ```

--- a/src/Flattr/README.md
+++ b/src/Flattr/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('flattr')->redirect();
+return Socialite::driver('flattr')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Flexkids/README.md
+++ b/src/Flexkids/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('flexkids')->redirect();
+return Socialite::driver('flexkids')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Flickr/README.md
+++ b/src/Flickr/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('flickr')->redirect();
+return Socialite::driver('flickr')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Foursquare/README.md
+++ b/src/Foursquare/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('foursquare')->redirect();
+return Socialite::driver('foursquare')->redirect();
 ```
 
 ### Returned User fields

--- a/src/FranceConnect/README.md
+++ b/src/FranceConnect/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('franceconnect')->redirect();
+return Socialite::driver('franceconnect')->redirect();
 ```

--- a/src/GarminConnect/README.md
+++ b/src/GarminConnect/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('garmin-connect')->redirect();
+return Socialite::driver('garmin-connect')->redirect();
 ```

--- a/src/GettyImages/README.md
+++ b/src/GettyImages/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('gettyimages')->redirect();
+return Socialite::driver('gettyimages')->redirect();
 ```

--- a/src/GitHub/README.md
+++ b/src/GitHub/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('github')->redirect();
+return Socialite::driver('github')->redirect();
 ```

--- a/src/GitLab/README.md
+++ b/src/GitLab/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('gitlab')->redirect();
+return Socialite::driver('gitlab')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Gitee/README.md
+++ b/src/Gitee/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('gitee')->redirect();
+return Socialite::driver('gitee')->redirect();
 ```

--- a/src/Goodreads/README.md
+++ b/src/Goodreads/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('goodreads')->redirect();
+return Socialite::driver('goodreads')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Google/README.md
+++ b/src/Google/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('google')->redirect();
+return Socialite::driver('google')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Graph/README.md
+++ b/src/Graph/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('graph')->redirect();
+return Socialite::driver('graph')->redirect();
 ```

--- a/src/HabrCareer/README.md
+++ b/src/HabrCareer/README.md
@@ -43,7 +43,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('habrcareer')->redirect();
+return Socialite::driver('habrcareer')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Harvest/README.md
+++ b/src/Harvest/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('harvest')->redirect();
+return Socialite::driver('harvest')->redirect();
 ```
 
 ### Returned User fields

--- a/src/HeadHunter/README.md
+++ b/src/HeadHunter/README.md
@@ -43,7 +43,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('headhunter')->redirect();
+return Socialite::driver('headhunter')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Heroku/README.md
+++ b/src/Heroku/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('heroku')->redirect();
+return Socialite::driver('heroku')->redirect();
 ```
 
 ### Returned User fields

--- a/src/HubSpot/README.md
+++ b/src/HubSpot/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('hubspot')->redirect();
+return Socialite::driver('hubspot')->redirect();
 ```
 
 ### Returned User fields

--- a/src/HumanApi/README.md
+++ b/src/HumanApi/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('humanapi')->redirect();
+return Socialite::driver('humanapi')->redirect();
 ```
 
 ### Returned User fields

--- a/src/IFSP/README.md
+++ b/src/IFSP/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('ifsp')->redirect();
+return Socialite::driver('ifsp')->redirect();
 ```

--- a/src/Imgur/README.md
+++ b/src/Imgur/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('imgur')->redirect();
+return Socialite::driver('imgur')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Instagram/README.md
+++ b/src/Instagram/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('instagram')->redirect();
+return Socialite::driver('instagram')->redirect();
 ```
 
 ### Returned User fields

--- a/src/InstagramBasic/README.md
+++ b/src/InstagramBasic/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('instagrambasic')->redirect();
+return Socialite::driver('instagrambasic')->redirect();
 ```

--- a/src/Intercom/README.md
+++ b/src/Intercom/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('intercom')->redirect();
+return Socialite::driver('intercom')->redirect();
 ```

--- a/src/Jira/README.md
+++ b/src/Jira/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('jira')->redirect();
+return Socialite::driver('jira')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Kakao/README.md
+++ b/src/Kakao/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('kakao')->redirect();
+return Socialite::driver('kakao')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Keycloak/README.md
+++ b/src/Keycloak/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('keycloak')->redirect();
+return Socialite::driver('keycloak')->redirect();
 ```

--- a/src/LaravelPassport/README.md
+++ b/src/LaravelPassport/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('laravelpassport')->redirect();
+return Socialite::driver('laravelpassport')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Line/README.md
+++ b/src/Line/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('line')->redirect();
+return Socialite::driver('line')->redirect();
 ```
 
 ### Returned User fields

--- a/src/LinkedIn/README.md
+++ b/src/LinkedIn/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('linkedin')->redirect();
+return Socialite::driver('linkedin')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Live/README.md
+++ b/src/Live/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('live')->redirect();
+return Socialite::driver('live')->redirect();
 ```

--- a/src/MailChimp/README.md
+++ b/src/MailChimp/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('mailchimp')->redirect();
+return Socialite::driver('mailchimp')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Mailru/README.md
+++ b/src/Mailru/README.md
@@ -42,7 +42,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('mailru')->redirect();
+return Socialite::driver('mailru')->redirect();
 ```
 
 ### Returned User fields

--- a/src/MakerLog/README.md
+++ b/src/MakerLog/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('makerlog')->redirect();
+return Socialite::driver('makerlog')->redirect();
 ```

--- a/src/Mattermost/README.md
+++ b/src/Mattermost/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('mattermost')->redirect();
+return Socialite::driver('mattermost')->redirect();
 ```
 
 ### Returned User fields

--- a/src/MediaCube/README.md
+++ b/src/MediaCube/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('mediacube')->redirect();
+return Socialite::driver('mediacube')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Medium/README.md
+++ b/src/Medium/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('medium')->redirect();
+return Socialite::driver('medium')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Meetup/README.md
+++ b/src/Meetup/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('meetup')->redirect();
+return Socialite::driver('meetup')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Microsoft/README.md
+++ b/src/Microsoft/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('microsoft')->redirect();
+return Socialite::driver('microsoft')->redirect();
 ```

--- a/src/Mixcloud/README.md
+++ b/src/Mixcloud/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('mixcloud')->redirect();
+return Socialite::driver('mixcloud')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Mollie/README.md
+++ b/src/Mollie/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('mollie')->redirect();
+return Socialite::driver('mollie')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Naver/README.md
+++ b/src/Naver/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('naver')->redirect();
+return Socialite::driver('naver')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Netlify/README.md
+++ b/src/Netlify/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('netlify')->redirect();
+return Socialite::driver('netlify')->redirect();
 ```

--- a/src/Nocks/README.md
+++ b/src/Nocks/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('nocks')->redirect();
+return Socialite::driver('nocks')->redirect();
 ```

--- a/src/OAuthgen/README.md
+++ b/src/OAuthgen/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('oauthgen')->redirect();
+return Socialite::driver('oauthgen')->redirect();
 ```
 
 ### Returned User fields

--- a/src/OSChina/README.md
+++ b/src/OSChina/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('oschina')->redirect();
+return Socialite::driver('oschina')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Odnoklassniki/README.md
+++ b/src/Odnoklassniki/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('odnoklassniki')->redirect();
+return Socialite::driver('odnoklassniki')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Okta/README.md
+++ b/src/Okta/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('okta')->redirect();
+return Socialite::driver('okta')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Orcid/README.md
+++ b/src/Orcid/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('orcid')->redirect();
+return Socialite::driver('orcid')->redirect();
 ```

--- a/src/Patreon/README.md
+++ b/src/Patreon/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('patreon')->redirect();
+return Socialite::driver('patreon')->redirect();
 ```
 
 ### Returned User fields

--- a/src/PayPal/README.md
+++ b/src/PayPal/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('paypal')->redirect();
+return Socialite::driver('paypal')->redirect();
 ```
 
 ### Returned User fields

--- a/src/PayPalSandbox/README.md
+++ b/src/PayPalSandbox/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('paypal_sandbox')->redirect();
+return Socialite::driver('paypal_sandbox')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Paymill/README.md
+++ b/src/Paymill/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('paymill')->redirect();
+return Socialite::driver('paymill')->redirect();
 ```

--- a/src/PeeringDB/README.md
+++ b/src/PeeringDB/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('peeringdb')->redirect();
+return Socialite::driver('peeringdb')->redirect();
 ```

--- a/src/Pinterest/README.md
+++ b/src/Pinterest/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('pinterest')->redirect();
+return Socialite::driver('pinterest')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Pipedrive/README.md
+++ b/src/Pipedrive/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('pipedrive')->redirect();
+return Socialite::driver('pipedrive')->redirect();
 ```

--- a/src/Podio/README.md
+++ b/src/Podio/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('podio')->redirect();
+return Socialite::driver('podio')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Procore/README.md
+++ b/src/Procore/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('procore')->redirect();
+return Socialite::driver('procore')->redirect();
 ```

--- a/src/ProductHunt/README.md
+++ b/src/ProductHunt/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('producthunt')->redirect();
+return Socialite::driver('producthunt')->redirect();
 ```
 
 ### Returned User fields

--- a/src/ProjectV/README.md
+++ b/src/ProjectV/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('projectv')->redirect();
+return Socialite::driver('projectv')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Pushbullet/README.md
+++ b/src/Pushbullet/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('pushbullet')->redirect();
+return Socialite::driver('pushbullet')->redirect();
 ```
 
 ### Returned User fields

--- a/src/QQ/README.md
+++ b/src/QQ/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('qq')->redirect();
+return Socialite::driver('qq')->redirect();
 ```
 
 ### Returned User fields

--- a/src/QuickBooks/README.md
+++ b/src/QuickBooks/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('quickbooks')->redirect();
+return Socialite::driver('quickbooks')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Readability/README.md
+++ b/src/Readability/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('readability')->redirect();
+return Socialite::driver('readability')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Redbooth/README.md
+++ b/src/Redbooth/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('redbooth')->redirect();
+return Socialite::driver('redbooth')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Reddit/README.md
+++ b/src/Reddit/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('reddit')->redirect();
+return Socialite::driver('reddit')->redirect();
 ```
 
 ### Returned User fields

--- a/src/RunKeeper/README.md
+++ b/src/RunKeeper/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('runkeeper')->redirect();
+return Socialite::driver('runkeeper')->redirect();
 ```
 
 ### Returned User fields

--- a/src/SURFconext/README.md
+++ b/src/SURFconext/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('surfconext')->redirect();
+return Socialite::driver('surfconext')->redirect();
 ```

--- a/src/Sage/README.md
+++ b/src/Sage/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('sage')->redirect();
+return Socialite::driver('sage')->redirect();
 ```

--- a/src/SalesForce/README.md
+++ b/src/SalesForce/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('SalesForce')->redirect();
+return Socialite::driver('SalesForce')->redirect();
 ```
 
 ### Returned User fields

--- a/src/SciStarter/README.md
+++ b/src/SciStarter/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('scistarter')->redirect();
+return Socialite::driver('scistarter')->redirect();
 ```
 
 ### Returned User fields

--- a/src/SharePoint/README.md
+++ b/src/SharePoint/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('sharepoint')->redirect();
+return Socialite::driver('sharepoint')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Shopify/README.md
+++ b/src/Shopify/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('shopify')->redirect();
+return Socialite::driver('shopify')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Slack/README.md
+++ b/src/Slack/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('slack')->redirect();
+return Socialite::driver('slack')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Smashcast/README.md
+++ b/src/Smashcast/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('smashcast')->redirect();
+return Socialite::driver('smashcast')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Snapchat/README.md
+++ b/src/Snapchat/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('snapchat')->redirect();
+return Socialite::driver('snapchat')->redirect();
 ```
 
 ### Returned User fields

--- a/src/SoundCloud/README.md
+++ b/src/SoundCloud/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('soundcloud')->redirect();
+return Socialite::driver('soundcloud')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Spotify/README.md
+++ b/src/Spotify/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('spotify')->redirect();
+return Socialite::driver('spotify')->redirect();
 ```
 
 ### Returned User fields

--- a/src/StackExchange/README.md
+++ b/src/StackExchange/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('stackexchange')->redirect();
+return Socialite::driver('stackexchange')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Steam/README.md
+++ b/src/Steam/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('steam')->redirect();
+return Socialite::driver('steam')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Steem/README.md
+++ b/src/Steem/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('steem')->redirect();
+return Socialite::driver('steem')->redirect();
 ```

--- a/src/StockTwits/README.md
+++ b/src/StockTwits/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('stocktwits')->redirect();
+return Socialite::driver('stocktwits')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Strava/README.md
+++ b/src/Strava/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('strava')->redirect();
+return Socialite::driver('strava')->redirect();
 ```
 
 ### Returned User fields

--- a/src/StreamElements/README.md
+++ b/src/StreamElements/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('streamelements')->redirect();
+return Socialite::driver('streamelements')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Stripe/README.md
+++ b/src/Stripe/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('stripe')->redirect();
+return Socialite::driver('stripe')->redirect();
 ```
 
 ### Returned User fields

--- a/src/TVShowTime/README.md
+++ b/src/TVShowTime/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('tvshowtime')->redirect();
+return Socialite::driver('tvshowtime')->redirect();
 ```
 
 ### Returned User fields

--- a/src/TeamService/README.md
+++ b/src/TeamService/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('teamservice')->redirect();
+return Socialite::driver('teamservice')->redirect();
 ```

--- a/src/Teamleader/README.md
+++ b/src/Teamleader/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('teamleader')->redirect();
+return Socialite::driver('teamleader')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Teamweek/README.md
+++ b/src/Teamweek/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('teamweek')->redirect();
+return Socialite::driver('teamweek')->redirect();
 ```
 
 ### Returned User fields

--- a/src/ThirtySevenSignals/README.md
+++ b/src/ThirtySevenSignals/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('37signals')->redirect();
+return Socialite::driver('37signals')->redirect();
 ```

--- a/src/Todoist/README.md
+++ b/src/Todoist/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('todoist')->redirect();
+return Socialite::driver('todoist')->redirect();
 ```

--- a/src/Trakt/README.md
+++ b/src/Trakt/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('trakt')->redirect();
+return Socialite::driver('trakt')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Trello/README.md
+++ b/src/Trello/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('trello')->redirect();
+return Socialite::driver('trello')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Tumblr/README.md
+++ b/src/Tumblr/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('tumblr')->redirect();
+return Socialite::driver('tumblr')->redirect();
 ```
 
 ### Returned User fields

--- a/src/TwentyThreeAndMe/README.md
+++ b/src/TwentyThreeAndMe/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('23andme')->redirect();
+return Socialite::driver('23andme')->redirect();
 ```

--- a/src/Twitch/README.md
+++ b/src/Twitch/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('twitch')->redirect();
+return Socialite::driver('twitch')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Twitter/README.md
+++ b/src/Twitter/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('twitter')->redirect();
+return Socialite::driver('twitter')->redirect();
 ```
 
 ### Returned User fields

--- a/src/UCL/README.md
+++ b/src/UCL/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('uclapi')->redirect();
+return Socialite::driver('uclapi')->redirect();
 ```
 
 ### Returned User fields

--- a/src/UFS/README.md
+++ b/src/UFS/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('ufs')->redirect();
+return Socialite::driver('ufs')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Uber/README.md
+++ b/src/Uber/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('uber')->redirect();
+return Socialite::driver('uber')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Ufutx/README.md
+++ b/src/Ufutx/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('ufutx')->redirect();
+return Socialite::driver('ufutx')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Unsplash/README.md
+++ b/src/Unsplash/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('unsplash')->redirect();
+return Socialite::driver('unsplash')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Untappd/README.md
+++ b/src/Untappd/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('untappd')->redirect();
+return Socialite::driver('untappd')->redirect();
 ```
 
 ### Returned User fields

--- a/src/VKontakte/README.md
+++ b/src/VKontakte/README.md
@@ -42,7 +42,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('vkontakte')->redirect();
+return Socialite::driver('vkontakte')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Venmo/README.md
+++ b/src/Venmo/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('venmo')->redirect();
+return Socialite::driver('venmo')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Vercel/README.md
+++ b/src/Vercel/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('vercel')->redirect();
+return Socialite::driver('vercel')->redirect();
 ```

--- a/src/VersionOne/README.md
+++ b/src/VersionOne/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('versionone')->redirect();
+return Socialite::driver('versionone')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Vimeo/README.md
+++ b/src/Vimeo/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('vimeo')->redirect();
+return Socialite::driver('vimeo')->redirect();
 ```
 
 ### Returned User fields

--- a/src/WeChatServiceAccount/README.md
+++ b/src/WeChatServiceAccount/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('wechat_service_account')->redirect();
+return Socialite::driver('wechat_service_account')->redirect();
 ```
 
 ### Returned User fields

--- a/src/WeChatWeb/README.md
+++ b/src/WeChatWeb/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('wechat_web')->redirect();
+return Socialite::driver('wechat_web')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Weibo/README.md
+++ b/src/Weibo/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('weibo')->redirect();
+return Socialite::driver('weibo')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Weixin/README.md
+++ b/src/Weixin/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('weixin')->redirect();
+return Socialite::driver('weixin')->redirect();
 ```
 
 ### Returned User fields

--- a/src/WeixinWeb/README.md
+++ b/src/WeixinWeb/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('weixinweb')->redirect();
+return Socialite::driver('weixinweb')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Withings/README.md
+++ b/src/Withings/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('withings')->redirect();
+return Socialite::driver('withings')->redirect();
 ```

--- a/src/WordPress/README.md
+++ b/src/WordPress/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('wordpress')->redirect();
+return Socialite::driver('wordpress')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Xero/README.md
+++ b/src/Xero/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('xero')->redirect();
+return Socialite::driver('xero')->redirect();
 ```

--- a/src/Xing/README.md
+++ b/src/Xing/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('xing')->redirect();
+return Socialite::driver('xing')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Yahoo/README.md
+++ b/src/Yahoo/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('yahoo')->redirect();
+return Socialite::driver('yahoo')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Yammer/README.md
+++ b/src/Yammer/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('yammer')->redirect();
+return Socialite::driver('yammer')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Yandex/README.md
+++ b/src/Yandex/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('yandex')->redirect();
+return Socialite::driver('yandex')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Yiban/README.md
+++ b/src/Yiban/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('yiban')->redirect();
+return Socialite::driver('yiban')->redirect();
 ```
 
 ### Returned User fields

--- a/src/YouTube/README.md
+++ b/src/YouTube/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('youtube')->redirect();
+return Socialite::driver('youtube')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Zalo/README.md
+++ b/src/Zalo/README.md
@@ -38,5 +38,5 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('zalo')->redirect();
+return Socialite::driver('zalo')->redirect();
 ```

--- a/src/Zendesk/README.md
+++ b/src/Zendesk/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('zendesk')->redirect();
+return Socialite::driver('zendesk')->redirect();
 ```
 
 ### Returned User fields

--- a/src/Zoho/README.md
+++ b/src/Zoho/README.md
@@ -42,7 +42,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('zoho')->redirect();
+return Socialite::driver('zoho')->redirect();
 ```
 
 ### Returned User fields

--- a/src/xREL/README.md
+++ b/src/xREL/README.md
@@ -38,7 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('xrel')->redirect();
+return Socialite::driver('xrel')->redirect();
 ```
 
 ### Returned User fields

--- a/tools/docgen.php
+++ b/tools/docgen.php
@@ -14,10 +14,10 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
 ### Add configuration to `config/services.php`
 
 ```php
-'%PROVIDER_ALIAS%' => [    
-  'client_id' => env('%PROVIDER_UPPER%_CLIENT_ID'),  
-  'client_secret' => env('%PROVIDER_UPPER%_CLIENT_SECRET'),  
-  'redirect' => env('%PROVIDER_UPPER%_REDIRECT_URI') 
+'%PROVIDER_ALIAS%' => [
+  'client_id' => env('%PROVIDER_UPPER%_CLIENT_ID'),
+  'client_secret' => env('%PROVIDER_UPPER%_CLIENT_SECRET'),
+  'redirect' => env('%PROVIDER_UPPER%_REDIRECT_URI')
 ],
 ```
 
@@ -41,7 +41,7 @@ protected \$listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('%PROVIDER_ALIAS%')->redirect();
+return Socialite::driver('%PROVIDER_ALIAS%')->redirect();
 ```
 
 DOC;


### PR DESCRIPTION
I saw this typo in every providers README.

The driver is called this way: `Socialite::with('provider')` while [`with`](https://laravel.com/docs/socialite#optional-parameters) serves another purpose.

The correct way to call Socialite driver is: `Socialite::driver('provider')`