### PR TITLE
Added client access token method for Okta

### DIFF
--- a/src/Okta/Provider.php
+++ b/src/Okta/Provider.php
@@ -108,7 +108,8 @@ class Provider extends AbstractProvider
     /**
      * Get the client access token response.
      *
-     * @param  string|null  $scope
+     * @param string|null $scope
+     *
      * @return array
      */
     public function getClientAccessTokenResponse(string $scope = null)

--- a/src/Okta/Provider.php
+++ b/src/Okta/Provider.php
@@ -106,6 +106,27 @@ class Provider extends AbstractProvider
     }
 
     /**
+     * @param string $scope
+     * @return array
+     */
+    public function getClientAccessTokenResponse(string $scope = '')
+    {
+        $user = $this->getConfig('client_id');
+        $pass = $this->getConfig('client_secret');
+
+        $response = $this->getHttpClient()->post($this->getTokenUrl(), [
+            'auth'        => [$user, $pass],
+            'headers'     => ['Cache-Control' => 'no-cache'],
+            'form_params' => [
+                'grant_type' => 'client_credentials',
+                'scope'      => $scope
+            ],
+        ]);
+
+        return json_decode($response->getBody(), true);
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function mapUserToObject(array $user)

--- a/src/Okta/Provider.php
+++ b/src/Okta/Provider.php
@@ -106,25 +106,23 @@ class Provider extends AbstractProvider
     }
 
     /**
-     * @param string $scope
+     * Get the client access token response.
      *
+     * @param  string|null  $scope
      * @return array
      */
-    public function getClientAccessTokenResponse(string $scope = '')
+    public function getClientAccessTokenResponse(string $scope = null)
     {
-        $user = $this->getConfig('client_id');
-        $pass = $this->getConfig('client_secret');
-
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
-            'auth'        => [$user, $pass],
-            'headers'     => ['Cache-Control' => 'no-cache'],
-            'form_params' => [
+            RequestOptions::AUTH        => [$this->clientId, $this->clientSecret],
+            RequestOptions::HEADERS     => ['Cache-Control' => 'no-cache'],
+            RequestOptions::FORM_PARAMS => [
                 'grant_type' => 'client_credentials',
-                'scope'      => $scope,
+                'scope'      => $scope ?? '',
             ],
         ]);
 
-        return json_decode($response->getBody(), true);
+        return json_decode((string) $response->getBody(), true);
     }
 
     /**

--- a/src/Okta/Provider.php
+++ b/src/Okta/Provider.php
@@ -107,6 +107,7 @@ class Provider extends AbstractProvider
 
     /**
      * @param string $scope
+     *
      * @return array
      */
     public function getClientAccessTokenResponse(string $scope = '')
@@ -119,7 +120,7 @@ class Provider extends AbstractProvider
             'headers'     => ['Cache-Control' => 'no-cache'],
             'form_params' => [
                 'grant_type' => 'client_credentials',
-                'scope'      => $scope
+                'scope'      => $scope,
             ],
         ]);
 

--- a/src/Okta/README.md
+++ b/src/Okta/README.md
@@ -52,8 +52,8 @@ return Socialite::driver('okta')->redirect();
 To obtain a client access token for authenticating to other apps without a user:
 
 ```php
-$resp = (object)Socialite::driver('okta')->getClientAccessTokenResponse();
-$token = $resp->access_token;
+$response = (object) Socialite::driver('okta')->getClientAccessTokenResponse();
+$token = $response->access_token;
 ```
 NOTE: no caching of this token is performed. It's strongly suggested caching the token locally for its ttl
 

--- a/src/Okta/README.md
+++ b/src/Okta/README.md
@@ -48,6 +48,15 @@ You should now be able to use the provider like you would regularly use Socialit
 return Socialite::driver('okta')->redirect();
 ```
 
+#### Client Token
+To obtain a client access token for authenticating to other apps without a user:
+
+```php
+$resp = (object)Socialite::driver('okta')->getClientAccessTokenResponse();
+$token = $resp->access_token;
+```
+NOTE: no caching of this token is performed. It's strongly suggested caching the token locally for its ttl
+
 ### Returned User fields
 
 - ``id``


### PR DESCRIPTION
Okta is heavily used for internal apps that may be authenticating to
each other in scheduled processes where no user token is involved.

This additional method is a QOL for obtaining a client token to
authenticate in these situations.

For additional context, please see the official okta documentation:
https://developer.okta.com/docs/guides/implement-grant-type/clientcreds/main/#about-the-client-credentials-grant

