### PR TITLE
Update lightsaml/lightsaml with new replacement package

### DIFF
--- a/src/Saml2/composer.json
+++ b/src/Saml2/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-         "litesaml/lightsaml": "^3.0",
+        "litesaml/lightsaml": "^3.0",
         "socialiteproviders/manager": "~4.0"
     },
     "autoload": {

--- a/src/Saml2/composer.json
+++ b/src/Saml2/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "lightsaml/lightsaml": "^2.0",
+         "litesaml/lightsaml": "^3.0",
         "socialiteproviders/manager": "~4.0"
     },
     "autoload": {


### PR DESCRIPTION
The `lightsaml/lightsaml` package has been marked as abandoned, with `litesaml/lightsaml` as the suggested replacement.
See [relevant commit](https://github.com/lightSAML/lightSAML/commit/22ac715f3feb499eaa5a8a61c9cd78ae468613f0).

<img width="908" alt="image" src="https://user-images.githubusercontent.com/21138205/170944215-0b01e3ae-d4e2-4165-82cc-b1ab6a7e4580.png">

According to the old package's README, the codebase did not change.