### PR TITLE
Twitch: Change nickname to use the login value

### DIFF
--- a/src/Twitch/Provider.php
+++ b/src/Twitch/Provider.php
@@ -71,7 +71,7 @@ class Provider extends AbstractProvider
 
         return (new User())->setRaw($user)->map([
             'id'       => $user['id'],
-            'nickname' => $user['display_name'],
+            'nickname' => $user['login'],
             'name'     => $user['display_name'],
             'email'    => Arr::get($user, 'email'),
             'avatar'   => $user['profile_image_url'],


### PR DESCRIPTION
I changed the nickname value of socialite to use the login value of twitch, if not we have twice the same value for nickname and name

