### PR TITLE
Add Fablabs.io provider

### DIFF
--- a/monorepo-builder.yml
+++ b/monorepo-builder.yml
@@ -38,6 +38,7 @@ parameters:
     src/Etsy: 'git@github.com:SocialiteProviders/Etsy.git'
     src/Eventbrite: 'git@github.com:SocialiteProviders/Eventbrite.git'
     src/EyeEm: 'git@github.com:SocialiteProviders/EyeEm.git'
+    src/Fablabs: 'git@github.com:SocialiteProviders/Fablabs.git'
     src/Facebook: 'git@github.com:SocialiteProviders/Facebook.git'
     src/Faceit: 'git@github.com:SocialiteProviders/Faceit.git'
     src/Fitbit: 'git@github.com:SocialiteProviders/Fitbit.git'

--- a/src/Fablabs/FablabsExtendSocialite.php
+++ b/src/Fablabs/FablabsExtendSocialite.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SocialiteProviders\Fablabs;
+
+use SocialiteProviders\Manager\SocialiteWasCalled;
+
+class FablabsExtendSocialite
+{
+    /**
+     * Register the provider.
+     *
+     * @param \SocialiteProviders\Manager\SocialiteWasCalled $socialiteWasCalled
+     */
+    public function handle(SocialiteWasCalled $socialiteWasCalled)
+    {
+        $socialiteWasCalled->extendSocialite('fablabs', Provider::class);
+    }
+}

--- a/src/Fablabs/Provider.php
+++ b/src/Fablabs/Provider.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace SocialiteProviders\Fablabs;
+
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
+use SocialiteProviders\Manager\OAuth2\User;
+
+class Provider extends AbstractProvider
+{
+    /**
+     * Unique Provider Identifier.
+     */
+    public const IDENTIFIER = 'FABLABS';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopes = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopeSeparator = ' ';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAuthUrl($state)
+    {
+        return $this->buildAuthUrlFromBase($this->getInstanceUri().'oauth/authorize', $state);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenUrl()
+    {
+        return $this->getInstanceUri().'oauth/token';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByToken($token)
+    {
+        $response = $this->getHttpClient()->get($this->getInstanceUri().'0/me.json', [
+            'headers' => [
+                'Authorization' => 'Bearer '.$token,
+            ],
+        ]);
+
+        return json_decode($response->getBody(), true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return (new User())->setRaw($user)->map([
+            'id'       => $user['id'],
+            'nickname' => $user['username'],
+            'name'     => trim($user['first_name'].' '.$user['last_name']),
+            'email'    => $user['email'],
+            'avatar'   => $user['avatar_url'],
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenFields($code)
+    {
+        return array_merge(parent::getTokenFields($code), [
+            'grant_type' => 'authorization_code',
+        ]);
+    }
+
+    protected function getInstanceUri()
+    {
+        return $this->getConfig('instance_uri', 'https://api.fablabs.io/');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function additionalConfigKeys()
+    {
+        return ['instance_uri'];
+    }
+}

--- a/src/Fablabs/README.md
+++ b/src/Fablabs/README.md
@@ -1,0 +1,54 @@
+# Fablabs
+
+```bash
+composer require socialiteproviders/fablabs
+```
+
+## Installation & Basic Usage
+
+Please see the [Base Installation Guide](https://socialiteproviders.com/usage/), then follow the provider specific instructions below.
+
+### Add configuration to `config/services.php`
+
+```php
+'fablabs' => [
+  'client_id' => env('FABLABS_CLIENT_ID'),
+  'client_secret' => env('FABLABS_CLIENT_SECRET'),
+  'redirect' => env('FABLABS_REDIRECT_URI')
+],
+```
+
+### Add provider event listener
+
+Configure the package's listener to listen for `SocialiteWasCalled` events.
+
+Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. See the [Base Installation Guide](https://socialiteproviders.com/usage/) for detailed instructions.
+
+```php
+protected $listen = [
+    \SocialiteProviders\Manager\SocialiteWasCalled::class => [
+        // ... other providers
+        'SocialiteProviders\\Fablabs\\FablabsExtendSocialite@handle',
+    ],
+];
+```
+
+### Usage
+
+You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
+
+```php
+return Socialite::driver('fablabs')->redirect();
+```
+
+### Returned User fields
+
+- `id`
+- `nickname`
+- `email`
+- `name`
+
+### Reference
+
+- [Fablabs.io](https://fablabs.io/);
+- [OAuth authorization Docs](https://docs.fablabs.io/);

--- a/src/Fablabs/composer.json
+++ b/src/Fablabs/composer.json
@@ -1,0 +1,19 @@
+{
+    "name": "socialiteproviders/fablabs",
+    "description": "Fablabs.io OAuth2 Provider for Laravel Socialite",
+    "license": "MIT",
+    "authors": [{
+        "name": "Julian Gallimore",
+        "email": "it@fabacademy.org"
+    }],
+    "require": {
+        "php": "^7.2 || ^8.0",
+        "ext-json": "*",
+        "socialiteproviders/manager": "~4.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialiteProviders\\Fablabs\\": ""
+        }
+    }
+}


### PR DESCRIPTION
Adds support for using [fablabs.io](https://fablabs.io/about) as a login provider