### PR TITLE
Remove unused code on Stripe provider

### DIFF
--- a/src/Stripe/Provider.php
+++ b/src/Stripe/Provider.php
@@ -64,10 +64,6 @@ class Provider extends AbstractProvider
         } elseif (isset($user['display_name'])) { // original location
             $nickname = $user['display_name'];
         }
-        $email = null;
-        if (isset($user['email'])) {
-            $email = $user['email'];
-        }
 
         return (new User())->setRaw($user)->map([
             'id'       => $user['id'],


### PR DESCRIPTION
The $email variable was not being used anywhere, Imho there is no need for the extra verbosity unless a case where there might be different api versions or similar like the display name

