### PR TITLE
add IMIS provider

### DIFF
--- a/src/Imis/ImisExtendSocialite.php
+++ b/src/Imis/ImisExtendSocialite.php
@@ -9,7 +9,7 @@ class ImisExtendSocialite
     /**
      * Register the provider.
      *
-     * @param \SocialiteProviders\Manager\SocialiteWasCalled $socialiteWasCalled
+     * @param  \SocialiteProviders\Manager\SocialiteWasCalled  $socialiteWasCalled
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {

--- a/src/Imis/ImisExtendSocialite.php
+++ b/src/Imis/ImisExtendSocialite.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SocialiteProviders\Imis;
+
+use SocialiteProviders\Manager\SocialiteWasCalled;
+
+class ImisExtendSocialite
+{
+    /**
+     * Register the provider.
+     *
+     * @param \SocialiteProviders\Manager\SocialiteWasCalled $socialiteWasCalled
+     */
+    public function handle(SocialiteWasCalled $socialiteWasCalled)
+    {
+        $socialiteWasCalled->extendSocialite('imis', Provider::class);
+    }
+}

--- a/src/Imis/ImisExtendSocialite.php
+++ b/src/Imis/ImisExtendSocialite.php
@@ -9,7 +9,7 @@ class ImisExtendSocialite
     /**
      * Register the provider.
      *
-     * @param  \SocialiteProviders\Manager\SocialiteWasCalled  $socialiteWasCalled
+     * @param \SocialiteProviders\Manager\SocialiteWasCalled $socialiteWasCalled
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {

--- a/src/Imis/Provider.php
+++ b/src/Imis/Provider.php
@@ -93,7 +93,7 @@ class Provider extends AbstractProvider
     protected function mapUserToObject(array $user)
     {
         // No IMIS guest users allowed. Throw an exception.
-        if (! isset($user['Items']['$values'][0]) || count($user['Items']['$values'][0]) < 1) {
+        if (!isset($user['Items']['$values'][0]) || count($user['Items']['$values'][0]) < 1) {
             throw new InvalidArgumentException('Guest user is not allowed');
         }
 

--- a/src/Imis/Provider.php
+++ b/src/Imis/Provider.php
@@ -75,19 +75,19 @@ class Provider extends AbstractProvider
     protected function getTokenFields($code)
     {
         return array_merge(parent::getTokenFields($code), [
-            'grant_type' => 'refresh_token',
+            'grant_type'    => 'refresh_token',
             'refresh_token' => $code,
         ]);
     }
 
     /**
-     * Returned user array containing all available user attributes
-     * Modified IMIS aliases to match standard OAuth2 claims - https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims.
+     * Returns a user array containing all available user attributes
+     * Modify IMIS aliases to match standard OAuth2 claims - https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims.
      *
-     * Assert is used to cencel the creation of the user and allow a redirect to the login url.
-     * https://www.php.net/manual/en/function.assert-options.php
+     * You can catch InvalidArgumentException and use that to redirect the user back to IMIS.
      *
      * {@inheritdoc}
+     *
      * @throws \InvalidArgumentException
      */
     protected function mapUserToObject(array $user)
@@ -100,11 +100,11 @@ class Provider extends AbstractProvider
         $user = $user['Items']['$values'][0];
 
         return (new User())->setRaw($user)->map([
-            'id' => $user['sub'] ?? null,
+            'id'       => $user['sub'] ?? null,
             'nickname' => null,
-            'name' => trim(($user['given_name'] ?? '').' '.($user['family_name'] ?? '')),
-            'email' => $user['email'] ?? null,
-            'avatar' => null,
+            'name'     => trim(($user['given_name'] ?? '').' '.($user['family_name'] ?? '')),
+            'email'    => $user['email'] ?? null,
+            'avatar'   => null,
         ]);
     }
 

--- a/src/Imis/Provider.php
+++ b/src/Imis/Provider.php
@@ -29,7 +29,7 @@ class Provider extends AbstractProvider
      */
     protected function getAuthUrl($state)
     {
-        return $this->buildAuthUrlFromBase($this->getImisUrl() . $this->getConfig('client_id').'.aspx', $state);
+        return $this->buildAuthUrlFromBase($this->getImisUrl().$this->getConfig('client_id').'.aspx', $state);
     }
 
     /**

--- a/src/Imis/Provider.php
+++ b/src/Imis/Provider.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace SocialiteProviders\Imis;
+
+use GuzzleHttp\RequestOptions;
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
+use SocialiteProviders\Manager\OAuth2\User;
+
+class Provider extends AbstractProvider
+{
+    /**
+     * Unique Provider Identifier.
+     */
+    public const IDENTIFIER = 'Imis';
+
+    /**
+     * Get the host Base URL.
+     *
+     * @return string
+     */
+    protected function getImisUrl()
+    {
+        return $this->getConfig('host');
+    }
+
+    /**
+     * {@inheritdoc}
+     * Get the login URL, Links to IMIS SSO Client Application.
+     */
+    protected function getAuthUrl($state)
+    {
+        return $this->buildAuthUrlFromBase($this->getImisUrl() . $this->getConfig('client_id').'.aspx', $state);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenUrl(): string
+    {
+        return $this->getImisUrl().'/token';
+    }
+
+    /**
+     * {@inheritdoc}
+     * IMIS does not support userInfo endpoints, so a custom query must be used.
+     */
+    protected function getUserByToken($token): array
+    {
+        $response = $this->getHttpClient()->get($this->getConfig('host').'/api/query?QueryName=$/OAuth2/userInfo', [
+            RequestOptions::HEADERS => [
+                'Authorization' => 'Bearer '.$token,
+            ],
+        ]);
+
+        return json_decode((string) $response->getBody(), true);
+    }
+
+    /**
+     * {@inheritdoc}
+     * Required fields to get the Bearer Token.
+     */
+    protected function getTokenFields($code)
+    {
+        return array_merge(parent::getTokenFields($code), [
+            'grant_type'    => 'refresh_token',
+            'client_id'     => $this->getConfig('client_id'),
+            'client_secret' => $this->getConfig('client_secret'),
+            'refresh_token' => $code,
+        ]);
+    }
+
+    /**
+     * Returned user array containing all available user attributes
+     * Modified IMIS aliases to match standard OAuth2 claims - https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims.
+     *
+     * Assert is used to cencel the creation of the user and allow a redirect to the login url.
+     * https://www.php.net/manual/en/function.assert-options.php
+     *
+     * {@inheritdoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+        // No IMIS guest users allowed. Redirect to login.
+        assert(isset($user['Items']['$values'][0]) && count($user['Items']['$values'][0]) > 0, 'Guest user is not allowed');
+
+        $user = $user['Items']['$values'][0];
+
+        return (new User())->setRaw($user)->map([
+            'id'       => $user['sub'] ?? null,
+            'nickname' => null,
+            'name'     => trim(($user['given_name'] ?? '').' '.($user['family_name'] ?? '')),
+            'email'    => $user['email'] ?? null,
+            'avatar'   => null,
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function additionalConfigKeys(): array
+    {
+        return [
+            'host',
+            'login_url',
+            'client_id',
+            'client_secret',
+            'query_name',
+            'redirect',
+        ];
+    }
+}

--- a/src/Imis/README.md
+++ b/src/Imis/README.md
@@ -1,0 +1,186 @@
+# IMIS
+
+[Imis.com](https://imis.com)
+
+```bash
+composer require socialiteproviders/imis
+```
+
+## Installation & Basic Usage
+
+Please see the [Base Installation Guide](https://socialiteproviders.com/usage/), then follow the provider specific instructions below.
+
+### Add configuration to `config/services.php`
+
+```php
+'imis' => [
+    'host' => env('IMIS_HOST'),
+    'login_url' => env('IMIS_LOGIN_URL'),
+    'client_id' => env('IMIS_CLIENT_ID'),
+    'client_secret' => env('IMIS_CLIENT_SECRET'),
+    'redirect' => env('IMIS_CALLBACK_URL'),
+],
+```
+
+### Add provider event listener
+
+Configure the package's listener to listen for `SocialiteWasCalled` events.
+
+Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. See the [Base Installation Guide](https://socialiteproviders.com/usage/) for detailed instructions.
+
+```php
+protected $listen = [
+    \SocialiteProviders\Manager\SocialiteWasCalled::class => [
+        // add your listeners (aka providers) here
+        'SocialiteProviders\\Imis\\ImisExtendSocialite@handle',
+    ],
+];
+```
+
+### Usage
+
+You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
+
+```php
+return Socialite::driver('imis')->redirect();
+```
+
+
+Example env
+```php
+IMIS_HOST=https://www.public-imis-site.com
+IMIS_LOGIN_URL=Web/Sign-in.aspx
+IMIS_CLIENT_ID=MySSOApp
+IMIS_CLIENT_SECRET=
+IMIS_CALLBACK_URL=https://example-laravel-site.com/oauth2/imis/callback
+```
+
+<hr>
+
+### Creating the IMIS UserInfo Query
+
+Create directory in root: 'OAuth2' and create query inside this directory.
+
+Define > Summary Tab
+
+- Name: userInfo
+
+- Description:
+
+  SSO user Info
+  Built to OAuth2 Standards
+  https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+
+Define > Sources Tab
+
+- Sources: UserData + PartyData
+- Relations: Custom (When UserData.Party Id = PartyData.Party Id)
+
+Define > Filters
+
+- Property: Where PartyData.Party Id
+- Function: None
+- Comparison: Equal
+- Value: Dynamic
+- LoggedInUserKey
+- Prompt: No
+- Limit number of results to 1
+
+Define > Display
+
+- PartyData.Party Id - Alias 'sub'
+- UserData.Username - Alias 'username'
+- UserData.Email - Alias 'email'
+- PartyData.First Name - Alias 'given_name'
+- PartyData.Last Name - Alias 'family_name'
+
+Response
+
+```html
+https://{{URL}}/api/query?QueryName=$/OAuth2/userInfo
+```
+
+```json
+{
+    "$type": "Asi.Soa.Core.DataContracts.PagedResult, Asi.Contracts",
+    "Items": {
+        "$type": "System.Collections.Generic.List`1[[System.Object, mscorlib]], mscorlib",
+        "$values": [
+            {
+                "$type": "System.Dynamic.ExpandoObject, System.Core",
+                "sub": "123456aa-UUID-0000-0000-000000000000",
+                "username": "EXAMPLE@EXAMPLE.COM.AU",
+                "email": "example@example.com",
+                "given_name": "First",
+                "family_name": "Last"
+            }
+        ]
+    },
+    "Offset": 0,
+    "Limit": 100,
+    "Count": 1,
+    "TotalCount": 1,
+    "NextPageLink": null,
+    "HasNext": false,
+    "NextOffset": 0
+}
+```
+<hr>
+
+#### Helpful tips
+
+- [SSO Setup Info](https://blog.jamessiebert.com/laravel-socialite-imis-tutorial/)
+- [Migrating from IQA to Query Service](https://developer.imis.com/docs/migrating-from-iqa-to-query-service-endpoint)
+- In IMIS use the same name for the Client ID and the SSO content item
+- A custom query needs to be created to return the user info, userInfo endpoints are not supported by Imis
+- Imis returns a 'refresh_token' instead of the auth code so the provider has been modified to handle this.
+- Imis does return values when a user is not logged in. The refresh_token and bearer token relate to a Guest user.
+  As the guest user has no user attributes, we should not allow this in our laravel app.
+  This is how I handle this:
+
+    ```php
+    // -- When handling a POST to the callback url
+    
+        public function oauthHandleCallback(Request $request, String $provider): RedirectResponse
+        {
+            switch ($provider) {
+            
+                case "imis":
+    
+                        // Copy 'refresh_token' to a 'code' for use in Socialite
+                        $request->request->add(['code' => $request->post('refresh_token')]);
+    
+                        // Fails if user is a guest
+                        try {
+                            $user = Socialite::driver('imis')->stateless()->user();
+                        }
+                        catch(\Throwable $e) {
+                            // Redirect to Imis login
+                            return redirect()->away(config('services.imis.host').'/'.config('services.imis.login_url'));
+                        }
+                    break;
+    
+                default:
+                    dd('provider fail not found');
+            }
+    
+            $authUser = $this->findOrCreateUser($user, $provider);
+    
+            Auth::login($authUser, true);
+    
+            return redirect(config('app.url').'/member');
+        }
+    ```
+
+
+[project setup tutorial](https://blog.jamessiebert.com/laravel-socialite-imis-tutorial)
+
+### Returned User fields
+
+- ``id``
+- ``nickname``
+- ``name``
+- ``email``
+- ``avatar``
+- ``user[]``
+

--- a/src/Imis/composer.json
+++ b/src/Imis/composer.json
@@ -2,7 +2,6 @@
     "name": "socialiteproviders/imis",
     "description": "IMIS OAuth2 Provider for Laravel Socialite",
     "keywords": [
-        "aws",
         "imis",
         "laravel",
         "oauth",

--- a/src/Imis/composer.json
+++ b/src/Imis/composer.json
@@ -1,0 +1,34 @@
+{
+    "name": "socialiteproviders/imis",
+    "description": "IMIS OAuth2 Provider for Laravel Socialite",
+    "keywords": [
+        "aws",
+        "imis",
+        "laravel",
+        "oauth",
+        "provider",
+        "socialite"
+    ],
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "James Siebert",
+            "email": "js@jamessiebert.com"
+        }
+    ],
+    "require": {
+        "php": "^7.4 || ^8.0",
+        "ext-json": "*",
+        "socialiteproviders/manager": "~4.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialiteProviders\\Imis\\": ""
+        }
+    },
+    "support": {
+        "issues": "https://github.com/socialiteproviders/providers/issues",
+        "source": "https://github.com/socialiteproviders/providers",
+        "docs": "https://socialiteproviders.com/imis"
+    }
+}


### PR DESCRIPTION
https://imis.com/

Notes:
- IMIS doesn't strictly follow the OAuth2 standard.
- A refresh token is returned instead of an auth code.
- IMIS can return a guest user with no data, this has been allowed for.
- IMIS doesn't support the userInfo endpoint so a custom query needs to be created on the IMIS site.