### PR TITLE
Saml2: Extend SAML2 support

### DIFF
--- a/src/Saml2/OasisAttributeNameUris.php
+++ b/src/Saml2/OasisAttributeNameUris.php
@@ -8,6 +8,7 @@ class OasisAttributeNameUris
     public const DISPLAY_NAME = 'urn:oid:2.16.840.1.113730.3.1.241';
     public const GIVEN_NAME = 'urn:oid:2.5.4.42';
     public const MAIL = 'urn:oid:0.9.2342.19200300.100.1.3';
+    public const ORGANIZATIONAL_UNIT_NAME = 'urn:oid:2.5.4.11';
     public const PHONE = 'urn:oid:2.5.4.20';
     public const PREFERRED_FIRST_NAME = 'urn:oid:1.2.840.113994.200.47';
     public const PREFERRED_MIDDLE_NAME = 'urn:oid:1.2.840.113994.200.48';

--- a/src/Saml2/OasisAttributeNameUris.php
+++ b/src/Saml2/OasisAttributeNameUris.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SocialiteProviders\Saml2;
+
+class OasisAttributeNameUris
+{
+    public const COMMON_NAME = 'urn:oid:2.5.4.3';
+    public const DISPLAY_NAME = 'urn:oid:2.16.840.1.113730.3.1.241';
+    public const GIVEN_NAME = 'urn:oid:2.5.4.42';
+    public const MAIL = 'urn:oid:0.9.2342.19200300.100.1.3';
+    public const PHONE = 'urn:oid:2.5.4.20';
+    public const PREFERRED_FIRST_NAME = 'urn:oid:1.2.840.113994.200.47';
+    public const PREFERRED_MIDDLE_NAME = 'urn:oid:1.2.840.113994.200.48';
+    public const PREFERRED_SURNAME = 'urn:oid:1.2.840.113994.200.49';
+    public const REGISTERED_GIVEN_NAME = 'urn:oid:1.2.840.113994.200.32';
+    public const REGISTERED_SURNAME = 'urn:oid:1.2.840.113994.200.31';
+    public const SURNAME = 'urn:oid:2.5.4.4';
+    public const TITLE = 'urn:oid:2.5.4.12';
+    public const UID = 'urn:oid:0.9.2342.19200300.100.1.1';
+}

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -521,7 +521,7 @@ class Provider extends AbstractProvider implements SocialiteProvider
             return;
         }
 
-        $assertion = $reader->decryptMultiAssertion([$credential], new DeserializationContext());
+        $assertion = $reader->decryptAssertion($credential->getPrivateKey(), new DeserializationContext());
         $this->messageContext->asResponse()->addAssertion($assertion);
     }
 

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -337,9 +337,9 @@ class Provider extends AbstractProvider implements SocialiteProvider
             ->getAllKeyDescriptorsByUse(KeyDescriptor::USE_SIGNING);
 
         /** @var SignatureXmlReader $signatureReader */
-        $signatureReader = SamlConstants::BINDING_SAML2_HTTP_REDIRECT === $this->getAssertionConsumerServiceBinding() ?
-            $this->messageContext->getMessage()->getSignature() :
-            $this->messageContext->asResponse()->getFirstAssertion()->getSignature();
+        $signatureReader = SamlConstants::BINDING_SAML2_HTTP_REDIRECT === $this->messageContext->getBindingType()
+            ? $this->messageContext->getMessage()->getSignature()
+            : $this->messageContext->asResponse()->getFirstAssertion()->getSignature();
 
         if (!$signatureReader) {
             return true;

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -29,6 +29,7 @@ use LightSaml\Model\Assertion\Issuer;
 use LightSaml\Model\Context\DeserializationContext;
 use LightSaml\Model\Context\SerializationContext;
 use LightSaml\Model\Metadata\AssertionConsumerService;
+use LightSaml\Model\Metadata\ContactPerson;
 use LightSaml\Model\Metadata\EntityDescriptor;
 use LightSaml\Model\Metadata\KeyDescriptor;
 use LightSaml\Model\Metadata\Metadata;
@@ -109,6 +110,9 @@ class Provider extends AbstractProvider implements SocialiteProvider
             'sp_certificate',
             'sp_private_key',
             'sp_private_key_passphrase',
+            'sp_tech_contact_surname',
+            'sp_tech_contact_givenname',
+            'sp_tech_contact_email',
             'sp_default_binding_method',
             'idp_binding_method',
         ];
@@ -261,6 +265,15 @@ class Provider extends AbstractProvider implements SocialiteProvider
             $spSsoDescriptor->setAuthnRequestsSigned(true)
                 ->addKeyDescriptor(new KeyDescriptor(KeyDescriptor::USE_SIGNING, $credential->getCertificate()))
                 ->addKeyDescriptor(new KeyDescriptor(KeyDescriptor::USE_ENCRYPTION, $credential->getCertificate()));
+        }
+
+        if ($this->getConfig('sp_tech_contact_email')) {
+            $entityDescriptor->addContactPerson(
+                (new ContactPerson())->setContactType('technical')
+                    ->setEmailAddress($this->getConfig('sp_tech_contact_email'))
+                    ->setSurName($this->getConfig('sp_tech_contact_surname'))
+                    ->setGivenName($this->getConfig('sp_tech_contact_givenname'))
+            );
         }
 
         return $entityDescriptor;

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -139,6 +139,9 @@ class Provider extends AbstractProvider implements SocialiteProvider
 
     protected function sendMessage(SamlMessage $message, string $bindingType): HttpFoundationResponse
     {
+        if ($credential = $this->credential()) {
+            $message->setSignature($this->signature($credential));
+        }
 
         $messageContext = new MessageContext();
         $messageContext->setMessage($message);

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -236,7 +236,7 @@ class Provider extends AbstractProvider implements SocialiteProvider
     public function getServiceProviderEntityDescriptor(): EntityDescriptor
     {
         $entityDescriptor = new EntityDescriptor();
-        $entityDescriptor
+        $entityDescriptor->setID(Helper::generateID())
             ->setEntityID($this->getConfig('sp_entityid', URL::to('auth/saml2')))
             ->addItem(
                 (new SpSsoDescriptor())

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -307,7 +307,7 @@ class Provider extends AbstractProvider implements SocialiteProvider
     public function getServiceProviderEntityDescriptor(): EntityDescriptor
     {
         $spSsoDescriptor = new SpSsoDescriptor();
-        $spSsoDescriptor->setWantAssertionsSigned(true);
+        $spSsoDescriptor->setWantAssertionsSigned(true)->addNameIDFormat(SamlConstants::NAME_ID_FORMAT_PERSISTENT);
 
         foreach ([SamlConstants::BINDING_SAML2_HTTP_REDIRECT, SamlConstants::BINDING_SAML2_HTTP_POST] as $binding) {
             $acsRoute = $this->getAssertionConsumerServiceRoute();

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -47,6 +47,7 @@ use LightSaml\Model\XmlDSig\SignatureXmlReader;
 use LightSaml\SamlConstants;
 use RobRichards\XMLSecLibs\XMLSecurityDSig;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
+use RuntimeException;
 use SocialiteProviders\Manager\Contracts\ConfigInterface;
 use SocialiteProviders\Manager\Exception\MissingConfigException;
 use Symfony\Component\HttpFoundation\Response as HttpFoundationResponse;
@@ -416,6 +417,7 @@ class Provider extends AbstractProvider implements SocialiteProvider
         }
 
         $this->receive();
+        $this->ensureSuccessfulStatus();
 
         if ($this->hasInvalidState()) {
             throw new InvalidStateException();
@@ -453,6 +455,15 @@ class Provider extends AbstractProvider implements SocialiteProvider
 
             return null;
         }, array_merge(static::ATTRIBUTE_MAP, $this->getConfig('attribute_map', [])));
+    }
+
+    protected function ensureSuccessfulStatus(): void
+    {
+        $status = $this->messageContext->asResponse()->getStatus();
+
+        if (!$status->isSuccess()) {
+            throw new RuntimeException('Server responded with: ' . $status->getStatusCode()->getValue());
+        }
     }
 
     protected function hasInvalidState(): bool

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -84,6 +84,33 @@ class Provider extends AbstractProvider implements SocialiteProvider
     public const CACHE_KEY = 'socialite_saml2_metadata';
     public const CACHE_KEY_TTL = self::CACHE_KEY.'_ttl';
 
+    public const ATTRIBUTE_MAP = [
+        'email' => [
+            ClaimTypes::EMAIL_ADDRESS,
+            OasisAttributeNameUris::MAIL,
+            ClaimTypes::ADFS_1_EMAIL,
+        ],
+        'name' => [
+            ClaimTypes::NAME,
+            OasisAttributeNameUris::DISPLAY_NAME,
+            ClaimTypes::COMMON_NAME,
+            OasisAttributeNameUris::COMMON_NAME,
+        ],
+        'last_name' => [
+            ClaimTypes::GIVEN_NAME,
+            OasisAttributeNameUris::GIVEN_NAME,
+        ],
+        'first_name' => [
+            ClaimTypes::SURNAME,
+            OasisAttributeNameUris::SURNAME,
+        ],
+        'upn' => [
+            ClaimTypes::UPN,
+            OasisAttributeNameUris::UID,
+            ClaimTypes::ADFS_1_UPN,
+        ],
+    ];
+
     public function __construct(Request $request)
     {
         parent::__construct($request, '', '', '');
@@ -425,37 +452,7 @@ class Provider extends AbstractProvider implements SocialiteProvider
             }
 
             return null;
-        }, $this->attributeMap());
-    }
-
-    protected function attributeMap(): array
-    {
-        return array_merge([
-            'email' => [
-                ClaimTypes::EMAIL_ADDRESS,
-                OasisAttributeNameUris::MAIL,
-                ClaimTypes::ADFS_1_EMAIL,
-            ],
-            'name' => [
-                ClaimTypes::NAME,
-                OasisAttributeNameUris::DISPLAY_NAME,
-                ClaimTypes::COMMON_NAME,
-                OasisAttributeNameUris::COMMON_NAME,
-            ],
-            'last_name' => [
-                ClaimTypes::GIVEN_NAME,
-                OasisAttributeNameUris::GIVEN_NAME,
-            ],
-            'first_name' => [
-                ClaimTypes::SURNAME,
-                OasisAttributeNameUris::SURNAME,
-            ],
-            'upn' => [
-                ClaimTypes::UPN,
-                OasisAttributeNameUris::UID,
-                ClaimTypes::ADFS_1_UPN,
-            ],
-        ], $this->getConfig('attribute_map', []));
+        }, array_merge(static::ATTRIBUTE_MAP, $this->getConfig('attribute_map', [])));
     }
 
     protected function hasInvalidState(): bool

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -327,7 +327,7 @@ class Provider extends AbstractProvider implements SocialiteProvider
 
         $state = $this->request->session()->pull('state');
 
-        return $state !== $this->messageContext->getMessage()->getRelayState();
+        return !(strlen($state) > 0 && $this->messageContext->getMessage()->getRelayState() === $state);
     }
 
     protected function hasInvalidSignature(): bool

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -256,6 +256,13 @@ class Provider extends AbstractProvider implements SocialiteProvider
             ->setEntityID($this->getConfig('sp_entityid', URL::to('auth/saml2')))
             ->addItem($spSsoDescriptor);
 
+        if ($credential = $this->credential()) {
+            $entityDescriptor->setSignature($this->signature($credential));
+            $spSsoDescriptor->setAuthnRequestsSigned(true)
+                ->addKeyDescriptor(new KeyDescriptor(KeyDescriptor::USE_SIGNING, $credential->getCertificate()))
+                ->addKeyDescriptor(new KeyDescriptor(KeyDescriptor::USE_ENCRYPTION, $credential->getCertificate()));
+        }
+
         return $entityDescriptor;
     }
 

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -151,17 +151,7 @@ class Provider extends AbstractProvider implements SocialiteProvider
             throw new MissingConfigException('When using "acs", both "entityid" and "certificate" must be set');
         }
 
-        $x509 = new X509Certificate();
-
-        /**
-         * The SAML certificate may be provided as either a properly formatted certificate with header and line breaks
-         * or as a string containing only the body.
-         */
-        if (Str::startsWith($certificate, '-----BEGIN CERTIFICATE-----')) {
-            $x509->loadPem($certificate);
-        } else {
-            $x509->setData($certificate);
-        }
+        $x509 = $this->makeCertificate($certificate);
 
         $builder = new SimpleEntityDescriptorBuilder($entityId, $acs, $acs, $x509);
 
@@ -379,6 +369,25 @@ class Provider extends AbstractProvider implements SocialiteProvider
     {
         Cache::forget(self::CACHE_KEY);
         Cache::forget(self::CACHE_KEY_TTL);
+    }
+
+    protected function makeCertificate(?string $data): X509Certificate
+    {
+        $cert = new X509Certificate();
+
+        if (null === $data) {
+            return $cert;
+        }
+
+        /**
+         * The SAML certificate may be provided as either a properly formatted certificate with header and line breaks
+         * or as a string containing only the body.
+         */
+        if (Str::startsWith($data, '-----BEGIN CERTIFICATE-----')) {
+            return $cert->loadPem($data);
+        }
+
+        return $cert->setData($data);
     }
 
     protected function getTokenUrl()

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -244,6 +244,7 @@ class Provider extends AbstractProvider implements SocialiteProvider
             if ($this->hasRouteBindingType($acsRoute, $binding)) {
                 $spSsoDescriptor->addAssertionConsumerService(
                     (new AssertionConsumerService())
+                        ->setIsDefault($this->getDefaultAssertionConsumerServiceBinding() === $binding)
                         ->setBinding($binding)
                         ->setLocation(URL::to($acsRoute))
                 );

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -397,7 +397,7 @@ class Provider extends AbstractProvider implements SocialiteProvider
     {
         $methods = [
             SamlConstants::BINDING_SAML2_HTTP_REDIRECT => 'GET',
-            SamlConstants::BINDING_SAML2_HTTP_POST => 'POST',
+            SamlConstants::BINDING_SAML2_HTTP_POST     => 'POST',
         ];
 
         if (!array_key_exists($bindingType, $methods)) {
@@ -462,7 +462,7 @@ class Provider extends AbstractProvider implements SocialiteProvider
         $status = $this->messageContext->asResponse()->getStatus();
 
         if (!$status->isSuccess()) {
-            throw new RuntimeException('Server responded with: ' . $status->getStatusCode()->getValue());
+            throw new RuntimeException('Server responded with: '.$status->getStatusCode()->getValue());
         }
     }
 

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -293,7 +293,7 @@ class Provider extends AbstractProvider implements SocialiteProvider
             }
 
             $slsRoute = $this->getSingleLogoutServiceRoute();
-            if ($this->hasRouteBindingType($slsRoute, $binding)) {
+            if ($slsRoute && $this->hasRouteBindingType($slsRoute, $binding)) {
                 $spSsoDescriptor->addSingleLogoutService((new SingleLogoutService(URL::to($slsRoute), $binding)));
             }
         }
@@ -352,7 +352,7 @@ class Provider extends AbstractProvider implements SocialiteProvider
 
     protected function getSingleLogoutServiceRoute(): string
     {
-        return Str::of($this->getConfig('sp_sls', 'auth/logout'))->ltrim('/');
+        return Str::of($this->getConfig('sp_sls'))->ltrim('/');
     }
 
     protected function getDefaultAssertionConsumerServiceBinding(): string

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -317,6 +317,10 @@ class Provider extends AbstractProvider implements SocialiteProvider
 
     protected function hasInvalidState(): bool
     {
+        if ($this->isStateless()) {
+            return false;
+        }
+
         $state = $this->request->session()->pull('state');
 
         $bindingFactory = new BindingFactory();

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -96,11 +96,11 @@ class Provider extends AbstractProvider implements SocialiteProvider
             ClaimTypes::COMMON_NAME,
             OasisAttributeNameUris::COMMON_NAME,
         ],
-        'last_name' => [
+        'first_name' => [
             ClaimTypes::GIVEN_NAME,
             OasisAttributeNameUris::GIVEN_NAME,
         ],
-        'first_name' => [
+        'last_name' => [
             ClaimTypes::SURNAME,
             OasisAttributeNameUris::SURNAME,
         ],

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -33,6 +33,7 @@ use LightSaml\Model\Metadata\ContactPerson;
 use LightSaml\Model\Metadata\EntityDescriptor;
 use LightSaml\Model\Metadata\KeyDescriptor;
 use LightSaml\Model\Metadata\Metadata;
+use LightSaml\Model\Metadata\Organization;
 use LightSaml\Model\Metadata\SpSsoDescriptor;
 use LightSaml\Model\Protocol\AuthnRequest;
 use LightSaml\Model\Protocol\NameIDPolicy;
@@ -113,6 +114,10 @@ class Provider extends AbstractProvider implements SocialiteProvider
             'sp_tech_contact_surname',
             'sp_tech_contact_givenname',
             'sp_tech_contact_email',
+            'sp_org_lang',
+            'sp_org_name',
+            'sp_org_display_name',
+            'sp_org_url',
             'sp_default_binding_method',
             'idp_binding_method',
         ];
@@ -265,6 +270,15 @@ class Provider extends AbstractProvider implements SocialiteProvider
             $spSsoDescriptor->setAuthnRequestsSigned(true)
                 ->addKeyDescriptor(new KeyDescriptor(KeyDescriptor::USE_SIGNING, $credential->getCertificate()))
                 ->addKeyDescriptor(new KeyDescriptor(KeyDescriptor::USE_ENCRYPTION, $credential->getCertificate()));
+        }
+
+        if ($this->getConfig('sp_org_name')) {
+            $entityDescriptor->addOrganization(
+                (new Organization())->setLang($this->getConfig('sp_org_lang', 'en'))
+                    ->setOrganizationDisplayName($this->getConfig('sp_org_display_name'))
+                    ->setOrganizationName($this->getConfig('sp_org_name'))
+                    ->setOrganizationURL($this->getConfig('sp_org_url'))
+            );
         }
 
         if ($this->getConfig('sp_tech_contact_email')) {

--- a/src/Saml2/README.md
+++ b/src/Saml2/README.md
@@ -116,19 +116,17 @@ If you add both routes to support both binding methods, you can select the defau
 
 You can enable the SingleLogoutService on your Service Provider by adding a GET route where you log the user out and generate the SAML2 logout response:
 ```php
-Route::post('/auth/logout', function () {
+Route::get('/auth/saml2/logout', function () {
     $response = Socialite::driver('saml2')->logout();
 });
 ```
 
-If you use a different route (from the default `/auth/logout`), you also have to set it in `config/services.php` as:
+To publish the SingleLogoutService in your service provider metadata, you also have to configure route in `config/services.php` as:
 ```php
 'saml2' => [
-  'sp_sls' => 'auth/logout',
+  'sp_sls' => 'auth/saml2/logout',
 ],
 ```
-
-The route is automatically published in your service provider metadata when the SingleLogoutService is configured.
 
 ### Signing and encryption
 

--- a/src/Saml2/README.md
+++ b/src/Saml2/README.md
@@ -110,6 +110,20 @@ If you add both routes to support both binding methods, you can select the defau
 ],
 ```
 
+You can also enable a SingleLogoutService on your Service Provider. Add a GET route where you log the user out and generate the SAML2 logout response:
+```php
+Route::post('/auth/logout', function () {
+    $response = Socialite::driver('saml2')->logout();
+});
+```
+
+If you use a different route (from the default `/auth/logout`), you also have to set it in `config/services.php` as:
+```php
+'saml2' => [
+  'sp_sls' => 'auth/logout',
+],
+```
+
 ### Signing and encryption
 
 SAML2 supports the signing and encryption of messages and assertions. Many Identity Providers make one or both mandatory. To enable this feature, you can generate a certificate for your application and provide it in `config/services.php` as:

--- a/src/Saml2/README.md
+++ b/src/Saml2/README.md
@@ -124,6 +124,8 @@ If you use a different route (from the default `/auth/logout`), you also have to
 ],
 ```
 
+Please note that the SAML2 Single Logout feature is a best effort way of centralized logout. With the current state of affairs it requires special circumstances to work. Always check your Service Provider and Identity Provider settings and configuration before enabling this.
+
 ### Signing and encryption
 
 SAML2 supports the signing and encryption of messages and assertions. Many Identity Providers make one or both mandatory. To enable this feature, you can generate a certificate for your application and provide it in `config/services.php` as:

--- a/src/Saml2/README.md
+++ b/src/Saml2/README.md
@@ -224,7 +224,7 @@ You can also publish the service provider's organization and technical support c
 ],
 ```
 
-For the organization only the `sp_org_name`, and for the contact only the `sp_tech_contact_email` is required. The `sp_org_lang` has English (`en`) as default.
+In case you would like to include this information, you have to configure at least the `sp_org_name` for the organization to be included, and the `sp_tech_contact_email` for the contact to be included. The `sp_org_lang` has English (`en`) as default.
 
 The signing and encryption certificates are automatically included in the metadata when a service provider certificate is configured.
 

--- a/src/Saml2/README.md
+++ b/src/Saml2/README.md
@@ -110,7 +110,11 @@ If you add both routes to support both binding methods, you can select the defau
 ],
 ```
 
-You can also enable a SingleLogoutService on your Service Provider. Add a GET route where you log the user out and generate the SAML2 logout response:
+#### Single logout
+
+**Warning!** Please note that the SAML2 Single Logout feature is a best effort way of centralized logout. With the current state of affairs it requires special circumstances to work. You have to set your session config `same_site = 'none'` and `secure = true` for it to work which has serious security implications. Please always make sure you understand the risks before using this feature.
+
+You can enable the SingleLogoutService on your Service Provider by adding a GET route where you log the user out and generate the SAML2 logout response:
 ```php
 Route::post('/auth/logout', function () {
     $response = Socialite::driver('saml2')->logout();
@@ -124,7 +128,7 @@ If you use a different route (from the default `/auth/logout`), you also have to
 ],
 ```
 
-Please note that the SAML2 Single Logout feature is a best effort way of centralized logout. With the current state of affairs it requires special circumstances to work. Always check your Service Provider and Identity Provider settings and configuration before enabling this.
+The route is automatically published in your service provider metadata when the SingleLogoutService is configured.
 
 ### Signing and encryption
 

--- a/src/Saml2/README.md
+++ b/src/Saml2/README.md
@@ -103,6 +103,33 @@ Route::post('/auth/callback', function () {
 However, note that this is *not compatible* with Laravel's CSRF filtering performed by default on `POST` routes in the `routes/web.php` file.
 To make this callback style work, you can either define this route outside `web.php` or add it as an exception in your `VerifyCsrfToken` HTTP middleware.
 
+If you add both routes to support both binding methods, you can select the default one in `config/services.php` like this:
+```php
+'saml2' => [
+  'sp_default_binding_method' => \LightSaml\SamlConstants::BINDING_SAML2_HTTP_POST,
+],
+```
+
+### Signing and encryption
+
+SAML2 supports the signing and encryption of messages and assertions. Many Identity Providers make one or both mandatory. To enable this feature, you can generate a certificate for your application and provide it in `config/services.php` as:
+```php
+'saml2' => [
+  'sp_certificate' => file_get_contents('path/to/sp_saml.crt'),
+  'sp_private_key' => file_get_contents('path/to/sp_saml.pem'),
+  'sp_private_key_passphrase' => 'passphrase to your private key, provide it only if you have one',
+],
+```
+
+The `sp_private_key_passphrase` is optional and should not be given if the private key is not encrypted.
+
+Always protect your private key and store it in a place where it is not accessible by the general public.
+
+An example command to generate a certificate and private key with openssl:
+```
+openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -keyout sp_saml.pem -out sp_saml.crt
+```
+
 ### Identity provider metadata
 
 When using a metadata URL for the identity provider the fetched metadata is cached for 24 hours by default.
@@ -166,12 +193,43 @@ Socialite::driver('saml2')->getServiceProviderEntityId()
 Socialite::driver('saml2')->getServiceProviderAssertionConsumerUrl()
 ```
 
+You can also publish the service provider's organization and technical support contact in the metadata by configuring them in `config/services.php` as:
+```php
+'saml2' => [
+  'sp_tech_contact_surname' => 'Doe',
+  'sp_tech_contact_givenname' => 'John',
+  'sp_tech_contact_email' => 'john.doe@example.com',
+  'sp_org_lang' => 'en',
+  'sp_org_name' => 'Example Corporation Ltd.',
+  'sp_org_display_name' => 'Example Corporation',
+  'sp_org_url' => 'https://corp.example',
+],
+```
+
+For the organization only the `sp_org_name`, and for the contact only the `sp_tech_contact_email` is required. The `sp_org_lang` has English (`en`) as default.
+
+The signing and encryption certificates are automatically included in the metadata when a service provider certificate is configured.
+
 ### User attributes and Name ID
 
 By SAML convention, the "Name ID" sent by the identity provider is used as the ID in the `User` class instance returned in the callback.
 
-The two well-known SAML attributes 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name' and 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress' are mapped into Name and Email Address respectively in the `User` class.
+Well-known SAML attributes from the 'http://schemas.xmlsoap.org/...' and the 'urn:oid:...' namespaces are mapped into `name`, `email`, `first_name`, `last_name` and `upn` in the `User` class.
 
 All other attributes returned by the identity provider are stored in the "raw" property of the `User` class and can be retrieved with `$user->getRaw()`.
+
+It is possible to extend/override the default mapping by providing a partial/full custom map in `config/services.php` as:
+```php
+'saml2' => [
+  'attribute_map' => [
+    // Add mappings as 'mapped_name' => 'saml_attribute' or 'mapped_name' => ['saml_attribute', ...], for example:
+    'email' => [
+      \SocialiteProviders\Saml2\OasisAttributeNameUris::MAIL,
+      \LightSaml\ClaimTypes::EMAIL_ADDRESS,
+    ],
+    'phone' => \SocialiteProviders\Saml2\OasisAttributeNameUris::PHONE,
+  ],
+],
+```
 
 The entire assertion is also stored in the `User` instance and can be retrieved with `$user->getAssertion()`.

--- a/src/Saml2/User.php
+++ b/src/Saml2/User.php
@@ -9,6 +9,27 @@ class User extends AbstractUser
 {
     protected $assertion;
 
+    /**
+     * The user's first name.
+     *
+     * @var string|null
+     */
+    public $first_name;
+
+    /**
+     * The user's last name.
+     *
+     * @var string|null
+     */
+    public $last_name;
+
+    /**
+     * The user's UPN (user principal name).
+     *
+     * @var string|null
+     */
+    public $upn;
+
     public function getAssertion(): Assertion
     {
         return $this->assertion;
@@ -19,5 +40,35 @@ class User extends AbstractUser
         $this->assertion = $assertion;
 
         return $this;
+    }
+
+    /**
+     * Get the first name of the user.
+     *
+     * @return string|null
+     */
+    public function getFirstName()
+    {
+        return $this->first_name;
+    }
+
+    /**
+     * Get the last name of the user.
+     *
+     * @return string|null
+     */
+    public function getLastName()
+    {
+        return $this->last_name;
+    }
+
+    /**
+     * Get the UPN of the user.
+     *
+     * @return string|null
+     */
+    public function getUpn()
+    {
+        return $this->upn;
     }
 }

--- a/src/Saml2/composer.json
+++ b/src/Saml2/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "ext-json": "*",
-        "dropbox/lightsaml": "^2.0",
+        "lightsaml/lightsaml": "^2.0",
         "socialiteproviders/manager": "~4.0"
     },
     "autoload": {


### PR DESCRIPTION
This pull request extends the Saml2 provider to support more of the SAML2 standard. Here is a list of all new functionality:
- Full backwards compatibility, **no** breaking changes
- **Singing and encryption**
  Many Identity Providers require the signing of requests and providing of a certificate for encryption. The provider can now take a certificate + private key as optional configuration parameters to support this. If they are provided, every outgoing message is signed, and the provider supports decrypting assertions coming from the provider. If the parameters are not provided there is no change in behaviour.
- **Support both `POST` and `REDIRECT` bindings simultaneously while using `POST` as the default**
  The current implementation prefers `REDIRECT` over `POST`. I added the option to support both and still be able to change the default. The change is backwards compatible as `REDIRECT` still takes precedence by default.
- **More information in the Service Provider metadata**
  Identity Providers can take more information from the metadata than provided by the current version. This PR adds the following extra information:
  - Every supported binding is present, not just the default one
  - The default binding method is marked as default
  - The required NameId format is present
  - Signing and encryption information when it is configured
  - Possibility to add technical contact details
  - Possibility to add organization information
- **Configurable attribute mapping with multiple accepted fields**
  - Support for both the `urn:oid:` and `http://schemas.xmlsoap.org/` namespaces
  - More fields are mapped automatically with complete backwards compatibility with the current version
  - Provider configuration parameter to override / extend the mappings
  - Popular `urn:oid:` attributes are available as a class of consts
- State checking is more conformant with the other providers and now supports the `stateless` feature
- Response status check is added to avoid unhandled errors trying to parse a message that only consists of an error status.
- **SAML2 Single Logout**
  SAML2 supports centralized logout. It comes with its drawbacks, but it is still good to have the option in the provider to support this feature. Warning about possible complications is in the readme.

Every new feature is documented in the readme.

The new features have been tested using Shibboleth, Azure, Microsoft ADFS and Okta.

Thank you for considering this extension.
