### PR TITLE
Bump JWT dep for eveonline provider

### DIFF
--- a/src/Eveonline/Provider.php
+++ b/src/Eveonline/Provider.php
@@ -83,7 +83,7 @@ class Provider extends AbstractProvider
     {
         $responseJwks = $this->getHttpClient()->get('https://login.eveonline.com/oauth/jwks');
         $responseJwksInfo = json_decode((string) $responseJwks->getBody(), true);
-        $decodedArray = (array) JWT::decode($jwt, JWK::parseKeySet($responseJwksInfo), ['RS256']);
+        $decodedArray = (array) JWT::decode($jwt, JWK::parseKeySet($responseJwksInfo));
 
         if ($decodedArray['iss'] !== 'login.eveonline.com' && $decodedArray['iss'] !== self::TRANQUILITY_ENDPOINT) {
             throw new UnexpectedValueException('Access token issuer mismatch');

--- a/src/Eveonline/composer.json
+++ b/src/Eveonline/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "firebase/php-jwt": "^5.2",
+        "firebase/php-jwt": "^6.0",
         "socialiteproviders/manager": "^4.0"
     },
     "autoload": {


### PR DESCRIPTION
The algorithm argument for the decode function has been removed as of [6.0.0](https://github.com/firebase/php-jwt/releases/tag/v6.0.0)

The [keyset](https://login.eveonline.com/oauth/jwks) contains a key that satisfies the [algorithm](https://github.com/firebase/php-jwt/blob/main/src/JWK.php#L74) for parsing the keys