### PR TITLE
Resolve TikTok Provider ErrorException.

### DIFF
--- a/src/TikTok/Provider.php
+++ b/src/TikTok/Provider.php
@@ -20,6 +20,11 @@ class Provider extends AbstractProvider
     protected $scopes = [
         'user.info.basic',
     ];
+    
+    /**
+     * @var User
+     */
+    protected $user;
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
Line 43 of TikTok Provider.php accesses an undefined property:

https://github.com/SocialiteProviders/Providers/blob/77796034c2d5be3fdfbf6a839725e5387234e7bb/src/TikTok/Provider.php#L43

This PR is to resolve ErrorException: Undefined property: SocialiteProviders\TikTok\Provider::$user
