### PR TITLE
feat(streamlabs): add third-party accounts

### DIFF
--- a/src/Streamlabs/Provider.php
+++ b/src/Streamlabs/Provider.php
@@ -58,11 +58,16 @@ class Provider extends AbstractProvider
      */
     protected function mapUserToObject(array $user)
     {
-        $user = $user['streamlabs'];
+        $mainAccount = $user['streamlabs'];
 
         return (new User())->setRaw($user)->map([
-            'id'       => $user['id'],
-            'name'     => $user['display_name'],
+            'id'        => $mainAccount['id'],
+            'name'      => $mainAccount['display_name'],
+            'accounts'  => [
+                'twitch'    => $user['twitch'] ?? null,
+                'youtube'   => $user['youtube'] ?? null,
+                'facebook'  => $user['facebook'] ?? null,
+            ],
         ]);
     }
 

--- a/src/Streamlabs/README.md
+++ b/src/Streamlabs/README.md
@@ -45,6 +45,9 @@ return Socialite::with('streamlabs')->redirect();
 
 - ``id``
 - ``name``
+- ``accounts``
+
+> Note: ``accounts`` is an array of providers that the user has signed-in with Streamlabs; included values are Twitch (``twitch``), YouTube (``youtube``), and Facebook (``facebook``).
 
 ### Reference
 


### PR DESCRIPTION
This PR allow developers to access the third-party accounts that the user signed-in with Streamlabs, so they can access more information (such as nicknames, profile picture, ...). Documentation has been updated as well.

Documentation: https://dev.streamlabs.com/reference#user