### PR TITLE
Do not limit the number of commits to fetch

### DIFF
--- a/.github/workflows/subtree-pr-close.yml
+++ b/.github/workflows/subtree-pr-close.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
As per #820, the upgrade of https://github.com/actions/checkout v3 has broken the subtree split.
This seems related to the depth (or history) this change allows to get all history for all branches and tags.

