### PR TITLE
SURFconext: Change URLs and keys to reflect changes done by SURF

### DIFF
--- a/src/SURFconext/Provider.php
+++ b/src/SURFconext/Provider.php
@@ -13,18 +13,18 @@ class Provider extends AbstractProvider
     protected $scopes = ['openid'];
 
     /**
-     * @see https://oidc.surfconext.nl/.well-known/openid-configuration
-     * @see https://oidc.test.surfconext.nl/.well-known/openid-configuration
+     * @see https://connect.surfconext.nl/.well-known/openid-configuration
+     * @see https://connect.test.surfconext.nl/.well-known/openid-configuration
      *
      * @return string
      */
     protected function getHostname()
     {
         if ($this->getConfig('test')) {
-            return 'oidc.test.surfconext.nl';
+            return 'connect.test.surfconext.nl/iodc';
         }
 
-        return 'oidc.surfconext.nl';
+        return 'connect.surfconext.nl/iodc';
     }
 
     /**
@@ -67,24 +67,24 @@ class Provider extends AbstractProvider
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([
-            'id'                            => Arr::get($user, 'sub'),
-            'name'                          => Arr::get($user, 'name'),
-            'nickname'                      => Arr::get($user, 'nickname'),
-            'email'                         => Arr::get($user, 'email'),
-            'avatar'                        => Arr::get($user, 'picture'),
-            'sub'                           => Arr::get($user, 'sub'),
-            'preferred_username'            => Arr::get($user, 'preferred_username'),
-            'given_name'                    => Arr::get($user, 'given_name'),
-            'family_name'                   => Arr::get($user, 'family_name'),
-            'schac_home_organization'       => Arr::get($user, 'schac_home_organization'),
-            'schac_home_organization_type'  => Arr::get($user, 'schac_home_organization_type'),
-            'edu_person_affiliations'       => Arr::get($user, 'edu_person_affiliations'),
-            'edu_person_scoped_affiliations'=> Arr::get($user, 'edu_person_scoped_affiliations'),
-            'edu_person_targeted_id'        => Arr::get($user, 'edu_person_targeted_id'),
-            'uids'                          => Arr::get($user, 'uids'),
-            'schac_personal_unique_codes'   => Arr::get($user, 'schac_personal_unique_codes'),
-            'edu_person_principal_name'     => Arr::get($user, 'edu_person_principal_name'),
-            'edu_person_entitlements'       => Arr::get($user, 'edu_person_entitlements'),
+            'id'                           => Arr::get($user, 'sub'),
+            'name'                         => Arr::get($user, 'name'),
+            'nickname'                     => Arr::get($user, 'nickname'),
+            'email'                        => Arr::get($user, 'email'),
+            'avatar'                       => Arr::get($user, 'picture'),
+            'sub'                          => Arr::get($user, 'sub'),
+            'preferred_username'           => Arr::get($user, 'preferred_username'),
+            'given_name'                   => Arr::get($user, 'given_name'),
+            'family_name'                  => Arr::get($user, 'family_name'),
+            'schac_home_organization'      => Arr::get($user, 'schac_home_organization'),
+            'schac_home_organization_type' => Arr::get($user, 'schac_home_organization_type'),
+            'eduperson_affiliation'        => Arr::get($user, 'eduperson_affiliation'),
+            'eduperson_scoped_affiliation' => Arr::get($user, 'eduperson_scoped_affiliation'),
+            'eduperson_targeted_id'        => Arr::get($user, 'eduperson_targeted_id'),
+            'uids'                         => Arr::get($user, 'uids'),
+            'schac_personal_unique_code'   => Arr::get($user, 'schac_personal_unique_code'),
+            'eduperson_principal_name'     => Arr::get($user, 'eduperson_principal_name'),
+            'eduperson_entitlement'        => Arr::get($user, 'eduperson_entitlement'),
         ]);
     }
 

--- a/src/SURFconext/README.md
+++ b/src/SURFconext/README.md
@@ -14,7 +14,8 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
 'surfconext' => [    
   'client_id' => env('SURFCONEXT_CLIENT_ID'),  
   'client_secret' => env('SURFCONEXT_CLIENT_SECRET'),  
-  'redirect' => env('SURFCONEXT_REDIRECT_URI') 
+  'redirect' => env('SURFCONEXT_REDIRECT_URI'),
+  'test' => env('SURFCONEXT_TEST')
 ],
 ```
 


### PR DESCRIPTION
Tried using this SocialiteProvider earlier today and it was not working. Decided to do some digging, temporarily add some code in our project to make it work. Everything is working now so decided to create a PR to get this changed structurally.

A few keynotes:
- SURF changed their endpoints and usage of old endpoints would lead to [a redirect to their docs regarding the migration](https://wiki.surfnet.nl/display/surfconextdev/OpenID+Connect+Migratie).
- Decided to document the optional test key as it was hidden now.