### PR TITLE
Update SoundCloud to newest security patch

### DIFF
--- a/src/SoundCloud/Provider.php
+++ b/src/SoundCloud/Provider.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\SoundCloud;
 
+use GuzzleHttp\RequestOptions;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -42,7 +43,12 @@ class Provider extends AbstractProvider
     protected function getUserByToken($token)
     {
         $response = $this->getHttpClient()->get(
-            'https://api.soundcloud.com/me.json?oauth_token='.$token
+            'https://api.soundcloud.com/me.json',
+            [
+                RequestOptions::HEADERS => [
+                    'Authorization' => 'OAuth '.$token,
+                ],
+            ]
         );
 
         return json_decode((string) $response->getBody(), true);


### PR DESCRIPTION
SoundCloud updated their OAuth flow to use a token in the header, instead of passing it via the query string.

More info here: https://developers.soundcloud.com/blog/security-updates-api

