### PR TITLE
Fix OKTA token URL.

### DIFF
--- a/src/Okta/Provider.php
+++ b/src/Okta/Provider.php
@@ -61,6 +61,16 @@ class Provider extends AbstractProvider
     }
 
     /**
+     * Get the Okta sever URL.
+     *
+     * @return string
+     */
+    protected function getOktaServerUrl(): string
+    {
+        return $this->getOktaUrl().'/oauth2/'.$this->getAuthServerId();
+    }
+
+    /**
      * {@inheritdoc}
      */
     public static function additionalConfigKeys()
@@ -73,7 +83,7 @@ class Provider extends AbstractProvider
      */
     protected function getAuthUrl($state)
     {
-        return $this->buildAuthUrlFromBase($this->getOktaUrl().'/oauth2/'.$this->getAuthServerId().'v1/authorize', $state);
+        return $this->buildAuthUrlFromBase($this->getOktaServerUrl().'v1/authorize', $state);
     }
 
     /**
@@ -81,7 +91,7 @@ class Provider extends AbstractProvider
      */
     protected function getTokenUrl()
     {
-        return $this->getOktaUrl().'/oauth2/'.$this->getAuthServerId().'/v1/token';
+        return $this->getOktaServerUrl().'v1/token';
     }
 
     /**
@@ -89,7 +99,7 @@ class Provider extends AbstractProvider
      */
     protected function getUserByToken($token)
     {
-        $response = $this->getHttpClient()->get($this->getOktaUrl().'/oauth2/'.$this->getAuthServerId().'v1/userinfo', [
+        $response = $this->getHttpClient()->get($this->getOktaServerUrl().'v1/userinfo', [
             'headers' => [
                 'Authorization' => 'Bearer '.$token,
             ],

--- a/src/Okta/Provider.php
+++ b/src/Okta/Provider.php
@@ -51,13 +51,9 @@ class Provider extends AbstractProvider
      */
     protected function getAuthServerId()
     {
-        $auth_server_id = $this->getConfig('auth_server_id', null);
+        $authServerId = (string) $this->getConfig('auth_server_id');
 
-        if ($auth_server_id) {
-            return $auth_server_id.'/';
-        }
-
-        return '';
+        return $authServerId === '' ? $authServerId : $authServerId.'/';
     }
 
     /**


### PR DESCRIPTION
This PR attempts to fix https://github.com/SocialiteProviders/Providers/pull/672
This typically happens when no `auth_server_id` has been set