### PR TITLE
Add support for isMemberOf claim to SURFconext provider

### DIFF
--- a/src/SURFconext/Provider.php
+++ b/src/SURFconext/Provider.php
@@ -79,6 +79,7 @@ class Provider extends AbstractProvider
             'family_name'                  => Arr::get($user, 'family_name'),
             'schac_home_organization'      => Arr::get($user, 'schac_home_organization'),
             'schac_home_organization_type' => Arr::get($user, 'schac_home_organization_type'),
+            'edumember_is_member_of'       => Arr::get($user, 'edumember_is_member_of'),
             'eduperson_affiliation'        => Arr::get($user, 'eduperson_affiliation'),
             'eduperson_scoped_affiliation' => Arr::get($user, 'eduperson_scoped_affiliation'),
             'eduperson_targeted_id'        => Arr::get($user, 'eduperson_targeted_id'),


### PR DESCRIPTION
Adds support for [SURFconext Teams](https://wiki.surfnet.nl/pages/viewpage.action?pageId=10132152) by including the `isMemberOf` claim to the current set of mapped attributes.

See: https://wiki.surfnet.nl/display/surfconextdev/Attributes+in+SURFconext#AttributesinSURFconext-isMemberOfisMemberOf