### PR TITLE
Removed extra slash from Okta token URL when auth_server_id config value is null

### DIFF
--- a/src/Okta/Provider.php
+++ b/src/Okta/Provider.php
@@ -81,7 +81,7 @@ class Provider extends AbstractProvider
      */
     protected function getTokenUrl()
     {
-        return $this->getOktaUrl().'/oauth2/'.$this->getAuthServerId().'/v1/token';
+        return $this->getOktaUrl().'/oauth2/'.$this->getAuthServerId().'v1/token';
     }
 
     /**


### PR DESCRIPTION
The following error is thrown when exchanging a code created at the standard Okta Authorization Server because the URLs don't match.

`https://dev-ID.okta.com/oauth2/v1` VS `https://dev-ID.okta.com/oauth2//v1`

![111229386-6f693600-85ab-11eb-9c26-36daaba29484](https://user-images.githubusercontent.com/6536955/116935529-50863800-ac1b-11eb-817d-4b90ffbe6327.png)

The other (authorize and userinfo) endpoints already handle this conditional inclusion of the slash properly.

Thanks

