### PR TITLE
Checking for tenant config throws warning in PHP 7.4

### DIFF
--- a/src/Azure/Provider.php
+++ b/src/Azure/Provider.php
@@ -32,7 +32,7 @@ class Provider extends AbstractProvider
     protected function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase(
-            'https://login.microsoftonline.com/'.(isset($this->config['tenant']) ? $this->config['tenant'] : 'common').'/oauth2/authorize',
+            'https://login.microsoftonline.com/'.($this->config['tenant'] ?? 'common').'/oauth2/authorize',
             $state
         );
     }

--- a/src/Azure/Provider.php
+++ b/src/Azure/Provider.php
@@ -32,7 +32,7 @@ class Provider extends AbstractProvider
     protected function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase(
-            'https://login.microsoftonline.com/'.($this->config['tenant'] ?: 'common').'/oauth2/authorize',
+            'https://login.microsoftonline.com/'.(isset($this->config['tenant']) ? $this->config['tenant'] : 'common').'/oauth2/authorize',
             $state
         );
     }


### PR DESCRIPTION
When we switched from PHP 7.3 to 7.4.20 we started getting an error message with the Azure Service Provider. It appears that in PHP 7.3 the code `$this->config['tenant'] ?: 'common'` resulted in a notice but in 7.4 it throws a warning which results in a 500 error. Adding an `isset()` check for the tenant property fixes the problem.

Error message when tenant config is not set:
```
2021-06-11 18:07:21] staging.ERROR: Trying to access array offset on value of type null {"exception":"[object] (ErrorException(code: 0): Trying to access array offset on value of type null at /var/www/html/vendor/socialiteproviders/microsoft-azure/Provider.php:35)
```