### PR TITLE
Move Flickr additionalConfigKeys to Provider so that it sets config correctly.

### DIFF
--- a/src/Flickr/Provider.php
+++ b/src/Flickr/Provider.php
@@ -11,6 +11,14 @@ class Provider extends AbstractProvider
      * Unique Provider Identifier.
      */
     public const IDENTIFIER = 'FLICKR';
+    
+    /**
+     * {@inheritdoc}
+     */
+    public static function additionalConfigKeys()
+    {
+        return ['perms'];
+    }    
 
     protected function mapUserToObject(array $user)
     {

--- a/src/Flickr/Provider.php
+++ b/src/Flickr/Provider.php
@@ -11,14 +11,14 @@ class Provider extends AbstractProvider
      * Unique Provider Identifier.
      */
     public const IDENTIFIER = 'FLICKR';
-    
+
     /**
      * {@inheritdoc}
      */
     public static function additionalConfigKeys()
     {
         return ['perms'];
-    }    
+    }
 
     protected function mapUserToObject(array $user)
     {

--- a/src/Flickr/Server.php
+++ b/src/Flickr/Server.php
@@ -12,14 +12,6 @@ class Server extends BaseServer
     /**
      * {@inheritdoc}
      */
-    public static function additionalConfigKeys()
-    {
-        return ['perms'];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function urlTemporaryCredentials()
     {
         return 'https://www.flickr.com/services/oauth/request_token';


### PR DESCRIPTION
additionalConfigKeys in Server is never called, and thus `perms` is never available. By moving it to `Provider.php` it then allows `perms` to become available after which `Server.php` can then obtain it correctly with `getConfig`