### PR TITLE
Added logoutUrl method and documentation for Okta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 composer.lock
+.idea

--- a/src/Okta/Provider.php
+++ b/src/Okta/Provider.php
@@ -142,6 +142,7 @@ class Provider extends AbstractProvider
             'profileUrl'     => Arr::get($user, 'profile'),
             'address'        => Arr::get($user, 'address'),
             'phone'          => Arr::get($user, 'phone'),
+            'id_token'       => $this->credentialsResponseBody['id_token'] ?? null,
         ]);
     }
 
@@ -153,5 +154,25 @@ class Provider extends AbstractProvider
         return array_merge(parent::getTokenFields($code), [
             'grant_type' => 'authorization_code',
         ]);
+    }
+
+    /**
+     * @param string      $idToken
+     * @param string|null $redirectUri
+     * @param string|null $state
+     *
+     * @return string
+     */
+    public function getLogoutUrl(string $idToken, string $redirectUri = null, string $state = null)
+    {
+        $url = $this->getOktaServerUrl().'v1/logout';
+
+        $params = http_build_query(array_filter([
+            'id_token_hint'            => $idToken,
+            'post_logout_redirect_uri' => $redirectUri,
+            'state'                    => $state,
+        ]));
+
+        return "$url?$params";
     }
 }

--- a/src/Okta/README.md
+++ b/src/Okta/README.md
@@ -48,6 +48,43 @@ You should now be able to use the provider like you would regularly use Socialit
 return Socialite::driver('okta')->redirect();
 ```
 
+Store a local copy in your callback:
+
+```php
+public function handleProviderCallback(\Illuminate\Http\Request $request)
+{
+    $user = Socialite::driver('okta')->user();
+    $localUser = User::updateOrCreate(['email' => $user->email], [
+        'email'    => $user->email,
+        'name'     => $user->name,
+        'token'    => $user->token,
+        'id_token' => $user->id_token
+    ]);
+
+    try {
+        Auth::login($localUser);
+    }
+    catch (\Throwable $e) {
+        return redirect('/login-okta');
+    }
+
+    return redirect('/home');
+}
+```
+
+Generate the logout url from your controller:
+
+```php
+public function logout(\Illuminate\Http\Request $request)
+{
+    $idToken = $request->user()->id_token;
+    $logoutUrl = Socialite::driver('okta')->getLogoutUrl($idToken, URL::to('/'));
+    Auth::logout();
+
+    return redirect($logoutUrl);
+}
+```
+
 #### Client Token
 To obtain a client access token for authenticating to other apps without a user:
 


### PR DESCRIPTION
Okta requires an `id_token` to be supplied to perform a logout via the
browser. Including this property to facilitate logout and potentially
other needed requests.

Updated the respective readme to clarify process and usage.

For additional context, please see official okta documentation:
https://developer.okta.com/docs/reference/api/oidc/#logout

