### PR TITLE
Change teamleader urls to focus.teamleader.eu

### DIFF
--- a/src/Teamleader/Provider.php
+++ b/src/Teamleader/Provider.php
@@ -22,7 +22,7 @@ class Provider extends AbstractProvider
      */
     protected function getAuthUrl($state)
     {
-        return $this->buildAuthUrlFromBase('https://app.teamleader.eu/oauth2/authorize', $state);
+        return $this->buildAuthUrlFromBase('https://focus.teamleader.eu/oauth2/authorize', $state);
     }
 
     /**
@@ -30,7 +30,7 @@ class Provider extends AbstractProvider
      */
     protected function getTokenUrl()
     {
-        return 'https://app.teamleader.eu/oauth2/access_token';
+        return 'https://focus.teamleader.eu/oauth2/access_token';
     }
 
     /**
@@ -38,7 +38,7 @@ class Provider extends AbstractProvider
      */
     protected function getUserByToken($token)
     {
-        $response = $this->getHttpClient()->get('https://api.teamleader.eu/users.me', [
+        $response = $this->getHttpClient()->get('https://api.focus.teamleader.eu/users.me', [
             'headers' => [
                 'Authorization' => 'Bearer '.$token,
             ],


### PR DESCRIPTION
The Teamleader application has been renamed to Teamleader Focus, more info about this can be found [here](https://www.teamleader.eu/blog/new-names-teamleader-focus-orbit). This product name change also means that the application, api, marketplace, etc. have a new home under [focus.teamleader.eu](https://focus.teamleader.eu).

This PR changes the Teamleader URLs in this repo to point to [focus.teamleader.eu](https://focus.teamleader.eu). The switch to these new URLs isn't urgent though, the old URLs will remain available for some time.