### PR TITLE
Remove socialite from TikTok composer.json

### DIFF
--- a/src/TikTok/composer.json
+++ b/src/TikTok/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "laravel/socialite": "~4.0 || ~5.0",
         "socialiteproviders/manager": "~4.0"
     },
     "autoload": {


### PR DESCRIPTION
I ran into some issues with this constraint installing the TikTok provider with Laravel 9.x.

I can see why the dependency was added - it references a Socialite exception. 

However, other SocialiteProviders that also reference Socialite classes omit `laravel/socialite` from their Composer files. TikTok is the only one that references it. This makes it consistent across the board.