### PR TITLE
Use Zoho-provided accounts server when provided

### DIFF
--- a/src/Zoho/Provider.php
+++ b/src/Zoho/Provider.php
@@ -24,13 +24,21 @@ class Provider extends AbstractProvider
     {
         return $this->buildAuthUrlFromBase('https://accounts.zoho.com/oauth/v2/auth', $state);
     }
+    
+    /**
+     * Gets the Accounts Server to use from Zoho provider
+     */
+    protected function getAccountsServerUrl()
+    {
+        return $this->request->input('accounts-server', 'https://accounts.zoho.com');
+    }
 
     /**
      * {@inheritdoc}
      */
     protected function getTokenUrl()
     {
-        return 'https://accounts.zoho.com/oauth/v2/token';
+        return $this->getAccountsServerUrl() . '/oauth/v2/token';
     }
 
     /**
@@ -38,7 +46,7 @@ class Provider extends AbstractProvider
      */
     protected function getUserByToken($token)
     {
-        $response = $this->getHttpClient()->get('https://accounts.zoho.com/oauth/user/info', [
+        $response = $this->getHttpClient()->get($this->getAccountsServerUrl() . '/oauth/user/info', [
             'headers' => [
                 'Authorization' => 'Bearer '.$token,
             ],

--- a/src/Zoho/Provider.php
+++ b/src/Zoho/Provider.php
@@ -26,7 +26,7 @@ class Provider extends AbstractProvider
     }
     
     /**
-     * Gets the Accounts Server to use from Zoho provider
+     * Gets the Accounts Server to use from Zoho provider.
      */
     protected function getAccountsServerUrl()
     {
@@ -38,7 +38,7 @@ class Provider extends AbstractProvider
      */
     protected function getTokenUrl()
     {
-        return $this->getAccountsServerUrl() . '/oauth/v2/token';
+        return $this->getAccountsServerUrl().'/oauth/v2/token';
     }
 
     /**
@@ -46,7 +46,7 @@ class Provider extends AbstractProvider
      */
     protected function getUserByToken($token)
     {
-        $response = $this->getHttpClient()->get($this->getAccountsServerUrl() . '/oauth/user/info', [
+        $response = $this->getHttpClient()->get($this->getAccountsServerUrl().'/oauth/user/info', [
             'headers' => [
                 'Authorization' => 'Bearer '.$token,
             ],

--- a/src/Zoho/Provider.php
+++ b/src/Zoho/Provider.php
@@ -24,6 +24,7 @@ class Provider extends AbstractProvider
     {
         return $this->buildAuthUrlFromBase('https://accounts.zoho.com/oauth/v2/auth', $state);
     }
+
     /**
      * Gets the Accounts Server to use from Zoho provider.
      */

--- a/src/Zoho/Provider.php
+++ b/src/Zoho/Provider.php
@@ -24,7 +24,6 @@ class Provider extends AbstractProvider
     {
         return $this->buildAuthUrlFromBase('https://accounts.zoho.com/oauth/v2/auth', $state);
     }
-    
     /**
      * Gets the Accounts Server to use from Zoho provider.
      */


### PR DESCRIPTION
In some instance, Zoho will return which accounts server to use to get further user's details.

For example, our customer in Europe is instructed to use https://accounts.zoho.eu (instead of .com) 

This change is about using the `accounts-server` provided by Zoho, if any. Otherwise will use the same as today by default.

Note, in my tests, the initial authUrl `getAuthUrl()` does not need to be taylored to the user's instance.

Thanks for massive amount of work done on Socialite!

Best Regards, 

Colin

