### PR TITLE
fix: keycloak scope separator

### DIFF
--- a/src/Keycloak/Provider.php
+++ b/src/Keycloak/Provider.php
@@ -13,6 +13,8 @@ class Provider extends AbstractProvider
      */
     public const IDENTIFIER = 'KEYCLOAK';
 
+    protected $scopeSeparator = ' ';
+
     public static function additionalConfigKeys()
     {
         return ['base_url', 'realms'];


### PR DESCRIPTION
Closes #553 