### PR TITLE
Allow Okta Auth Server ID to be empty for use with Okta OIDC app integration

### DIFF
--- a/src/Okta/Provider.php
+++ b/src/Okta/Provider.php
@@ -45,7 +45,7 @@ class Provider extends AbstractProvider
     }
 
     /**
-     * Returns the Auth Server ID based on config option 'auth_server_id'
+     * Returns the Auth Server ID based on config option 'auth_server_id'.
      *
      * @return string
      */
@@ -53,11 +53,11 @@ class Provider extends AbstractProvider
     {
         $auth_server_id = $this->getConfig('auth_server_id', null);
 
-        if($auth_server_id) {
-            return $auth_server_id . "/";
+        if ($auth_server_id) {
+            return $auth_server_id.'/';
         }
 
-        return "";
+        return '';
     }
 
     /**

--- a/src/Okta/Provider.php
+++ b/src/Okta/Provider.php
@@ -45,11 +45,19 @@ class Provider extends AbstractProvider
     }
 
     /**
-     * {@inheritdoc}
+     * Returns the Auth Server ID based on config option 'auth_server_id'
+     *
+     * @return string
      */
     protected function getAuthServerId()
     {
-        return $this->getConfig('auth_server_id', 'default');
+        $auth_server_id = $this->getConfig('auth_server_id', null);
+
+        if($auth_server_id) {
+            return $auth_server_id . "/";
+        }
+
+        return "";
     }
 
     /**
@@ -65,7 +73,7 @@ class Provider extends AbstractProvider
      */
     protected function getAuthUrl($state)
     {
-        return $this->buildAuthUrlFromBase($this->getOktaUrl().'/oauth2/'.$this->getAuthServerId().'/v1/authorize', $state);
+        return $this->buildAuthUrlFromBase($this->getOktaUrl().'/oauth2/'.$this->getAuthServerId().'v1/authorize', $state);
     }
 
     /**
@@ -81,7 +89,7 @@ class Provider extends AbstractProvider
      */
     protected function getUserByToken($token)
     {
-        $response = $this->getHttpClient()->get($this->getOktaUrl().'/oauth2/'.$this->getAuthServerId().'/v1/userinfo', [
+        $response = $this->getHttpClient()->get($this->getOktaUrl().'/oauth2/'.$this->getAuthServerId().'v1/userinfo', [
             'headers' => [
                 'Authorization' => 'Bearer '.$token,
             ],

--- a/src/Okta/README.md
+++ b/src/Okta/README.md
@@ -21,7 +21,9 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
 
 #### Custom Auth Server
 
-If you're using a custom auth server, pass the `auth_server_id` config option. For more information, see the [okta docs](https://developer.okta.com/docs/concepts/auth-servers/).
+If you're using Okta Developer you should set `auth_server_id` config option appropriately. It should be set to "default", or to the server id of your Custom Authorization Server.
+
+For more information, see the [okta docs](https://developer.okta.com/docs/concepts/auth-servers/).
 
 ### Add provider event listener
 


### PR DESCRIPTION
This PR fixes a recent change (https://github.com/SocialiteProviders/Providers/pull/520) that broke existing functionality for Okta users who do not use a custom Auth Server ID or the Okta Developer product.

### Background

The changes in the above PR were valid for users of the Okta Developer (https://developer.okta.com/) product but caused a breaking change for users of Okta (https://www.okta.com/uk/workforce-identity/).

Specifically it is the Okta OIDC connect integration that is now broken due to the inability to set an empty `auth_server_id` as there is an extra `/` present in the URL. 

Details of the Okta OIDC integrations can be found on the help page here: https://help.okta.com/en/prod/Content/Topics/Apps/Apps_App_Integration_Wizard_OIDC.htm

Based on the `.well-known/openid-configuration` for an Okta tenant you can see the `/oauth2/v1/` format does not match the current default of `/oauth2/default/v1/`:

```
"issuer":"https://example.okta.com"
"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"
"token_endpoint":"https://example.okta.com/oauth2/v1/token"
```

### Justification for change

The previous PR added useful functionality but was a breaking change for existing Okta users.

The changes in this PR will restore the original working behaviour while:

- Not affecting users with an `auth_server_id` option set
- Providing updated instructions for Okta Developer users who may need to set `default` in their config