### PR TITLE
Added Saml2 provider

### DIFF
--- a/monorepo-builder.yml
+++ b/monorepo-builder.yml
@@ -119,6 +119,7 @@ parameters:
     src/RunKeeper: 'git@github.com:SocialiteProviders/RunKeeper.git'
     src/Sage: 'git@github.com:SocialiteProviders/Sage.git'
     src/SalesForce: 'git@github.com:SocialiteProviders/SalesForce.git'
+    src/Saml2: 'git@github.com:SocialiteProviders/Saml2.git'
     src/SciStarter: 'git@github.com:SocialiteProviders/SciStarter.git'
     src/SharePoint: 'git@github.com:SocialiteProviders/SharePoint.git'
     src/Shopify: 'git@github.com:SocialiteProviders/Shopify.git'

--- a/src/Saml2/InvalidSignatureException.php
+++ b/src/Saml2/InvalidSignatureException.php
@@ -6,5 +6,4 @@ use InvalidArgumentException;
 
 class InvalidSignatureException extends InvalidArgumentException
 {
-    //
 }

--- a/src/Saml2/InvalidSignatureException.php
+++ b/src/Saml2/InvalidSignatureException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SocialiteProviders\Saml2;
+
+use InvalidArgumentException;
+
+class InvalidSignatureException extends InvalidArgumentException
+{
+    //
+}

--- a/src/Saml2/NotSupportedException.php
+++ b/src/Saml2/NotSupportedException.php
@@ -6,5 +6,4 @@ use InvalidArgumentException;
 
 class NotSupportedException extends InvalidArgumentException
 {
-    //
 }

--- a/src/Saml2/NotSupportedException.php
+++ b/src/Saml2/NotSupportedException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SocialiteProviders\Saml2;
+
+use InvalidArgumentException;
+
+class NotSupportedException extends InvalidArgumentException
+{
+    //
+}

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -55,14 +55,14 @@ class Provider extends AbstractProvider implements SocialiteProvider
     protected $user;
 
     /**
-     * The configuration
+     * The configuration.
      *
      * @var array
      */
     protected $config;
 
     const CACHE_KEY = 'socialite_saml2_metadata';
-    const CACHE_KEY_TTL = self::CACHE_KEY . '_ttl';
+    const CACHE_KEY_TTL = self::CACHE_KEY.'_ttl';
 
     public function __construct(Request $request)
     {
@@ -187,7 +187,6 @@ class Provider extends AbstractProvider implements SocialiteProvider
     }
 
     /**
-     * @return EntityDescriptor
      * @throws MissingConfigException
      * @throws GuzzleException
      */
@@ -209,9 +208,6 @@ class Provider extends AbstractProvider implements SocialiteProvider
         throw new MissingConfigException('Either the "metadata" or "acs" config keys must be set');
     }
 
-    /**
-     * @return EntityDescriptor
-     */
     public function getServiceProviderEntityDescriptor(): EntityDescriptor
     {
         $entityDescriptor = new EntityDescriptor();
@@ -269,11 +265,11 @@ class Provider extends AbstractProvider implements SocialiteProvider
         }
 
         if ($this->hasInvalidState()) {
-            throw new InvalidStateException;
+            throw new InvalidStateException();
         }
 
         if ($this->hasInvalidSignature()) {
-            throw new InvalidSignatureException;
+            throw new InvalidSignatureException();
         }
 
         $bindingFactory = new BindingFactory();
@@ -331,7 +327,7 @@ class Provider extends AbstractProvider implements SocialiteProvider
         );
 
         /** @var SignatureXmlReader $signatureReader */
-        $signatureReader = $this->getAssertionConsumerServiceBinding() === SamlConstants::BINDING_SAML2_HTTP_REDIRECT ?
+        $signatureReader = SamlConstants::BINDING_SAML2_HTTP_REDIRECT === $this->getAssertionConsumerServiceBinding() ?
             $messageContext->getMessage()->getSignature() :
             $messageContext->asResponse()->getFirstAssertion()->getSignature();
 
@@ -353,28 +349,29 @@ class Provider extends AbstractProvider implements SocialiteProvider
             ->setContent($serializationContext->getDocument()->saveXML());
     }
 
-    public function clearIdentityProviderMetadataCache() {
+    public function clearIdentityProviderMetadataCache()
+    {
         Cache::forget(self::CACHE_KEY);
         Cache::forget(self::CACHE_KEY_TTL);
     }
 
     protected function getTokenUrl()
     {
-        throw new NotSupportedException;
+        throw new NotSupportedException();
     }
 
     protected function getAuthUrl($state)
     {
-        throw new NotSupportedException;
+        throw new NotSupportedException();
     }
 
     protected function getUserByToken($token)
     {
-        throw new NotSupportedException;
+        throw new NotSupportedException();
     }
 
     protected function mapUserToObject(array $user)
     {
-        throw new NotSupportedException;
+        throw new NotSupportedException();
     }
 }

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -144,7 +144,7 @@ class Provider extends AbstractProvider implements SocialiteProvider
 
         /**
          * The SAML certificate may be provided as either a properly formatted certificate with header and line breaks
-         * or as a string containing only the body
+         * or as a string containing only the body.
          */
         if (Str::startsWith($certificate, '-----BEGIN CERTIFICATE-----')) {
             $x509->loadPem($certificate);

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -140,14 +140,17 @@ class Provider extends AbstractProvider implements SocialiteProvider
             throw new MissingConfigException('When using "acs", both "entityid" and "certificate" must be set');
         }
 
-        if (!Str::startsWith($certificate, '-----BEGIN CERTIFICATE-----')) {
-            $certificate = "-----BEGIN CERTIFICATE-----\r\n".
-                implode("\r\n", str_split($certificate, 80)).
-                "\r\n-----END CERTIFICATE-----\r\n";
-        }
-
         $x509 = new X509Certificate();
-        $x509->loadPem($certificate);
+
+        /**
+         * The SAML certificate may be provided as either a properly formatted certificate with header and line breaks
+         * or as a string containing only the body
+         */
+        if (Str::startsWith($certificate, '-----BEGIN CERTIFICATE-----')) {
+            $x509->loadPem($certificate);
+        } else {
+            $x509->setData($certificate);
+        }
 
         $builder = new SimpleEntityDescriptorBuilder($entityId, $acs, $acs, $x509);
 

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -34,6 +34,7 @@ use LightSaml\Model\Metadata\KeyDescriptor;
 use LightSaml\Model\Metadata\Metadata;
 use LightSaml\Model\Metadata\SpSsoDescriptor;
 use LightSaml\Model\Protocol\AuthnRequest;
+use LightSaml\Model\Protocol\NameIDPolicy;
 use LightSaml\Model\XmlDSig\SignatureXmlReader;
 use LightSaml\SamlConstants;
 use SocialiteProviders\Manager\Contracts\ConfigInterface;
@@ -118,6 +119,7 @@ class Provider extends AbstractProvider implements SocialiteProvider
             ->setRelayState($state)
             ->setIssueInstant(new DateTime())
             ->setDestination($identityProviderConsumerService->getLocation())
+            ->setNameIDPolicy((new NameIDPolicy())->setFormat(SamlConstants::NAME_ID_FORMAT_PERSISTENT))
             ->setIssuer(new Issuer($this->getServiceProviderEntityDescriptor()->getEntityID()));
 
         $redirectBinding = new HttpRedirectBinding();

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -324,17 +324,17 @@ class Provider extends AbstractProvider implements SocialiteProvider
             ->getFirstIdpSsoDescriptor()
             ->getAllKeyDescriptorsByUse(KeyDescriptor::USE_SIGNING);
 
+        /** @var SignatureXmlReader $signatureReader */
+        $signatureReader = SamlConstants::BINDING_SAML2_HTTP_REDIRECT === $this->getAssertionConsumerServiceBinding() ?
+            $messageContext->getMessage()->getSignature() :
+            $messageContext->asResponse()->getFirstAssertion()->getSignature();
+
+        if (!$signatureReader) {
+            return true;
+        }
+
         foreach ($keyDescriptors as $keyDescriptor) {
             $key = KeyHelper::createPublicKey($keyDescriptor->getCertificate());
-
-            /** @var SignatureXmlReader $signatureReader */
-            $signatureReader = SamlConstants::BINDING_SAML2_HTTP_REDIRECT === $this->getAssertionConsumerServiceBinding() ?
-                $messageContext->getMessage()->getSignature() :
-                $messageContext->asResponse()->getFirstAssertion()->getSignature();
-
-            if (!$signatureReader) {
-                continue;
-            }
 
             try {
                 if ($signatureReader->validate($key)) {

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -1,0 +1,353 @@
+<?php
+
+namespace SocialiteProviders\Saml2;
+
+use DateTime;
+use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Facades\Validator;
+use Laravel\Socialite\Contracts\Provider as SocialiteProvider;
+use Laravel\Socialite\Two\AbstractProvider;
+use Laravel\Socialite\Two\InvalidStateException;
+use LightSaml\Binding\BindingFactory;
+use LightSaml\Binding\HttpRedirectBinding;
+use LightSaml\Builder\EntityDescriptor\SimpleEntityDescriptorBuilder;
+use LightSaml\ClaimTypes;
+use LightSaml\Context\Profile\MessageContext;
+use LightSaml\Credential\KeyHelper;
+use LightSaml\Credential\X509Certificate;
+use LightSaml\Helper;
+use LightSaml\Model\Assertion\Issuer;
+use LightSaml\Model\Context\DeserializationContext;
+use LightSaml\Model\Context\SerializationContext;
+use LightSaml\Model\Metadata\AssertionConsumerService;
+use LightSaml\Model\Metadata\EntityDescriptor;
+use LightSaml\Model\Metadata\KeyDescriptor;
+use LightSaml\Model\Metadata\Metadata;
+use LightSaml\Model\Metadata\SpSsoDescriptor;
+use LightSaml\Model\Protocol\AuthnRequest;
+use LightSaml\Model\XmlDSig\SignatureXmlReader;
+use LightSaml\SamlConstants;
+use SocialiteProviders\Manager\Contracts\ConfigInterface;
+use SocialiteProviders\Manager\Exception\MissingConfigException;
+
+class Provider extends AbstractProvider implements SocialiteProvider
+{
+    /**
+     * The HTTP request instance.
+     *
+     * @var Request
+     */
+    protected $request;
+
+    /**
+     * The SAML2 User instance.
+     *
+     * @var User
+     */
+    protected $user;
+
+    /**
+     * The configuration
+     *
+     * @var array
+     */
+    protected $config;
+
+    public function __construct(Request $request)
+    {
+        parent::__construct($request, '', '', '');
+    }
+
+    public function setConfig(ConfigInterface $config): Provider
+    {
+        $config = $config->get();
+
+        $this->config = $config;
+
+        return $this;
+    }
+
+    public static function additionalConfigKeys(): array
+    {
+        return [
+            'client_id',
+            'client_secret',
+            'redirect',
+            'metadata',
+            'ttl',
+            'acs',
+            'entityid',
+            'certificate',
+            'sp_acs',
+        ];
+    }
+
+    protected function getConfig($key = null, $default = null)
+    {
+        if (!empty($key) && empty($this->config[$key])) {
+            return $default;
+        }
+
+        return $key ? Arr::get($this->config, $key, $default) : $this->config;
+    }
+
+    public function redirect()
+    {
+        $this->request->session()->put('state', $state = $this->getState());
+
+        $identityProviderConsumerService = $this->getIdentityProviderEntityDescriptor()
+            ->getFirstIdpSsoDescriptor()
+            ->getFirstSingleSignOnService(SamlConstants::BINDING_SAML2_HTTP_REDIRECT);
+
+        $authnRequest = new AuthnRequest();
+        $authnRequest
+            ->setID(Helper::generateID())
+            ->setProtocolBinding($this->getAssertionConsumerServiceBinding())
+            ->setRelayState($state)
+            ->setIssueInstant(new DateTime())
+            ->setDestination($identityProviderConsumerService->getLocation())
+            ->setIssuer(new Issuer($this->getServiceProviderEntityDescriptor()->getEntityID()));
+
+        $redirectBinding = new HttpRedirectBinding();
+
+        $messageContext = new MessageContext();
+        $messageContext->setMessage($authnRequest);
+
+        return $redirectBinding->send($messageContext);
+    }
+
+    protected function getIdentityProviderEntityDescriptorManually(): EntityDescriptor
+    {
+        $acs = $this->getConfig('acs');
+        $entityId = $this->getConfig('entityid');
+        $certificate = $this->getConfig('certificate');
+
+        if (!$entityId || !$certificate) {
+            throw new MissingConfigException('When using "acs", both "entityid" and "certificate" must be set');
+        }
+
+        $x509 = new X509Certificate();
+        $x509->loadPem($certificate);
+
+        $builder = new SimpleEntityDescriptorBuilder($entityId, $acs, '', $x509);
+
+        return $builder->get();
+    }
+
+    protected function getIdentityProviderEntityDescriptorFromXml(): EntityDescriptor
+    {
+        return Metadata::fromXML($this->getConfig('metadata'), new DeserializationContext());
+    }
+
+    protected function getIdentityProviderEntityDescriptorFromUrl(): EntityDescriptor
+    {
+        $key = 'socialite.saml2.metadata';
+        $fetchTimeKey = $key.'.ttl';
+
+        $metadataUrl = $this->getConfig('metadata');
+        $xml = Cache::get($key);
+        $ttl = Cache::get($fetchTimeKey);
+
+        $deserializationContext = new DeserializationContext();
+
+        if ($xml && $ttl && $ttl + $this->getConfig('ttl', 86400) < time()) {
+            return Metadata::fromXML($xml, $deserializationContext);
+        }
+
+        Cache::forever($fetchTimeKey, time());
+
+        try {
+            $xml = $this->getHttpClient()
+                ->get($metadataUrl)
+                ->getBody()
+                ->getContents();
+
+            Cache::forever($key, $xml);
+        } catch (GuzzleException $e) {
+            if (!$xml) {
+                throw $e;
+            }
+        }
+
+        return Metadata::fromXML($xml, $deserializationContext);
+    }
+
+    /**
+     * @return EntityDescriptor
+     * @throws MissingConfigException
+     * @throws GuzzleException
+     */
+    public function getIdentityProviderEntityDescriptor(): EntityDescriptor
+    {
+        if ($this->getConfig('acs')) {
+            return $this->getIdentityProviderEntityDescriptorManually();
+        }
+
+        $metadata = $this->getConfig('metadata');
+        if ($metadata) {
+            if (!Validator::make(['u' => $metadata], ['u' => 'url'])->fails()) {
+                return $this->getIdentityProviderEntityDescriptorFromUrl();
+            } else {
+                return $this->getIdentityProviderEntityDescriptorFromXml();
+            }
+        }
+
+        throw new MissingConfigException('Either the "metadata" or "acs" config keys must be set');
+    }
+
+    public function getServiceProviderEntityDescriptor(): EntityDescriptor
+    {
+        $entityDescriptor = new EntityDescriptor();
+        $entityDescriptor
+            ->setEntityID(URL::to('auth/saml2'))
+            ->addItem(
+                (new SpSsoDescriptor())
+                    ->setWantAssertionsSigned(true)
+                    ->addAssertionConsumerService(
+                        (new AssertionConsumerService())
+                            ->setBinding($this->getAssertionConsumerServiceBinding())
+                            ->setLocation(URL::to($this->getAssertionConsumerServiceRoute()))
+                    )
+            );
+
+        return $entityDescriptor;
+    }
+
+    public function getServiceProviderAssertionConsumerUrl()
+    {
+        return $this->getServiceProviderEntityDescriptor()
+            ->getFirstSpSsoDescriptor()
+            ->getFirstAssertionConsumerService()
+            ->getLocation();
+    }
+
+    public function getServiceProviderEntityId()
+    {
+        return $this->getServiceProviderEntityDescriptor()
+            ->getEntityID();
+    }
+
+    protected function getAssertionConsumerServiceRoute(): string
+    {
+        return $this->getConfig('sp_acs', 'auth/callback');
+    }
+
+    protected function getAssertionConsumerServiceBinding(): string
+    {
+        return Arr::has(
+            Route::getRoutes()->getRoutesByMethod(),
+            'GET.'.$this->getAssertionConsumerServiceRoute()
+        ) ?
+            SamlConstants::BINDING_SAML2_HTTP_REDIRECT :
+            SamlConstants::BINDING_SAML2_HTTP_POST;
+    }
+
+    public function user()
+    {
+        if ($this->user) {
+            return $this->user;
+        }
+
+        if ($this->hasInvalidState()) {
+            throw new InvalidStateException;
+        }
+
+        if ($this->hasInvalidSignature()) {
+            throw new InvalidSignatureException;
+        }
+
+        $bindingFactory = new BindingFactory();
+        $binding = $bindingFactory->getBindingByRequest($this->request);
+
+        $messageContext = new MessageContext();
+        $binding->receive($this->request, $messageContext);
+
+        $assertion = $messageContext->asResponse()->getFirstAssertion();
+        $attributeStatement = $assertion->getFirstAttributeStatement();
+
+        $this->user = new User();
+        $this->user->setAssertion($assertion);
+        $this->user->map(['id' => $assertion->getSubject()->getNameID()->getValue()]);
+
+        if ($attributeStatement) {
+            foreach (['name' => ClaimTypes::NAME, 'email' => ClaimTypes::EMAIL_ADDRESS] as $key => $claim) {
+                if ($attribute = $attributeStatement->getFirstAttributeByName($claim)) {
+                    $this->user->map([$key => $attribute->getFirstAttributeValue()]);
+                }
+            }
+
+            $this->user->setRaw($attributeStatement->getAllAttributes());
+        }
+
+        return $this->user;
+    }
+
+    protected function hasInvalidState(): bool
+    {
+        $state = $this->request->session()->pull('state');
+
+        $bindingFactory = new BindingFactory();
+        $binding = $bindingFactory->getBindingByRequest($this->request);
+
+        $messageContext = new MessageContext();
+        $binding->receive($this->request, $messageContext);
+
+        return $state !== $messageContext->getMessage()->getRelayState();
+    }
+
+    protected function hasInvalidSignature(): bool
+    {
+        $bindingFactory = new BindingFactory();
+        $binding = $bindingFactory->getBindingByRequest($this->request);
+
+        $messageContext = new MessageContext();
+        $binding->receive($this->request, $messageContext);
+
+        $key = KeyHelper::createPublicKey(
+            $this->getIdentityProviderEntityDescriptor()
+                ->getFirstIdpSsoDescriptor()
+                ->getFirstKeyDescriptor(KeyDescriptor::USE_SIGNING)
+                ->getCertificate()
+        );
+
+        /** @var SignatureXmlReader $signatureReader */
+        $signatureReader = $this->getAssertionConsumerServiceBinding() === SamlConstants::BINDING_SAML2_HTTP_REDIRECT ?
+            $messageContext->getMessage()->getSignature() :
+            $messageContext->asResponse()->getFirstAssertion()->getSignature();
+
+        return !$signatureReader->validate($key);
+    }
+
+    public function getServiceProviderMetadata(): Response
+    {
+        $entityDescriptor = $this->getServiceProviderEntityDescriptor();
+        $serializationContext = new SerializationContext();
+        $entityDescriptor->serialize($serializationContext->getDocument(), $serializationContext);
+
+        return (new Response())
+            ->header('content-type', 'application/samlmetadata+xml')
+            ->setContent($serializationContext->getDocument()->saveXML());
+    }
+
+    protected function getTokenUrl()
+    {
+    }
+
+    protected function getAuthUrl($state)
+    {
+    }
+
+    protected function getUserByToken($token)
+    {
+    }
+
+    protected function mapUserToObject(array $user)
+    {
+    }
+}

--- a/src/Saml2/README.md
+++ b/src/Saml2/README.md
@@ -157,3 +157,13 @@ The entity ID and assertion consumer URL of the service provider can also be pro
 Socialite::driver('saml2')->getServiceProviderEntityId()
 Socialite::driver('saml2')->getServiceProviderAssertionConsumerUrl()
 ```
+
+### User attributes and Name ID
+
+By SAML convention, the "Name ID" sent by the identity provider is used as the ID in the `User` class instance returned in the callback.
+
+The two well-known SAML attributes 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name' and 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress' are mapped into Name and Email Address respectively in the `User` class.
+
+All other attributes returned by the identity provider are stored in the "raw" property of the `User` class and can be retrieved with `$user->getRaw()`.
+
+The entire assertion is also stored in the `User` instance and can be retrieved with `$user->getAssertion()`.

--- a/src/Saml2/README.md
+++ b/src/Saml2/README.md
@@ -1,0 +1,42 @@
+# Saml2
+
+```bash
+composer require socialiteproviders/saml2
+```
+
+## Installation & Basic Usage
+
+Please see the [Base Installation Guide](https://socialiteproviders.com/usage/), then follow the provider specific instructions below.
+
+### Add configuration to `config/services.php`
+
+```php
+'saml2' => [
+  'client_id' => env('SAML2_CLIENT_ID'),
+  'client_secret' => env('SAML2_CLIENT_SECRET'),
+  'redirect' => env('SAML2_REDIRECT_URI')
+],
+```
+
+### Add provider event listener
+
+Configure the package's listener to listen for `SocialiteWasCalled` events.
+
+Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. See the [Base Installation Guide](https://socialiteproviders.com/usage/) for detailed instructions.
+
+```php
+protected $listen = [
+    \SocialiteProviders\Manager\SocialiteWasCalled::class => [
+        // ... other providers
+        'SocialiteProviders\\Saml2\\Saml2ExtendSocialite@handle',
+    ],
+];
+```
+
+### Usage
+
+You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
+
+```php
+return Socialite::driver('saml2')->redirect();
+```

--- a/src/Saml2/Saml2ExtendSocialite.php
+++ b/src/Saml2/Saml2ExtendSocialite.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SocialiteProviders\Saml2;
+
+use SocialiteProviders\Manager\SocialiteWasCalled;
+
+class Saml2ExtendSocialite
+{
+    /**
+     * Register the provider.
+     *
+     * @param  SocialiteWasCalled  $socialiteWasCalled
+     */
+    public function handle(SocialiteWasCalled $socialiteWasCalled)
+    {
+        $socialiteWasCalled->extendSocialite('saml2', Provider::class);
+    }
+}

--- a/src/Saml2/Saml2ExtendSocialite.php
+++ b/src/Saml2/Saml2ExtendSocialite.php
@@ -8,8 +8,6 @@ class Saml2ExtendSocialite
 {
     /**
      * Register the provider.
-     *
-     * @param  SocialiteWasCalled  $socialiteWasCalled
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {

--- a/src/Saml2/User.php
+++ b/src/Saml2/User.php
@@ -21,4 +21,3 @@ class User extends AbstractUser
         return $this;
     }
 }
-

--- a/src/Saml2/User.php
+++ b/src/Saml2/User.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SocialiteProviders\Saml2;
+
+use Laravel\Socialite\AbstractUser;
+use LightSaml\Model\Assertion\Assertion;
+
+class User extends AbstractUser
+{
+    protected $assertion;
+
+    public function getAssertion(): Assertion
+    {
+        return $this->assertion;
+    }
+
+    public function setAssertion(Assertion $assertion): User
+    {
+        $this->assertion = $assertion;
+
+        return $this;
+    }
+}
+

--- a/src/Saml2/composer.json
+++ b/src/Saml2/composer.json
@@ -1,0 +1,22 @@
+{
+    "name": "socialiteproviders/saml2",
+    "description": "SAML2 Service Provider for Laravel Socialite",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Chris Lloyd",
+            "email": "chrislloyd403@gmail.com"
+        }
+    ],
+    "require": {
+        "php": "^7.2 || ^8.0",
+        "ext-json": "*",
+        "socialiteproviders/manager": "~4.0",
+        "dropbox/lightsaml": "^2.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialiteProviders\\Saml2\\": ""
+        }
+    }
+}


### PR DESCRIPTION
This is not an OAuth provider, but it does meet the Socialite specification in terms of implementing the contract by extending `Laravel\Socialite\Two\AbstractProvider`, implementing `Laravel\Socialite\Contracts\Provider` and following the same configuration method.

For testing you should be able to use any SAML provider (Google, Azure), but there is a test service that works here too: https://samltest.id

https://samltest.id is a good example of a service that doesn't implement the HTTP-Redirect part of the specification, as noted in the "SAML Protocol" part of the README.md, but Google, Azure and many others do.

For testing this with samltest.id:
* Install the provider, and configure according to the docs using `https://samltest.id/saml/idp` as the `metadata` value
* Expose the Laravel app using ngrok or similar, setting `$proxies = '*'` in `TrustProxies.php` for the purposes of testing.
* Add the metadata route in Laravel (see docs)
* Change the callback route to use POST (required by samltest.id), and add the callback to the Csrf exception list in `VerifyCsrfToken.php` if you are using the web.php routes file
* Submit the metadata URL (https://xyz.ngrok.io/auth/saml2/metadata) to https://samltest.id/upload.php
* Access https://xyz.ngrok.io/auth/redirect in your browser to start the flow.