### PR TITLE
fix eve jwt issue

### DIFF
--- a/src/Eveonline/composer.json
+++ b/src/Eveonline/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "firebase/php-jwt": "^5.2 || ^6.0",
+        "firebase/php-jwt": "^6.0",
         "socialiteproviders/manager": "^4.0"
     },
     "autoload": {


### PR DESCRIPTION
As discussed in https://github.com/SocialiteProviders/Providers/issues/813

This PR reverts the following PR: "Re-add firebase/php-jwt v5.2 to composer for eveonline provider (#807)"
This reverts commit 9e494cbfb615866bd6aac4e469fdc007158417f8.

### ⚠️ Attention:
Besides merging this PR and tagging you **must** delete the previous 4.1.0 tag not only on github but on packagist too:
https://github.com/SocialiteProviders/Eveonline/tags
<img width="444" alt="image" src="https://user-images.githubusercontent.com/6583519/156912793-267c287b-8af4-4775-a002-afe4799dcfe0.png">
<img width="1069" alt="image" src="https://user-images.githubusercontent.com/6583519/156912841-5a0d859a-c5d4-49f7-b625-1299a54fb7b3.png">

then you can re-tag which should then contain the merged commit/pr with 4.1.0.

If you do not remove the old *4.1.0* tag, composer will still download the broken version from packagist for anyone using the v5 firebase/php-jwt library 



