### PR TITLE
Fixed Flickr doesn't recognise the permission set

### DIFF
--- a/src/Flickr/Server.php
+++ b/src/Flickr/Server.php
@@ -33,7 +33,7 @@ class Server extends BaseServer
         $authorizeUrl = 'https://www.flickr.com/services/oauth/authorize';
 
         if ($perms = $this->getConfig('perms')) {
-            return $authorizeUrl."?perms={$perms}";
+            return "{$authorizeUrl}?perms={$perms}";
         }
 
         return $authorizeUrl;

--- a/src/Flickr/Server.php
+++ b/src/Flickr/Server.php
@@ -22,7 +22,9 @@ class Server extends BaseServer
      */
     public function urlAuthorization()
     {
-        return 'https://www.flickr.com/services/oauth/authorize';
+        $perms = env('FLICKR_AUTHORIZATION_PERMS');
+
+        return 'https://www.flickr.com/services/oauth/authorize'.($perms ? "?perms={$perms}" : '');
     }
 
     /**

--- a/src/Flickr/Server.php
+++ b/src/Flickr/Server.php
@@ -12,6 +12,14 @@ class Server extends BaseServer
     /**
      * {@inheritdoc}
      */
+    public static function additionalConfigKeys()
+    {
+        return ['perms'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function urlTemporaryCredentials()
     {
         return 'https://www.flickr.com/services/oauth/request_token';
@@ -22,9 +30,13 @@ class Server extends BaseServer
      */
     public function urlAuthorization()
     {
-        $perms = env('FLICKR_AUTHORIZATION_PERMS');
+        $authorizeUrl = 'https://www.flickr.com/services/oauth/authorize';
 
-        return 'https://www.flickr.com/services/oauth/authorize'.($perms ? "?perms={$perms}" : '');
+        if ($perms = $this->getConfig('perms')) {
+            return $authorizeUrl."?perms={$perms}";
+        }
+
+        return $authorizeUrl;
     }
 
     /**


### PR DESCRIPTION
Currently when using Flickr it will result in the error: "Oops! Flickr doesn't recognise the permission set." - The authorize URL must have perms specified on it:

https://www.flickr.com/groups/51035612836@N01/discuss/72157692896948105/

Docs are here:

https://www.flickr.com/services/api/auth.oauth.html

I have verified that once this is added everything works correctly again.

