### PR TITLE
Added necessary step to Twitter docs

### DIFF
--- a/src/Twitter/README.md
+++ b/src/Twitter/README.md
@@ -18,6 +18,10 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
 ],
 ```
 
+### Add URL to Twitter
+
+Your redirect or callback URL needs to be added to your app in the [Twitter Developers Dashboard](https://developer.twitter.com/en/apps).
+
 ### Add provider event listener
 
 Configure the package's listener to listen for `SocialiteWasCalled` events.


### PR DESCRIPTION
Twitter login won't work without this step and will return a vague error instead.

