### PR TITLE
fix: HubSpot compatibility problem with joelbutcher/socialstream

### DIFF
--- a/src/HubSpot/Provider.php
+++ b/src/HubSpot/Provider.php
@@ -58,7 +58,7 @@ class Provider extends AbstractProvider
         return (new User())->setRaw($user)->map([
             'nickname' => null, 'name' => '',
             'email'    => $user['user'], 'avatar' => null,
-            'id'       => $user['user_id']
+            'id'       => $user['user_id'],
         ]);
     }
 

--- a/src/HubSpot/Provider.php
+++ b/src/HubSpot/Provider.php
@@ -5,6 +5,9 @@ namespace SocialiteProviders\HubSpot;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
+/** 
+ * @see https://legacydocs.hubspot.com/docs/methods/oauth2/oauth2-overview
+ */
 class Provider extends AbstractProvider
 {
     /**

--- a/src/HubSpot/Provider.php
+++ b/src/HubSpot/Provider.php
@@ -5,7 +5,7 @@ namespace SocialiteProviders\HubSpot;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
-/** 
+/**
  * @see https://legacydocs.hubspot.com/docs/methods/oauth2/oauth2-overview
  */
 class Provider extends AbstractProvider
@@ -59,8 +59,10 @@ class Provider extends AbstractProvider
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([
-            'nickname' => null, 'name' => '',
-            'email'    => $user['user'], 'avatar' => null,
+            'nickname' => null,
+            'name'     => null,
+            'email'    => $user['user'],
+            'avatar'   => null,
             'id'       => $user['user_id'],
         ]);
     }

--- a/src/HubSpot/Provider.php
+++ b/src/HubSpot/Provider.php
@@ -56,9 +56,9 @@ class Provider extends AbstractProvider
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([
-            'nickname' => null, 'name' => "",
+            'nickname' => null, 'name' => '',
             'email'    => $user['user'], 'avatar' => null,
-            'id' => $user['user_id']
+            'id'       => $user['user_id']
         ]);
     }
 

--- a/src/HubSpot/Provider.php
+++ b/src/HubSpot/Provider.php
@@ -56,8 +56,9 @@ class Provider extends AbstractProvider
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([
-            'nickname' => null, 'name' => null,
+            'nickname' => null, 'name' => "",
             'email'    => $user['user'], 'avatar' => null,
+            'id' => $user['user_id']
         ]);
     }
 


### PR DESCRIPTION
The database table "connected_accounts" in joelbutcher/socialstream require a name and function "findConnectedAccountForProviderAndId" requires an ID user from provider.

fix: https://github.com/SocialiteProviders/Providers/issues/640



