### PR TITLE
Make SAML2 binding configurable & fix regression introduced by #712

### DIFF
--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -93,6 +93,7 @@ class Provider extends AbstractProvider implements SocialiteProvider
             'certificate',
             'sp_acs',
             'sp_entityid',
+            'idp_binding_method'
         ];
     }
 

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -108,7 +108,7 @@ class Provider extends AbstractProvider implements SocialiteProvider
     public function redirect()
     {
         $this->request->session()->put('state', $state = $this->getState());
-        
+
         $binding = $this->getConfig('idp_binding_method', SamlConstants::BINDING_SAML2_HTTP_REDIRECT);
 
         $identityProviderConsumerService = $this->getIdentityProviderEntityDescriptor()

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -31,8 +31,8 @@ use LightSaml\Model\Context\SerializationContext;
 use LightSaml\Model\Metadata\AssertionConsumerService;
 use LightSaml\Model\Metadata\EntityDescriptor;
 use LightSaml\Model\Metadata\KeyDescriptor;
-use LightSaml\Model\Metadata\SpSsoDescriptor;
 use LightSaml\Model\Metadata\Metadata;
+use LightSaml\Model\Metadata\SpSsoDescriptor;
 use LightSaml\Model\Protocol\AuthnRequest;
 use LightSaml\Model\Protocol\NameIDPolicy;
 use LightSaml\Model\XmlDSig\SignatureXmlReader;
@@ -93,7 +93,7 @@ class Provider extends AbstractProvider implements SocialiteProvider
             'certificate',
             'sp_acs',
             'sp_entityid',
-            'idp_binding_method'
+            'idp_binding_method',
         ];
     }
 

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -2,7 +2,6 @@
 
 namespace SocialiteProviders\Saml2;
 
-use _HumbugBox58fd4d9e2a25\RdKafka\Metadata;
 use DateTime;
 use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Http\Request;
@@ -33,6 +32,7 @@ use LightSaml\Model\Metadata\AssertionConsumerService;
 use LightSaml\Model\Metadata\EntityDescriptor;
 use LightSaml\Model\Metadata\KeyDescriptor;
 use LightSaml\Model\Metadata\SpSsoDescriptor;
+use LightSaml\Model\Metadata\Metadata;
 use LightSaml\Model\Protocol\AuthnRequest;
 use LightSaml\Model\Protocol\NameIDPolicy;
 use LightSaml\Model\XmlDSig\SignatureXmlReader;

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -108,10 +108,12 @@ class Provider extends AbstractProvider implements SocialiteProvider
     public function redirect()
     {
         $this->request->session()->put('state', $state = $this->getState());
+        
+        $binding = $this->getConfig('idp_binding_method', SamlConstants::BINDING_SAML2_HTTP_REDIRECT);
 
         $identityProviderConsumerService = $this->getIdentityProviderEntityDescriptor()
             ->getFirstIdpSsoDescriptor()
-            ->getFirstSingleSignOnService(SamlConstants::BINDING_SAML2_HTTP_REDIRECT);
+            ->getFirstSingleSignOnService($binding);
 
         $authnRequest = new AuthnRequest();
         $authnRequest


### PR DESCRIPTION
When implementing SAML2 configuration to work with jumpcloud.com as Identify Provider, I realised their SSO binding method is a "POST" and not a "REDIRECT". 

Problem: Redirect method is hardcoded in the code. 

Solution : This change makes it configurable in the services.php file. It is backward compatible as it takes the current value as default.

