### PR TITLE
Fix wrong event provider namespace in QQ's README.

### DIFF
--- a/src/QQ/README.md
+++ b/src/QQ/README.md
@@ -28,7 +28,7 @@ Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. 
 protected $listen = [
     \SocialiteProviders\Manager\SocialiteWasCalled::class => [
         // ... other providers
-        \SocialiteProviders\QQ\QQExtendSocialite::class.'@handle',
+        \SocialiteProviders\QQ\QqExtendSocialite::class.'@handle',
     ],
 ];
 ```


### PR DESCRIPTION
This PR fixes the issue in https://github.com/SocialiteProviders/Providers/issues/775, where the namespace in the event provider does not match the actual class name. Notice the double uppercase Q's in the example as opposed to the single uppercase in the class name.

https://github.com/SocialiteProviders/Providers/blob/85f27b5b069a6fc676b428c24513a97394cf18ec/src/QQ/QqExtendSocialite.php#L7