### PR TITLE
Change given_name (is firstName on keycloak) to name

### DIFF
--- a/src/Keycloak/Provider.php
+++ b/src/Keycloak/Provider.php
@@ -69,7 +69,7 @@ class Provider extends AbstractProvider
         return (new User())->setRaw($user)->map([
             'id'        => Arr::get($user, 'sub'),
             'nickname'  => Arr::get($user, 'preferred_username'),
-            'name'      => Arr::get($user, 'given_name'),
+            'name'      => Arr::get($user, 'name'),
             'email'     => Arr::get($user, 'email'),
         ]);
     }


### PR DESCRIPTION
The given_name on keycloak is user attribut "firstName" by default and is not possible to replace this mapper to give full name.
To get full name you need to call name

See Socialite request full name
https://github.com/laravel/socialite/blob/b5c67f187ddcf15529ff7217fa735b132620dfac/src/AbstractUser.php#L25
