### PR TITLE
Remove useless class properties

### DIFF
--- a/src/Fablabs/Provider.php
+++ b/src/Fablabs/Provider.php
@@ -15,11 +15,6 @@ class Provider extends AbstractProvider
     /**
      * {@inheritdoc}
      */
-    protected $scopes = [];
-
-    /**
-     * {@inheritdoc}
-     */
     protected $scopeSeparator = ' ';
 
     /**

--- a/src/Gitea/Provider.php
+++ b/src/Gitea/Provider.php
@@ -15,11 +15,6 @@ class Provider extends AbstractProvider
     /**
      * {@inheritdoc}
      */
-    protected $scopes = [];
-
-    /**
-     * {@inheritdoc}
-     */
     protected $scopeSeparator = ' ';
 
     /**

--- a/src/Pixnet/Provider.php
+++ b/src/Pixnet/Provider.php
@@ -18,11 +18,6 @@ class Provider extends AbstractProvider
     /**
      * {@inheritdoc}
      */
-    protected $scopes = [];
-
-    /**
-     * {@inheritdoc}
-     */
     protected function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase('https://emma.pixnet.cc/oauth2/authorize', $state);


### PR DESCRIPTION
Those properties are overridden with the same values and can be safely removed.