### PR TITLE
Add Azure AD B2C Provider

### DIFF
--- a/src/AzureADB2C/AzureADB2CExtendSocialite.php
+++ b/src/AzureADB2C/AzureADB2CExtendSocialite.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SocialiteProviders\AzureADB2C;
+
+use SocialiteProviders\Manager\SocialiteWasCalled;
+
+class AzureADB2CExtendSocialite
+{
+    /**
+     * Register the provider.
+     *
+     * @param  \SocialiteProviders\Manager\SocialiteWasCalled $socialiteWasCalled
+     */
+    public function handle(SocialiteWasCalled $socialiteWasCalled)
+    {
+        $socialiteWasCalled->extendSocialite('azureadb2c', Provider::class);
+    }
+}

--- a/src/AzureADB2C/Provider.php
+++ b/src/AzureADB2C/Provider.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace SocialiteProviders\AzureADB2C;
+
+use Firebase\JWT\JWK;
+use GuzzleHttp\Client;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Cache;
+use Lcobucci\Clock\SystemClock;
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Signer\Rsa\Sha256;
+use Lcobucci\JWT\Validation\Constraint\IssuedBy;
+use Lcobucci\JWT\Validation\Constraint\LooseValidAt;
+use Lcobucci\JWT\Validation\Constraint\SignedWith;
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
+use SocialiteProviders\Manager\OAuth2\User;
+
+class Provider extends AbstractProvider
+{
+    /**
+     * Unique Provider Identifier.
+     */
+    public const IDENTIFIER = 'AZUREADB2C';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopes = [
+        'openid'
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAuthUrl($state)
+    {
+        return $this->buildAuthUrlFromBase(
+            sprintf(
+                'https://%s.b2clogin.com/%s.onmicrosoft.com/%s/oauth2/v2.0/authorize',
+                $this->getConfig('domain'),
+                $this->getConfig('domain'),
+                $this->getConfig('policy')
+                ),
+            $state
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenUrl()
+    {
+        return sprintf(
+            'https://%s.b2clogin.com/%s.onmicrosoft.com/%s/oauth2/v2.0/token',
+            $this->getConfig('domain'),
+            $this->getConfig('domain'),
+            $this->getConfig('policy')
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByToken($token)
+    {
+        $this->verifyIdToken($token);
+        $claims = explode('.', $token)[1];
+
+        return json_decode(base64_decode($claims), true);
+
+    }
+
+    private function verifyIdToken($jwt)
+    {
+        $jwtContainer = Configuration::forUnsecuredSigner();
+        $token = $jwtContainer->parser()->parse($jwt);
+
+        $data = Cache::remember('socialite:AzureADB2C-JWKSet', 5 * 60, function () {
+            $response = (new Client())->get(
+                sprintf(
+                    'https://%s.b2clogin.com/%s.onmicrosoft.com/%s/discovery/v2.0/keys',
+                    $this->getConfig('domain'),
+                    $this->getConfig('domain'),
+                    $this->getConfig('policy')
+                ));
+            return json_decode((string) $response->getBody(), true);
+        });
+
+        $publicKeys = JWK::parseKeySet($data);
+        $kid = $token->headers()->get('kid');
+
+        if (isset($publicKeys[$kid])) {
+            $publicKey = openssl_pkey_get_details($publicKeys[$kid]);
+            $constraints = [
+                new SignedWith(new Sha256(), InMemory::plainText($publicKey['key'])),
+                new IssuedBy(
+                    sprintf(
+                        'https://%s.b2clogin.com/%s/v2.0/',
+                        $this->getConfig('domain'),
+                        $this->getConfig('tenantid')
+                        )),
+                new LooseValidAt(SystemClock::fromSystemTimezone()),
+            ];
+
+            try {
+                $jwtContainer->validator()->assert($token, ...$constraints);
+
+                return true;
+            } catch (RequiredConstraintsViolated $e) {
+                throw new InvalidStateException($e->getMessage());
+            }
+        }
+
+        throw new InvalidStateException('Invalid JWT Signature');
+    }
+
+
+    public function user()
+    {
+        $response = $this->getAccessTokenResponse($this->getCode());
+
+        $claims = $this->getUserByToken(
+            Arr::get($response, 'id_token')
+        );
+
+        return $this->mapUserToObject($claims);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return (new User())->setRaw($user)->map([
+            'id'   => $user['sub'],
+            'name' => $user['name'],
+        ]);
+    }
+
+    /**
+     * @return array
+     */
+    public static function additionalConfigKeys()
+    {
+        return [
+            'domain',
+            'policy',
+            'tenantid'
+        ];
+    }
+}

--- a/src/AzureADB2C/README.md
+++ b/src/AzureADB2C/README.md
@@ -1,0 +1,50 @@
+# Azure AD B2C
+
+```bash
+composer require socialiteproviders/azureadb2c
+```
+
+## Installation & Basic Usage
+
+Please see the [Base Installation Guide](https://socialiteproviders.com/usage/), then follow the provider specific instructions below.
+
+### Add configuration to `config/services.php`
+
+```php
+'azureadb2c' => [
+    'client_id' => env('AADB2C_ClientId'),
+    'client_secret' => env('AADB2C_ClientSecret'),
+    'redirect' => env('AADB2C_RedirectUri'),
+    'domain' => env('AADB2C_Domain'),
+    'policy' => env('AADB2C_Policy'),
+    'tenantid' => env('AADB2C_TenantId')
+],
+```
+
+### Add provider event listener
+
+Configure the package's listener to listen for `SocialiteWasCalled` events.
+
+Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. See the [Base Installation Guide](https://socialiteproviders.com/usage/) for detailed instructions.
+
+```php
+protected $listen = [
+    \SocialiteProviders\Manager\SocialiteWasCalled::class => [
+        // ... other providers
+        'SocialiteProviders\\AzureADB2C\\AzureADB2CExtendSocialite@handle',
+    ],
+];
+```
+
+### Usage
+
+You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
+
+```php
+return Socialite::driver('azureadb2c')->redirect();
+```
+
+### Returned User fields
+
+- ``sub``
+- ``name``

--- a/src/AzureADB2C/composer.json
+++ b/src/AzureADB2C/composer.json
@@ -1,0 +1,34 @@
+{
+    "name": "socialiteproviders/azureadb2c",
+    "description": "AzureADB2C OAuth2 Provider for Laravel Socialite",
+    "keywords": [
+        "Azure Active Directory",
+        "Azure AD",
+        "Azure Active Directory B2C",
+        "Azure AD B2C",
+        "OpenID Connect",
+        "laravel Azure AD B2C",
+        "laravel socialite",
+        "laravel",
+        "socialite Azure AD B2C",
+        "socialite"
+    ],
+    "license": "MIT",
+    "authors": [{
+        "name": "Naohiro Fujie",
+        "email": "naohiro.fujie@eidentity.jp"
+    }],
+    "require": {
+        "php": "^7.4 || ^8.0",
+        "ext-json": "*",
+        "ext-openssl": "*",
+        "firebase/php-jwt": "^5.2",
+        "lcobucci/jwt": "^4.0",
+        "socialiteproviders/manager": "~4.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialiteProviders\\AzureADB2C\\": ""
+        }
+    }
+}


### PR DESCRIPTION
Add Azure AD B2C provider because OpenID Connect implementation on Azure AD B2C is bit different from Azure AD's one.

- Azure AD B2C does not issue access_token by default to obtain user attributes via Microsoft Graph API
- To obtain attributes from Azure AD B2C, it is required to get claims from id_token