### PR TITLE
[Apple] Add support for a `user` as an associative array in Apple provider

### DIFF
--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -202,19 +202,15 @@ class Provider extends AbstractProvider
      */
     protected function mapUserToObject(array $user)
     {
-        $value = trim((string) $this->request->input('user'));
+        $userRequest = $this->getUserRequest();
 
-        if ($value !== '') {
-            $userRequest = json_decode($value, true);
-
-            if (isset($userRequest['name'])) {
-                $user['name'] = $userRequest['name'];
-                $fullName = trim(
-                    ($user['name']['firstName'] ?? '')
-                    .' '
-                    .($user['name']['lastName'] ?? '')
-                );
-            }
+        if (isset($userRequest['name'])) {
+            $user['name'] = $userRequest['name'];
+            $fullName = trim(
+                ($user['name']['firstName'] ?? '')
+                .' '
+                .($user['name']['lastName'] ?? '')
+            );
         }
 
         return (new User())
@@ -224,5 +220,22 @@ class Provider extends AbstractProvider
                 'name'  => $fullName ?? null,
                 'email' => $user['email'] ?? null,
             ]);
+    }
+
+    private function getUserRequest(): array
+    {
+        $value = $this->request->input('user');
+
+        if (is_array($value)) {
+            return $value;
+        }
+
+        $value = trim((string) $value);
+
+        if ($value === '') {
+            return [];
+        }
+
+        return json_decode($value, true);
     }
 }


### PR DESCRIPTION
I'm currently using the Apple provider for social login from a mobile app, which communicates with a Laravel API at the back-end.
The app authenticates with Apple first, and I verify with Apple (with Socialite) that the app is sending valid IDs and name, before persisting the state in a DB.

I'm facing an issue whereas the Apple provider at https://github.com/SocialiteProviders/Providers/blob/master/src/Apple/Provider.php#L205 tries to cast to string (to be later JSON-decoded) an associative array, which makes Socialite crash at that line with an error `Array to string conversion`

This PR aims at catching that case, together with isolating the logic for getting the user from the request.

Let me know if there is anything I need/can do in terms of CI/tests :)

Closes #643 