### PR TITLE
fix: keycloak logout url

### DIFF
--- a/src/Keycloak/Provider.php
+++ b/src/Keycloak/Provider.php
@@ -87,10 +87,18 @@ class Provider extends AbstractProvider
     /**
      * Return logout endpoint with redirect_uri query parameter.
      *
+     * @param string|null $redirectUri
+     *
      * @return string
      */
-    public function getLogoutUrl(string $redirectUri)
+    public function getLogoutUrl(?string $redirectUri = null): string
     {
-        return $this->getBaseUrl().'/protocol/openid-connect/logout?redirect_uri='.urlencode($redirectUri);
+        $logoutUrl = $this->getBaseUrl() . '/protocol/openid-connect/logout';
+
+        if ($redirectUri === null) {
+            return $logoutUrl;
+        }
+
+        return $logoutUrl . '?redirect_uri=' . urlencode($redirectUri);
     }
 }


### PR DESCRIPTION
Closes https://github.com/SocialiteProviders/Providers/issues/859

Allow passing null to generate a logout url without the redirect param as per 
https://www.keycloak.org/docs/latest/upgrading/index.html#openid-connect-logout