### PR TITLE
AzureADB2C: make it possible to define multiple policies

### DIFF
--- a/src/AzureADB2C/Provider.php
+++ b/src/AzureADB2C/Provider.php
@@ -26,11 +26,21 @@ class Provider extends AbstractProvider
         'openid',
     ];
 
+    /**
+     * Get the policy.
+     *
+     * @return string
+     */
     private function getPolicy()
     {
         return $this->parameters['policy'] ?? 'login';
     }
 
+    /**
+     * Get the B2C policy.
+     *
+     * @return mixed
+     */
     private function getB2CPolicy()
     {
         $policy = $this->getConfig('policy');
@@ -42,6 +52,11 @@ class Provider extends AbstractProvider
         return $policy;
     }
 
+    /**
+     * Set the redirect URL.
+     *
+     * @return void
+     */
     private function setRedirectUrl()
     {
         $redirectTemplate = $this->getConfig('redirect_template');


### PR DESCRIPTION
fixes https://github.com/SocialiteProviders/Providers/issues/818

This all feels quite hacky, especially overriding the `redirectUrl` but I didn't manage to figure out another way.

Note I am using SocialStream, so I had to override quite a few things there as well, to pass the policy as a parameter to the `Provider`

```
Socialite::driver($provider)
  ->with(['policy' => $policy])
  ->redirect();
```

I hope I sufficiently taken care of backwards compatibility.