### PR TITLE
Rework okta client token method for consistency

### DIFF
--- a/src/Okta/Provider.php
+++ b/src/Okta/Provider.php
@@ -108,18 +108,19 @@ class Provider extends AbstractProvider
     /**
      * Get the client access token response.
      *
-     * @param string|null $scope
+     * @param array|string $scopes
      *
      * @return array
      */
-    public function getClientAccessTokenResponse(string $scope = null)
+    public function getClientAccessTokenResponse($scopes = null)
     {
+        $scopes = $scopes ?? $this->getScopes();
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             RequestOptions::AUTH        => [$this->clientId, $this->clientSecret],
             RequestOptions::HEADERS     => ['Cache-Control' => 'no-cache'],
             RequestOptions::FORM_PARAMS => [
                 'grant_type' => 'client_credentials',
-                'scope'      => $scope ?? '',
+                'scope'      => $this->formatScopes((array) $scopes, $this->scopeSeparator),
             ],
         ]);
 


### PR DESCRIPTION
I'm realizing it's advisable to be consistent with the existing
conventions for setting the scopes. In all other cases scopes are set as
an array.

Using existing scopes to accommodate for situations where the user might
be registering the provider globally:
```
$provider = Socialite::driver('okta')->setScopes(['offline_access', 'openid']);
```

I believe it still makes sense to allow overrides directly to accommodate for
situations when both:

- a client access token scope would differ from the user scope
- the provider is registered as a singleton
- you're requesting both types of tokens on the same request

granted that seems pretty rare, so perhaps the override isn't necessary.

