### PR TITLE
Avoid unnecessary key check if token kid doesn't match

### DIFF
--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -141,19 +141,17 @@ class Provider extends AbstractProvider
 
         $publicKeys = JWK::parseKeySet($data);
 
-        $signatureVerified = false;
+        $kid = $token->getClaim('kid');
 
-        foreach ($publicKeys as $res) {
-            $publicKey = openssl_pkey_get_details($res);
+        if (isset($publicKeys[$kid])) {
+            $publicKey = openssl_pkey_get_details($publicKeys[$kid]);
+
             if ($token->verify($signer, $publicKey['key'])) {
-                $signatureVerified = true;
+                return true;
             }
         }
-        if (!$signatureVerified) {
-            throw new InvalidStateException('Invalid JWT Signature');
-        }
 
-        return true;
+        throw new InvalidStateException('Invalid JWT Signature');
     }
 
     /**


### PR DESCRIPTION
Current implementation performs an `openssl_pkey_get_details` and a `$token->verify` against all JWK keys distributed by Apple. This is time-consuming and can be optimized. 

Apple provides in its JWT token the `kid` claims describing which JWK key has been used for token signing, and therefore which JWK key should be used for token signing verification.

https://developer.apple.com/documentation/sign_in_with_apple/fetch_apple_s_public_key_for_verifying_token_signature

> The endpoint can return multiple keys, and the count of keys can vary over time. From this set of keys, select the key with the matching key identifier (kid) to verify the signature of any JSON Web Token (JWT) issued by Apple. For more information, see the JSON Web Signature specification.

This PR updates `Provider::verify` method to avoid unnecessary `openssl_pkey_get_details` and `$token->verify` calls for unknown `kid`, and also perform verification against only one JWK key.