### PR TITLE
apple: Support for newer versions

### DIFF
--- a/src/Apple/composer.json
+++ b/src/Apple/composer.json
@@ -36,7 +36,7 @@
         "ext-openssl": "*",
         "firebase/php-jwt": "^5.2",
         "lcobucci/jwt": "^4.0",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.0"
     },
     "suggest": {
         "ahilmurugesan/socialite-apple-helper": "Automatic Apple client key generation and management."


### PR DESCRIPTION
I have a project using Laravel, and I've been trying to upgrade to Laravel 9, however, this package manager was locked at 4.0. Newer version 4.1 has added support for laravel 9 which I'm after.