### PR TITLE
Fix indice avatar with null in mercado libre provider

### DIFF
--- a/src/MercadoLibre/Provider.php
+++ b/src/MercadoLibre/Provider.php
@@ -88,7 +88,7 @@ class Provider extends AbstractProvider
             'nickname' => $user['nickname'],
             'name'     => $user['first_name'].' '.$user['last_name'],
             'email'    => $user['email'],
-            'avatar'   => $user['thumbnail']['picture_url'],
+            'avatar'   => $user['thumbnail']['picture_url'] ?? null,
         ]);
     }
 


### PR DESCRIPTION
I realized that returns from the free market are not sending the thumbnail index so I set it to null if these indexes do not arrive because I was returning an error when trying to retrieve the authenticated user's data.

I would like you to evaluate this PR, and see if this change is valid.