### PR TITLE
Dropbox scope separator, updated docs

### DIFF
--- a/src/Dropbox/Provider.php
+++ b/src/Dropbox/Provider.php
@@ -14,11 +14,16 @@ class Provider extends AbstractProvider
     public const IDENTIFIER = 'DROPBOX';
 
     /**
-     * The separating character for the requested scopes.
-     *
-     * @var string
+     * {@inheritdoc}
      */
     protected $scopeSeparator = ' ';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopes = [
+        'account_info.read',
+    ];
 
     /**
      * {@inheritdoc}

--- a/src/Dropbox/Provider.php
+++ b/src/Dropbox/Provider.php
@@ -14,6 +14,13 @@ class Provider extends AbstractProvider
     public const IDENTIFIER = 'DROPBOX';
 
     /**
+     * The separating character for the requested scopes.
+     *
+     * @var string
+     */
+    protected $scopeSeparator = ' ';
+
+    /**
      * {@inheritdoc}
      */
     protected function getAuthUrl($state)

--- a/src/Dropbox/README.md
+++ b/src/Dropbox/README.md
@@ -38,7 +38,9 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::driver('dropbox')->redirect();
+return Socialite::driver('dropbox')
+    ->scopes(['account_info.read'])
+    ->redirect();
 ```
 
 ### Returned User fields

--- a/src/Dropbox/README.md
+++ b/src/Dropbox/README.md
@@ -38,9 +38,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::driver('dropbox')
-    ->scopes(['account_info.read'])
-    ->redirect();
+return Socialite::driver('dropbox')->redirect();
 ```
 
 ### Returned User fields


### PR DESCRIPTION
Dropbox uses a space for multiple scopes.

![image](https://user-images.githubusercontent.com/627060/96612742-bdf7fa00-12c3-11eb-80c3-f1cce7ccb8c7.png)

Updated documentation to include the proper usage with the base default scope because not specifying any scopes will result in an error message.

![image](https://user-images.githubusercontent.com/627060/96612802-d49e5100-12c3-11eb-9d20-f7860074074d.png)