### PR TITLE
Do not allow class property typing.

### DIFF
--- a/src/Adobe/Provider.php
+++ b/src/Adobe/Provider.php
@@ -15,7 +15,7 @@ class Provider extends AbstractProvider implements ProviderInterface
     public const IDENTIFIER = 'ADOBE';
     public const BASE_URL = 'https://ims-na1.adobelogin.com/ims';
 
-    protected array $scopes = ['openid', 'email', 'profile'];
+    protected $scopes = ['openid', 'email', 'profile'];
 
     protected function getAuthUrl($state): string
     {


### PR DESCRIPTION
Do not allow class property typing!
This feature was only introduced with PHP7.4 and this package supports PHP7.2 