### PR TITLE
Saml2 provider: Add standard OData config keys as additional keys

### DIFF
--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -86,6 +86,9 @@ class Provider extends AbstractProvider implements SocialiteProvider
     public static function additionalConfigKeys(): array
     {
         return [
+            'client_id',
+            'client_secret',
+            'redirect',
             'metadata',
             'ttl',
             'acs',


### PR DESCRIPTION
Noted in #791, recent changes in Socialite Providers prevents the documented installation method from working as-is. This restores the original functionality by making the standard keys "additional", as they are not required for Saml2 configuration.