### PR TITLE
Use short arrow closures

### DIFF
--- a/src/Bitly/Provider.php
+++ b/src/Bitly/Provider.php
@@ -60,7 +60,7 @@ class Provider extends AbstractProvider
             'id'       => null,
             'nickname' => $user['login'],
             'name'     => $user['name'],
-            'email'    => Arr::collapse(Arr::where($user['emails'], fn($value) => $value['is_primary']))['email'],
+            'email'    => Arr::collapse(Arr::where($user['emails'], fn ($value) => $value['is_primary']))['email'],
         ]);
     }
 

--- a/src/Bitly/Provider.php
+++ b/src/Bitly/Provider.php
@@ -60,9 +60,7 @@ class Provider extends AbstractProvider
             'id'       => null,
             'nickname' => $user['login'],
             'name'     => $user['name'],
-            'email'    => Arr::collapse(Arr::where($user['emails'], function ($value) {
-                return $value['is_primary'];
-            }))['email'],
+            'email'    => Arr::collapse(Arr::where($user['emails'], fn($value) => $value['is_primary']))['email'],
         ]);
     }
 

--- a/src/Minecraft/Provider.php
+++ b/src/Minecraft/Provider.php
@@ -84,7 +84,7 @@ class Provider extends AbstractProvider
     {
         $uuid = preg_replace('/(.{8})(.{4})(.{4})(.{4})(.{12})/', '$1-$2-$3-$4-$5', $user['id']);
 
-        $activeSkin = array_filter($user['skins'], fn($skin) => $skin['state'] === 'ACTIVE');
+        $activeSkin = array_filter($user['skins'], fn ($skin) => $skin['state'] === 'ACTIVE');
 
         $avatar = count($activeSkin) === 1 ? $activeSkin[0]['url'] : null;
 

--- a/src/Minecraft/Provider.php
+++ b/src/Minecraft/Provider.php
@@ -82,11 +82,9 @@ class Provider extends AbstractProvider
      */
     protected function mapUserToObject(array $user)
     {
-        $activeSkin = array_filter($user['skins'], function ($skin) {
-            return 'ACTIVE' === $skin['state'];
-        });
-
         $uuid = preg_replace('/(.{8})(.{4})(.{4})(.{4})(.{12})/', '$1-$2-$3-$4-$5', $user['id']);
+
+        $activeSkin = array_filter($user['skins'], fn($skin) => $skin['state'] === 'ACTIVE');
 
         $avatar = count($activeSkin) === 1 ? $activeSkin[0]['url'] : null;
 

--- a/src/Telegram/Provider.php
+++ b/src/Telegram/Provider.php
@@ -105,9 +105,7 @@ class Provider extends AbstractProvider
         throw_if($validator->fails(), InvalidArgumentException::class);
 
         $dataToHash = collect($this->request->except('hash'))
-                        ->transform(function ($val, $key) {
-                            return "$key=$val";
-                        })
+                        ->transform(fn($val, $key) => "$key=$val")
                         ->sort()
                         ->join("\n");
 

--- a/src/Telegram/Provider.php
+++ b/src/Telegram/Provider.php
@@ -105,7 +105,7 @@ class Provider extends AbstractProvider
         throw_if($validator->fails(), InvalidArgumentException::class);
 
         $dataToHash = collect($this->request->except('hash'))
-                        ->transform(fn($val, $key) => "$key=$val")
+                        ->transform(fn ($val, $key) => "$key=$val")
                         ->sort()
                         ->join("\n");
 

--- a/tools/close-subtree-prs.php
+++ b/tools/close-subtree-prs.php
@@ -9,10 +9,10 @@ use Zttp\Zttp;
  * documentation.
  */
 $repos = collect(range(1, 5))
-    ->map(fn(int $page) => Zttp::withHeaders(['Accept' => 'application/vnd.github.v3+json'])->get('https://api.github.com/orgs/SocialiteProviders/repos?per_page=100&page='.$page)->json())
+    ->map(fn (int $page) => Zttp::withHeaders(['Accept' => 'application/vnd.github.v3+json'])->get('https://api.github.com/orgs/SocialiteProviders/repos?per_page=100&page='.$page)->json())
     ->flatten(1)
     ->sortBy('name')
-    ->filter(fn(array $repo) => $repo['has_issues'] === false)
+    ->filter(fn (array $repo) => $repo['has_issues'] === false)
     ->each(function (array $repo) {
         $res = Zttp::withHeaders([
             'Accept'        => 'application/vnd.github.v3+json',

--- a/tools/close-subtree-prs.php
+++ b/tools/close-subtree-prs.php
@@ -9,14 +9,10 @@ use Zttp\Zttp;
  * documentation.
  */
 $repos = collect(range(1, 5))
-    ->map(function (int $page) {
-        return Zttp::withHeaders(['Accept' => 'application/vnd.github.v3+json'])->get('https://api.github.com/orgs/SocialiteProviders/repos?per_page=100&page='.$page)->json();
-    })
+    ->map(fn(int $page) => Zttp::withHeaders(['Accept' => 'application/vnd.github.v3+json'])->get('https://api.github.com/orgs/SocialiteProviders/repos?per_page=100&page='.$page)->json())
     ->flatten(1)
     ->sortBy('name')
-    ->filter(function (array $repo) {
-        return $repo['has_issues'] === false;
-    })
+    ->filter(fn(array $repo) => $repo['has_issues'] === false)
     ->each(function (array $repo) {
         $res = Zttp::withHeaders([
             'Accept'        => 'application/vnd.github.v3+json',

--- a/tools/release-major-version.php
+++ b/tools/release-major-version.php
@@ -19,13 +19,9 @@ $excludedRepos = [
 define('NEW_VERSION', '4.0.0');
 
 $repos = collect(range(1, 5))
-    ->map(function (int $page) {
-        return Zttp::withHeaders(['Accept' => 'application/vnd.github.v3+json'])->get('https://api.github.com/orgs/SocialiteProviders/repos?per_page=100&page='.$page)->json();
-    })
+    ->map(fn(int $page) => Zttp::withHeaders(['Accept' => 'application/vnd.github.v3+json'])->get('https://api.github.com/orgs/SocialiteProviders/repos?per_page=100&page='.$page)->json())
     ->flatten(1)
-    ->filter(function (array $repo) {
-        return $repo['description'] && str_contains($repo['description'], '[READ ONLY] Subtree split');
-    })
+    ->filter(fn(array $repo) => $repo['description'] && str_contains($repo['description'], '[READ ONLY] Subtree split'))
     ->sortBy('name')
     ->each(function (array $repo) {
         $res = Zttp::withHeaders([
@@ -33,9 +29,7 @@ $repos = collect(range(1, 5))
             'Authorization' => 'token '.getenv('GITHUB_TOKEN'),
         ])->get($repo['url'].'/releases');
 
-        $higherThanNew = collect($res->json())->filter(function (array $rel) {
-            return Comparator::greaterThanOrEqualTo($rel['tag_name'], NEW_VERSION);
-        });
+        $higherThanNew = collect($res->json())->filter(fn(array $rel) => Comparator::greaterThanOrEqualTo($rel['tag_name'], NEW_VERSION));
 
         if ($higherThanNew->isNotEmpty()) {
             echo sprintf("Found Higher Release %s for provider %s, skipping\n", $higherThanNew->first()['tag_name'], $repo['name']);

--- a/tools/release-major-version.php
+++ b/tools/release-major-version.php
@@ -19,9 +19,9 @@ $excludedRepos = [
 define('NEW_VERSION', '4.0.0');
 
 $repos = collect(range(1, 5))
-    ->map(fn(int $page) => Zttp::withHeaders(['Accept' => 'application/vnd.github.v3+json'])->get('https://api.github.com/orgs/SocialiteProviders/repos?per_page=100&page='.$page)->json())
+    ->map(fn (int $page) => Zttp::withHeaders(['Accept' => 'application/vnd.github.v3+json'])->get('https://api.github.com/orgs/SocialiteProviders/repos?per_page=100&page='.$page)->json())
     ->flatten(1)
-    ->filter(fn(array $repo) => $repo['description'] && str_contains($repo['description'], '[READ ONLY] Subtree split'))
+    ->filter(fn (array $repo) => $repo['description'] && str_contains($repo['description'], '[READ ONLY] Subtree split'))
     ->sortBy('name')
     ->each(function (array $repo) {
         $res = Zttp::withHeaders([
@@ -29,7 +29,7 @@ $repos = collect(range(1, 5))
             'Authorization' => 'token '.getenv('GITHUB_TOKEN'),
         ])->get($repo['url'].'/releases');
 
-        $higherThanNew = collect($res->json())->filter(fn(array $rel) => Comparator::greaterThanOrEqualTo($rel['tag_name'], NEW_VERSION));
+        $higherThanNew = collect($res->json())->filter(fn (array $rel) => Comparator::greaterThanOrEqualTo($rel['tag_name'], NEW_VERSION));
 
         if ($higherThanNew->isNotEmpty()) {
             echo sprintf("Found Higher Release %s for provider %s, skipping\n", $higherThanNew->first()['tag_name'], $repo['name']);

--- a/tools/update-repo-descriptions.php
+++ b/tools/update-repo-descriptions.php
@@ -17,9 +17,9 @@ $excludedRepos = [
 ];
 
 $repos = collect(range(1, 5))
-    ->map(fn(int $page) => Zttp::withHeaders(['Accept' => 'application/vnd.github.v3+json'])->get('https://api.github.com/orgs/SocialiteProviders/repos?per_page=100&page='.$page)->json())
+    ->map(fn (int $page) => Zttp::withHeaders(['Accept' => 'application/vnd.github.v3+json'])->get('https://api.github.com/orgs/SocialiteProviders/repos?per_page=100&page='.$page)->json())
     ->flatten(1)
-    ->filter(fn(array $repo) => !$repo['archived'] && !in_array($repo['name'], $excludedRepos, true))
+    ->filter(fn (array $repo) => !$repo['archived'] && !in_array($repo['name'], $excludedRepos, true))
     ->sortBy('name')
     ->each(function (array $repo) {
         $res = Zttp::withHeaders([

--- a/tools/update-repo-descriptions.php
+++ b/tools/update-repo-descriptions.php
@@ -17,13 +17,9 @@ $excludedRepos = [
 ];
 
 $repos = collect(range(1, 5))
-    ->map(function (int $page) {
-        return Zttp::withHeaders(['Accept' => 'application/vnd.github.v3+json'])->get('https://api.github.com/orgs/SocialiteProviders/repos?per_page=100&page='.$page)->json();
-    })
+    ->map(fn(int $page) => Zttp::withHeaders(['Accept' => 'application/vnd.github.v3+json'])->get('https://api.github.com/orgs/SocialiteProviders/repos?per_page=100&page='.$page)->json())
     ->flatten(1)
-    ->filter(function (array $repo) use ($excludedRepos) {
-        return !$repo['archived'] && !in_array($repo['name'], $excludedRepos, true);
-    })
+    ->filter(fn(array $repo) => !$repo['archived'] && !in_array($repo['name'], $excludedRepos, true))
     ->sortBy('name')
     ->each(function (array $repo) {
         $res = Zttp::withHeaders([


### PR DESCRIPTION
Since we have recently bumped the codebase to `>=7.4`, we can now safely use short arrow closures.