### PR TITLE
Add getLogoutUrl for Keycloak provider

### DIFF
--- a/src/Keycloak/Provider.php
+++ b/src/Keycloak/Provider.php
@@ -83,4 +83,14 @@ class Provider extends AbstractProvider
             'grant_type' => 'authorization_code',
         ]);
     }
+
+    /**
+     * Return logout endpoint with redirect_uri query parameter.
+     *
+     * @return string
+     */
+    public function getLogoutUrl(string $redirectUri)
+    {
+        return $this->getBaseUrl().'/protocol/openid-connect/logout?redirect_uri='.urlencode($redirectUri);
+    }
 }

--- a/src/Keycloak/README.md
+++ b/src/Keycloak/README.md
@@ -43,6 +43,15 @@ You should now be able to use the provider like you would regularly use Socialit
 return Socialite::driver('keycloak')->redirect();
 ```
 
+To logout of your app and Keycloak:
+```php
+public function logout() {
+    Auth::logout(); // Logout of your app
+    $redirectUri = Config::get('app.url'); // The URL the user is redirected to
+    return redirect(Socialite::driver('keycloak')->getLogoutUrl($redirectUri)); // Redirect to Keycloak
+}
+```
+
 #### Keycloak <= 3.2
 
 Keycloak below v3.2 requires no scopes to be set. Later versions require the `openid` scope for all requests.


### PR DESCRIPTION
Adds a Keycloak provider method that returns a logout endpoint in line with the [Keycloak logout documentation](https://www.keycloak.org/docs/latest/securing_apps/index.html#logout).