### PR TITLE
add missing Starling user fields

### DIFF
--- a/src/Starling/Provider.php
+++ b/src/Starling/Provider.php
@@ -93,6 +93,8 @@ class Provider extends AbstractProvider
             'id'    => $user['accountHolderUid'],
             'name'  => trim(sprintf('%s %s %s', $user['title'], $user['firstName'], $user['lastName'])),
             'email' => $user['email'],
+            'phone' => $user['phone'],
+            'dateOfBirth' => $user['dateOfBirth'],
         ]);
     }
 


### PR DESCRIPTION
Updates the User returned for Starling, adding the phone and dateOfBirth fields that are returned (according the API docs at https://developer.starlingbank.com/docs#api-reference-1)

description: | Information about an individual account holder
-- | --
title | string example: Mr
firstName | string example: Dave
lastName | string example: Bowman
dateOfBirth | string($date) example: 1968-04-02
email | string example: dave.bowman@example.com
phone | string example: +447700900123
