### PR TITLE
spelling mistake

### DIFF
--- a/src/Bitrix24/README.md
+++ b/src/Bitrix24/README.md
@@ -1,7 +1,7 @@
 # Bitrix24
 
 ```bash
-composer require socialiteproviders/bitix24
+composer require socialiteproviders/bitrix24
 ```
 
 ## Installation & Basic Usage
@@ -11,11 +11,10 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
 ### Add configuration to `config/services.php`
 
 ```php
-'bitix24' => [
+'bitrix24' => [
       'endpoint' => env('BITRIX24_ENDPOINT_URI'),
       'client_id' => env('BITRIX24_CLIENT_ID'),
       'client_secret' => env('BITRIX24_CLIENT_SECRET'),
-      'redirect' => env('BITRIX24_REDIRECT_URI'),
 ],
 ```
 


### PR DESCRIPTION
bitix24 -> bitrix24 in the Readme.md
and unnecessary key in config options:
'redirect' => env('BITRIX24_REDIRECT_URI'),
it must be set on the Bitrix24 side
