### PR TITLE
Fix JWT kid reading

### DIFF
--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -141,7 +141,7 @@ class Provider extends AbstractProvider
 
         $publicKeys = JWK::parseKeySet($data);
 
-        $kid = $token->getClaim('kid');
+        $kid = $token->getHeader('kid');
 
         if (isset($publicKeys[$kid])) {
             $publicKey = openssl_pkey_get_details($publicKeys[$kid]);


### PR DESCRIPTION
This pull request fixes https://github.com/SocialiteProviders/Providers/issues/530 introduced by PR https://github.com/SocialiteProviders/Providers/pull/528. 

The `kid` claim (key Id) is always provided in header section of a JWT token, and wrong assumption was made about ability of retrieving this value using the `getClaim()`method of lcobucci/jwt library.

As guessed by @arun07as, using [getHeader()](https://github.com/lcobucci/jwt/blob/3.3.3/src/Token.php#L106) method resolve the issue.