### PR TITLE
Adding missing configuration value to Quickbooks readme

### DIFF
--- a/src/QuickBooks/README.md
+++ b/src/QuickBooks/README.md
@@ -15,7 +15,7 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
   'client_id' => env('QUICKBOOKS_CLIENT_ID'),
   'client_secret' => env('QUICKBOOKS_CLIENT_SECRET'),
   'redirect' => env('QUICKBOOKS_REDIRECT_URI'),
-  'env' => env('APP_ENV'),
+  'env' => env('QUICKBOOKS_ENV'),
 ],
 ```
 

--- a/src/QuickBooks/README.md
+++ b/src/QuickBooks/README.md
@@ -11,10 +11,11 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
 ### Add configuration to `config/services.php`
 
 ```php
-'quickbooks' => [    
-  'client_id' => env('QUICKBOOKS_CLIENT_ID'),  
-  'client_secret' => env('QUICKBOOKS_CLIENT_SECRET'),  
-  'redirect' => env('QUICKBOOKS_REDIRECT_URI') 
+'quickbooks' => [
+  'client_id' => env('QUICKBOOKS_CLIENT_ID'),
+  'client_secret' => env('QUICKBOOKS_CLIENT_SECRET'),
+  'redirect' => env('QUICKBOOKS_REDIRECT_URI'),
+  'env' => env('APP_ENV'),
 ],
 ```
 

--- a/src/QuickBooks/README.md
+++ b/src/QuickBooks/README.md
@@ -19,6 +19,8 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
 ],
 ```
 
+The `env`-value should be `development` for the sandbox environment and `production` for production environment.
+
 ### Add provider event listener
 
 Configure the package's listener to listen for `SocialiteWasCalled` events.


### PR DESCRIPTION
Hey,

I've noticed that an important parameter is missing. Without `env`, you can't actually test it locally as the production environment will be called. The PR adds a hint on the parameter and a note explaining the purpose. Might save someone else a few hours.

Cheers,
Peter