### PR TITLE
Update Cognito Provider

### DIFF
--- a/src/Cognito/Provider.php
+++ b/src/Cognito/Provider.php
@@ -91,6 +91,7 @@ class Provider extends AbstractProvider
             'nickname' => $user['nickname'] ?? null,
             'name'     => trim(Arr::get($user, 'given_name', '').' '.Arr::get($user, 'family_name', '')),
             'email'    => $user['email'] ?? null,
+            'avatar'   => null,
         ]);
     }
 

--- a/src/Cognito/Provider.php
+++ b/src/Cognito/Provider.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\Cognito;
 
+use Illuminate\Support\Arr;
 use GuzzleHttp\RequestOptions;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
@@ -85,7 +86,12 @@ class Provider extends AbstractProvider
      */
     protected function mapUserToObject(array $user)
     {
-        return (new User())->setRaw($user);
+        return (new User())->setRaw($user)->map([
+            'id' => $user['sub'] ?? null,
+            'nickname' => $user['nickname'] ?? null,
+            'name' => trim(Arr::get($user, 'given_name', '').' '.Arr::get($user, 'family_name', '')),
+            'email' => $user['email'] ?? null,
+        ]);
     }
 
     /**

--- a/src/Cognito/Provider.php
+++ b/src/Cognito/Provider.php
@@ -86,13 +86,7 @@ class Provider extends AbstractProvider
      */
     protected function mapUserToObject(array $user)
     {
-        return (new User())->setRaw($user)->map([
-            'id'       => $user['sub'],
-            'nickname' => $user['nickname'],
-            'name'     => trim(Arr::get($user, 'given_name', '').' '.Arr::get($user, 'family_name', '')),
-            'email'    => $user['email'],
-            'avatar'   => null,
-        ]);
+        return (new User())->setRaw($user);
     }
 
     /**

--- a/src/Cognito/Provider.php
+++ b/src/Cognito/Provider.php
@@ -2,8 +2,8 @@
 
 namespace SocialiteProviders\Cognito;
 
-use Illuminate\Support\Arr;
 use GuzzleHttp\RequestOptions;
+use Illuminate\Support\Arr;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -87,10 +87,10 @@ class Provider extends AbstractProvider
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([
-            'id' => $user['sub'] ?? null,
+            'id'       => $user['sub'] ?? null,
             'nickname' => $user['nickname'] ?? null,
-            'name' => trim(Arr::get($user, 'given_name', '').' '.Arr::get($user, 'family_name', '')),
-            'email' => $user['email'] ?? null,
+            'name'     => trim(Arr::get($user, 'given_name', '').' '.Arr::get($user, 'family_name', '')),
+            'email'    => $user['email'] ?? null,
         ]);
     }
 

--- a/src/Cognito/Provider.php
+++ b/src/Cognito/Provider.php
@@ -3,7 +3,6 @@
 namespace SocialiteProviders\Cognito;
 
 use GuzzleHttp\RequestOptions;
-use Illuminate\Support\Arr;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 


### PR DESCRIPTION
Removed Cognito provider fields that can cause errors.
Errors were occurring when the Cognito user pool doesn't have these same fields defined.