### PR TITLE
Turn off http errors when fetching Microsoft avatars

### DIFF
--- a/src/Microsoft/MicrosoftUser.php
+++ b/src/Microsoft/MicrosoftUser.php
@@ -14,6 +14,7 @@ class MicrosoftUser extends User
     public function getAvatar()
     {
         $client = new Client();
+        
         try {
             $response = $client->get(
                 'https://graph.microsoft.com/v1.0/me/photo/$value',
@@ -24,7 +25,6 @@ class MicrosoftUser extends User
                     ],
                 ]
             );
-
             return (new MicrosoftAvatar())->setResponse($response);
         } catch (\GuzzleHttp\Exception\ClientException $e) {
             return null;

--- a/src/Microsoft/MicrosoftUser.php
+++ b/src/Microsoft/MicrosoftUser.php
@@ -13,7 +13,7 @@ class MicrosoftUser extends User
      */
     public function getAvatar()
     {
-        $client = new Client();
+        $client = new Client(['http_errors' => false]);
         $response = $client->get(
             'https://graph.microsoft.com/v1.0/me/photo/$value',
             [

--- a/src/Microsoft/MicrosoftUser.php
+++ b/src/Microsoft/MicrosoftUser.php
@@ -3,6 +3,7 @@
 namespace SocialiteProviders\Microsoft;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\RequestOptions;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -27,7 +28,7 @@ class MicrosoftUser extends User
             );
 
             return (new MicrosoftAvatar())->setResponse($response);
-        } catch (\GuzzleHttp\Exception\ClientException $e) {
+        } catch (ClientException $e) {
             return null;
         }
     }

--- a/src/Microsoft/MicrosoftUser.php
+++ b/src/Microsoft/MicrosoftUser.php
@@ -14,7 +14,7 @@ class MicrosoftUser extends User
     public function getAvatar()
     {
         $client = new Client();
-        
+
         try {
             $response = $client->get(
                 'https://graph.microsoft.com/v1.0/me/photo/$value',
@@ -25,6 +25,7 @@ class MicrosoftUser extends User
                     ],
                 ]
             );
+
             return (new MicrosoftAvatar())->setResponse($response);
         } catch (\GuzzleHttp\Exception\ClientException $e) {
             return null;

--- a/src/Microsoft/MicrosoftUser.php
+++ b/src/Microsoft/MicrosoftUser.php
@@ -13,17 +13,21 @@ class MicrosoftUser extends User
      */
     public function getAvatar()
     {
-        $client = new Client(['http_errors' => false]);
-        $response = $client->get(
-            'https://graph.microsoft.com/v1.0/me/photo/$value',
-            [
-                RequestOptions::HEADERS => [
-                    'Accept'        => 'image/*',
-                    'Authorization' => 'Bearer '.$this->token,
-                ],
-            ]
-        );
+        $client = new Client();
+        try {
+            $response = $client->get(
+                'https://graph.microsoft.com/v1.0/me/photo/$value',
+                [
+                    RequestOptions::HEADERS => [
+                        'Accept'        => 'image/*',
+                        'Authorization' => 'Bearer '.$this->token,
+                    ],
+                ]
+            );
 
-        return (new MicrosoftAvatar())->setResponse($response);
+            return (new MicrosoftAvatar())->setResponse($response);
+        } catch (\GuzzleHttp\Exception\ClientException $e) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/SocialiteProviders/Providers/issues/824 where a 404 error bubbles up if the avatar doesn't exist