### PR TITLE
Add default scope to the GitLab Provider

### DIFF
--- a/src/GitLab/Provider.php
+++ b/src/GitLab/Provider.php
@@ -15,6 +15,11 @@ class Provider extends AbstractProvider
     /**
      * {@inheritdoc}
      */
+    protected $scopes = ['read_user'];
+
+    /**
+     * {@inheritdoc}
+     */
     protected $scopeSeparator = ' ';
 
     /**


### PR DESCRIPTION
### Summary

This PR is intended to fix an issue originally found in BookStackApp/BookStack#2359 where the GitLab provider cannot be used without either:

* Using a very wide permission scope (Complete read/write access);
* Overriding the scopes on the provider.

### Detail

Currently, when authenticating GitLab will show the below error unless the `api` scope is set on the "Application" created within GitLab.

> The requested scope is invalid, unknown, or malformed.

The `api` scope is described by GitLab as so:

> Grants complete read/write access to the API, including all groups and projects, the container registry, and the package registry.

Of course this much broader than the details we need, which can instead be covered by the `read_user` scope which is described like so:

> Grants read-only access to the authenticated user's profile through the /user API endpoint, which includes username, public email, and full name. Also grants access to read-only API endpoints under /users.

I think there have been changes in GitLab which may have made requirement of the `read_user` less apparent in the past. Previously in GitLab you could create an "Application" and select no scopes, which would have looked to provide minimal permissions but may have been equivalent to selecting the `api` scope, but this is no longer possible.

This aligns with [changes made](https://github.com/laravel/socialite/pull/403/files) in the base Laravel provider.

### Backwards Compatibility

From my testing this could be considered a breaking change, requiring the updating of scopes on the "Application" within GitLab. 
If the "Application" does not have the `read_user` scope then they will get an "Invalid scope" error, This is true even if it has the permissive `api` scope which would have allowed the current empty-scope functionality to work. 

Above I described that you could previously create a GitLab "Application" with no scopes. I am not sure how this would affect these scenarios. It may cause an error like having only the `api` scope checked or it may be equal to having all scopes checked so this would not be a breaking change in that scenario. It's not possible to test this without reverting to older GitLab versions or having an existing instance of such an "Application". Either way, the above means this would have to be a breaking change anyway. 

---

There is a workaround available (Manually define scope) so I don't see it as vital that this breaking change is introduced but I'd have thought the increased security in the default scopes would be worth it, but it's not for me to decide so I'll of course respect the maintainers' choice on the matter. 