### PR TITLE
Bump to PHP 8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         validate: [ false ]
         fail-fast: [ false ]
-        php-versions: [  '8.0', '8.1' ]
+        php-versions: [ '8.0', '8.1' ]
         exclude:
           - php-versions: '8.1'
         include:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,15 +11,12 @@ jobs:
       matrix:
         validate: [ false ]
         fail-fast: [ false ]
-        php-versions: ['7.4', '8.0', '8.1' ]
+        php-versions: [  '8.0', '8.1' ]
         exclude:
-          - php-versions: '8.0'
           - php-versions: '8.1'
         include:
-          - php-versions: '8.0'
-            validate: true
           - php-versions: '8.1'
-            fail-fast: true
+            validate: true
 
     name: PHP ${{ matrix.php-versions }}
     steps:

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Collection of all OAuth2 Providers for Laravel Socialite",
     "license": "MIT",
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "league/oauth1-client": "^1.9",
         "socialiteproviders/manager": "~4.0"

--- a/src/Acclaim/composer.json
+++ b/src/Acclaim/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Admitad/composer.json
+++ b/src/Admitad/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Adobe/composer.json
+++ b/src/Adobe/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Amazon/composer.json
+++ b/src/Amazon/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/AmoCRM/composer.json
+++ b/src/AmoCRM/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/AngelList/composer.json
+++ b/src/AngelList/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/AppNet/composer.json
+++ b/src/AppNet/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Apple/composer.json
+++ b/src/Apple/composer.json
@@ -31,7 +31,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "ext-openssl": "*",
         "firebase/php-jwt": "^6.2",

--- a/src/ArcGIS/composer.json
+++ b/src/ArcGIS/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Asana/composer.json
+++ b/src/Asana/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Atlassian/composer.json
+++ b/src/Atlassian/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.0"
     },

--- a/src/Auth0/composer.json
+++ b/src/Auth0/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Aweber/composer.json
+++ b/src/Aweber/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Azure/composer.json
+++ b/src/Azure/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/AzureADB2C/composer.json
+++ b/src/AzureADB2C/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "ext-openssl": "*",
         "firebase/php-jwt": "^5.2",

--- a/src/Battlenet/composer.json
+++ b/src/Battlenet/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Bexio/composer.json
+++ b/src/Bexio/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "socialiteproviders/manager": "^4.0",
         "ext-json": "*"
     },

--- a/src/Binance/composer.json
+++ b/src/Binance/composer.json
@@ -10,7 +10,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Bitbucket/composer.json
+++ b/src/Bitbucket/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Bitly/composer.json
+++ b/src/Bitly/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Bitrix24/composer.json
+++ b/src/Bitrix24/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.0"
     },

--- a/src/Blackboard/composer.json
+++ b/src/Blackboard/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.0"
     },

--- a/src/Box/composer.json
+++ b/src/Box/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Buffer/composer.json
+++ b/src/Buffer/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/CampaignMonitor/composer.json
+++ b/src/CampaignMonitor/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Cheddar/composer.json
+++ b/src/Cheddar/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/ClaveUnica/composer.json
+++ b/src/ClaveUnica/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Cognito/composer.json
+++ b/src/Cognito/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Coinbase/composer.json
+++ b/src/Coinbase/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/ConstantContact/composer.json
+++ b/src/ConstantContact/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Coursera/composer.json
+++ b/src/Coursera/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Dailymotion/composer.json
+++ b/src/Dailymotion/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Dataporten/composer.json
+++ b/src/Dataporten/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Deezer/composer.json
+++ b/src/Deezer/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Deviantart/composer.json
+++ b/src/Deviantart/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/DigitalOcean/composer.json
+++ b/src/DigitalOcean/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Discogs/composer.json
+++ b/src/Discogs/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Discord/composer.json
+++ b/src/Discord/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Disqus/composer.json
+++ b/src/Disqus/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Douban/composer.json
+++ b/src/Douban/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Dribbble/composer.json
+++ b/src/Dribbble/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Dropbox/composer.json
+++ b/src/Dropbox/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Envato/composer.json
+++ b/src/Envato/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Etsy/composer.json
+++ b/src/Etsy/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Eventbrite/composer.json
+++ b/src/Eventbrite/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Eveonline/composer.json
+++ b/src/Eveonline/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "firebase/php-jwt": "^6.0",
         "socialiteproviders/manager": "^4.0"

--- a/src/Exment/composer.json
+++ b/src/Exment/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/EyeEm/composer.json
+++ b/src/EyeEm/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Fablabs/composer.json
+++ b/src/Fablabs/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Facebook/composer.json
+++ b/src/Facebook/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Faceit/composer.json
+++ b/src/Faceit/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Figma/composer.json
+++ b/src/Figma/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Fitbit/composer.json
+++ b/src/Fitbit/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/FiveHundredPixel/composer.json
+++ b/src/FiveHundredPixel/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Flattr/composer.json
+++ b/src/Flattr/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Flexkids/composer.json
+++ b/src/Flexkids/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Flexmls/composer.json
+++ b/src/Flexmls/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.0"
     },

--- a/src/Flickr/composer.json
+++ b/src/Flickr/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Foursquare/composer.json
+++ b/src/Foursquare/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/FranceConnect/composer.json
+++ b/src/FranceConnect/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/GarminConnect/composer.json
+++ b/src/GarminConnect/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/GettyImages/composer.json
+++ b/src/GettyImages/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/GitHub/composer.json
+++ b/src/GitHub/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/GitLab/composer.json
+++ b/src/GitLab/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Gitea/composer.json
+++ b/src/Gitea/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Gitee/composer.json
+++ b/src/Gitee/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Goodreads/composer.json
+++ b/src/Goodreads/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Google/composer.json
+++ b/src/Google/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Graph/composer.json
+++ b/src/Graph/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Gumroad/composer.json
+++ b/src/Gumroad/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.0"
     },

--- a/src/HabrCareer/composer.json
+++ b/src/HabrCareer/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/HarID/composer.json
+++ b/src/HarID/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Harvest/composer.json
+++ b/src/Harvest/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/HeadHunter/composer.json
+++ b/src/HeadHunter/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Heroku/composer.json
+++ b/src/Heroku/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/HubSpot/composer.json
+++ b/src/HubSpot/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/HumanApi/composer.json
+++ b/src/HumanApi/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/IFSP/composer.json
+++ b/src/IFSP/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Imgur/composer.json
+++ b/src/Imgur/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Imis/composer.json
+++ b/src/Imis/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Instagram/composer.json
+++ b/src/Instagram/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/InstagramBasic/composer.json
+++ b/src/InstagramBasic/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Instructure/composer.json
+++ b/src/Instructure/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Intercom/composer.json
+++ b/src/Intercom/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Jira/composer.json
+++ b/src/Jira/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "ext-openssl": "*",
         "socialiteproviders/manager": "~4.0"

--- a/src/Kakao/composer.json
+++ b/src/Kakao/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Keycloak/composer.json
+++ b/src/Keycloak/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/LaravelPassport/composer.json
+++ b/src/LaravelPassport/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Lichess/composer.json
+++ b/src/Lichess/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Line/composer.json
+++ b/src/Line/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/LinkedIn/composer.json
+++ b/src/LinkedIn/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Linode/composer.json
+++ b/src/Linode/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Live/composer.json
+++ b/src/Live/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/MailChimp/composer.json
+++ b/src/MailChimp/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Mailru/composer.json
+++ b/src/Mailru/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/MakerLog/composer.json
+++ b/src/MakerLog/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Mattermost/composer.json
+++ b/src/Mattermost/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/MediaCube/composer.json
+++ b/src/MediaCube/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Mediawiki/composer.json
+++ b/src/Mediawiki/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Medium/composer.json
+++ b/src/Medium/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Meetup/composer.json
+++ b/src/Meetup/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/MercadoLibre/composer.json
+++ b/src/MercadoLibre/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Microsoft/composer.json
+++ b/src/Microsoft/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Minecraft/composer.json
+++ b/src/Minecraft/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Mixcloud/composer.json
+++ b/src/Mixcloud/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Mollie/composer.json
+++ b/src/Mollie/composer.json
@@ -10,7 +10,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Monday/composer.json
+++ b/src/Monday/composer.json
@@ -25,7 +25,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Monzo/composer.json
+++ b/src/Monzo/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.0"
     },

--- a/src/MusicBrainz/composer.json
+++ b/src/MusicBrainz/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.0"
     },

--- a/src/Naver/composer.json
+++ b/src/Naver/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "ext-libxml": "*",
         "ext-simplexml": "*",

--- a/src/Netlify/composer.json
+++ b/src/Netlify/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Neto/composer.json
+++ b/src/Neto/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.0"
     },

--- a/src/Nextcloud/composer.json
+++ b/src/Nextcloud/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Nocks/composer.json
+++ b/src/Nocks/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Notion/composer.json
+++ b/src/Notion/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/OAuthgen/composer.json
+++ b/src/OAuthgen/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/OSChina/composer.json
+++ b/src/OSChina/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Odnoklassniki/composer.json
+++ b/src/Odnoklassniki/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Okta/composer.json
+++ b/src/Okta/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/OpenStreetMap/composer.json
+++ b/src/OpenStreetMap/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Orcid/composer.json
+++ b/src/Orcid/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Ovh/composer.json
+++ b/src/Ovh/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "ovh/ovh": "^2.0",
         "socialiteproviders/manager": "~4.0"

--- a/src/Patreon/composer.json
+++ b/src/Patreon/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/PayPal/composer.json
+++ b/src/PayPal/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/PayPalSandbox/composer.json
+++ b/src/PayPalSandbox/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Paymill/composer.json
+++ b/src/Paymill/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/PeeringDB/composer.json
+++ b/src/PeeringDB/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Pinterest/composer.json
+++ b/src/Pinterest/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Pipedrive/composer.json
+++ b/src/Pipedrive/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Pixnet/composer.json
+++ b/src/Pixnet/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Podio/composer.json
+++ b/src/Podio/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Procore/composer.json
+++ b/src/Procore/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/ProductHunt/composer.json
+++ b/src/ProductHunt/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/ProjectV/composer.json
+++ b/src/ProjectV/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Pushbullet/composer.json
+++ b/src/Pushbullet/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/QQ/composer.json
+++ b/src/QQ/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/QuickBooks/composer.json
+++ b/src/QuickBooks/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Readability/composer.json
+++ b/src/Readability/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Redbooth/composer.json
+++ b/src/Redbooth/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Reddit/composer.json
+++ b/src/Reddit/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Rekono/composer.json
+++ b/src/Rekono/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/RunKeeper/composer.json
+++ b/src/RunKeeper/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/SURFconext/composer.json
+++ b/src/SURFconext/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Sage/composer.json
+++ b/src/Sage/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/SalesForce/composer.json
+++ b/src/SalesForce/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Saml2/composer.json
+++ b/src/Saml2/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "litesaml/lightsaml": "^3.0",
         "socialiteproviders/manager": "~4.0"

--- a/src/SciStarter/composer.json
+++ b/src/SciStarter/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/SharePoint/composer.json
+++ b/src/SharePoint/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Shopify/composer.json
+++ b/src/Shopify/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Slack/composer.json
+++ b/src/Slack/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Smashcast/composer.json
+++ b/src/Smashcast/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Snapchat/composer.json
+++ b/src/Snapchat/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/SoundCloud/composer.json
+++ b/src/SoundCloud/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Spotify/composer.json
+++ b/src/Spotify/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/StackExchange/composer.json
+++ b/src/StackExchange/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Starling/composer.json
+++ b/src/Starling/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Steam/composer.json
+++ b/src/Steam/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Steem/composer.json
+++ b/src/Steem/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/StockTwits/composer.json
+++ b/src/StockTwits/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Strava/composer.json
+++ b/src/Strava/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/StreamElements/composer.json
+++ b/src/StreamElements/composer.json
@@ -10,7 +10,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Streamlabs/composer.json
+++ b/src/Streamlabs/composer.json
@@ -10,7 +10,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Stripe/composer.json
+++ b/src/Stripe/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/SuperOffice/composer.json
+++ b/src/SuperOffice/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "^3.6 || ^4.0"
     },

--- a/src/TVShowTime/composer.json
+++ b/src/TVShowTime/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/TeamService/composer.json
+++ b/src/TeamService/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Teamleader/composer.json
+++ b/src/Teamleader/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Teamweek/composer.json
+++ b/src/Teamweek/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Telegram/composer.json
+++ b/src/Telegram/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "socialiteproviders/manager": "~4.0"
     },
     "extra": {

--- a/src/ThirtySevenSignals/composer.json
+++ b/src/ThirtySevenSignals/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/TikTok/composer.json
+++ b/src/TikTok/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "socialiteproviders/manager": "~4.0"
     },
     "autoload": {

--- a/src/Todoist/composer.json
+++ b/src/Todoist/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Toyhouse/composer.json
+++ b/src/Toyhouse/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Trakt/composer.json
+++ b/src/Trakt/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Trello/composer.json
+++ b/src/Trello/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Tumblr/composer.json
+++ b/src/Tumblr/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/TwentyThreeAndMe/composer.json
+++ b/src/TwentyThreeAndMe/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/TwitCasting/composer.json
+++ b/src/TwitCasting/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Twitch/composer.json
+++ b/src/Twitch/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Twitter/composer.json
+++ b/src/Twitter/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/UCL/composer.json
+++ b/src/UCL/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/UFS/composer.json
+++ b/src/UFS/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Uber/composer.json
+++ b/src/Uber/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Ufutx/composer.json
+++ b/src/Ufutx/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Unsplash/composer.json
+++ b/src/Unsplash/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Untappd/composer.json
+++ b/src/Untappd/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/VKontakte/composer.json
+++ b/src/VKontakte/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Venmo/composer.json
+++ b/src/Venmo/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Vercel/composer.json
+++ b/src/Vercel/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/VersionOne/composer.json
+++ b/src/VersionOne/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Vimeo/composer.json
+++ b/src/Vimeo/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/WeChatServiceAccount/composer.json
+++ b/src/WeChatServiceAccount/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/WeChatWeb/composer.json
+++ b/src/WeChatWeb/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Webex/composer.json
+++ b/src/Webex/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.0"
     },

--- a/src/Weibo/composer.json
+++ b/src/Weibo/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Weixin/composer.json
+++ b/src/Weixin/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/WeixinWeb/composer.json
+++ b/src/WeixinWeb/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Whmcs/composer.json
+++ b/src/Whmcs/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Withings/composer.json
+++ b/src/Withings/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/WordPress/composer.json
+++ b/src/WordPress/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Xero/composer.json
+++ b/src/Xero/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "firebase/php-jwt": "^5.2",
         "socialiteproviders/manager": "~4.0"

--- a/src/Xing/composer.json
+++ b/src/Xing/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Yahoo/composer.json
+++ b/src/Yahoo/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Yammer/composer.json
+++ b/src/Yammer/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Yandex/composer.json
+++ b/src/Yandex/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Yiban/composer.json
+++ b/src/Yiban/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/YouTube/composer.json
+++ b/src/YouTube/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Zalo/composer.json
+++ b/src/Zalo/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Zendesk/composer.json
+++ b/src/Zendesk/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Zoho/composer.json
+++ b/src/Zoho/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Zoom/composer.json
+++ b/src/Zoom/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.0"
     },

--- a/src/xREL/composer.json
+++ b/src/xREL/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },


### PR DESCRIPTION
PHP 7.4 will be EOL in Nov. 2022.

This PR bumps PHP minimum requirement to `^8.0`.

This change requires a new major release.