### PR TITLE
Update ProductHunt API to v2

### DIFF
--- a/src/ProductHunt/Provider.php
+++ b/src/ProductHunt/Provider.php
@@ -33,7 +33,7 @@ class Provider extends AbstractProvider
     protected function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase(
-            'https://api.producthunt.com/v1/oauth/authorize',
+            'https://api.producthunt.com/v2/oauth/authorize',
             $state
         );
     }
@@ -43,7 +43,7 @@ class Provider extends AbstractProvider
      */
     protected function getTokenUrl()
     {
-        return 'https://api.producthunt.com/v1/oauth/token';
+        return 'https://api.producthunt.com/v2/oauth/token';
     }
 
     /**
@@ -51,14 +51,28 @@ class Provider extends AbstractProvider
      */
     protected function getUserByToken($token)
     {
-        $response = $this->getHttpClient()->get(
-            'https://api.producthunt.com/v1/me?access_token='.$token,
+        $response = $this->getHttpClient()->post(
+            'https://api.producthunt.com/v2/api/graphql',
             [
                 RequestOptions::HEADERS => [
                     'Content-Type'  => 'application/json',
                     'Accept'        => 'application/json',
                     'Authorization' => 'Bearer '.$token,
                 ],
+                RequestOptions::JSON => [
+                    'query' => <<<GQL
+                        {
+                            viewer {
+                                user {
+                                    id
+                                    name
+                                    profileImage
+                                    username
+                                }
+                            }
+                        }
+                    GQL,
+                ]
             ]
         );
 
@@ -70,15 +84,13 @@ class Provider extends AbstractProvider
      */
     protected function mapUserToObject(array $user)
     {
-        $user = $user['user'] ?? [];
-        $avatar = $user['image_url'] ?? [];
-        $avatar = $avatar['original'] ?? null;
+        $user = $user['data']['viewer']['user'] ?? [];
+        $avatar = $user['profileImage'] ?? null;
 
         return (new User())->setRaw($user)->map([
             'id'       => $user['id'],
             'nickname' => $user['username'],
             'name'     => $user['name'],
-            'email'    => $user['email'],
             'avatar'   => $avatar,
         ]);
     }

--- a/src/ProductHunt/Provider.php
+++ b/src/ProductHunt/Provider.php
@@ -60,8 +60,7 @@ class Provider extends AbstractProvider
                     'Authorization' => 'Bearer '.$token,
                 ],
                 RequestOptions::JSON => [
-                    'query' => <<<GQL
-                        {
+                    'query' => '{
                             viewer {
                                 user {
                                     id
@@ -70,9 +69,8 @@ class Provider extends AbstractProvider
                                     username
                                 }
                             }
-                        }
-                    GQL,
-                ]
+                        }',
+                ],
             ]
         );
 

--- a/src/ProductHunt/README.md
+++ b/src/ProductHunt/README.md
@@ -46,5 +46,4 @@ return Socialite::driver('producthunt')->redirect();
 - ``id``
 - ``nickname``
 - ``name``
-- ``email``
 - ``avatar``

--- a/src/ProductHunt/composer.json
+++ b/src/ProductHunt/composer.json
@@ -22,7 +22,7 @@
     },
     "autoload": {
         "psr-4": {
-            "SocialiteProviders\\AngelList\\": ""
+            "SocialiteProviders\\ProductHunt\\": ""
         }
     },
     "support": {


### PR DESCRIPTION
This PR updates the ProductHunt driver to use the [v2](https://api.producthunt.com/v2/docs) API since v1 is now [deprecated](https://api.producthunt.com/v1/docs). This means the users' email is no longer returned, I've opened an [issue](https://github.com/producthunt/producthunt-api/issues/247) in ProductHunts' producthunt-api repo related to that since it was included in v1, so I've asked if it could be added to the v2 GraphQL [User Schema](http://api-v2-docs.producthunt.com.s3-website-us-east-1.amazonaws.com/object/user/). If it gets added I'll update the provider again. 

This PR also fixes the driver since the PSR-4 namespace was sadly wrong so Composer autoloaded the driver under the `SocialiteProviders\AngelList` namespace instead of `SocialiteProviders\ProductHunt` causing a ReflectionError when Laravel tried to resolve the driver. 🤷‍♂️

Thank you for making this package, an amazing addition to the Laravel community. 🤘🔥