### PR TITLE
Adds null fallback for avatar as zoom does not send it if it does not exist

### DIFF
--- a/src/Zoom/Provider.php
+++ b/src/Zoom/Provider.php
@@ -66,7 +66,7 @@ class Provider extends AbstractProvider
             'nickname' => $user['first_name'].' '.$user['last_name'],
             'name'     => $user['first_name'].' '.$user['last_name'],
             'email'    => $user['email'],
-            'avatar'   => $user['pic_url'],
+            'avatar'   => $user['pic_url'] ?? null,
         ]);
     }
 


### PR DESCRIPTION
Turns out Zoom does not send the `pic_url` field if you do not have one set in their platform 🤷 