### PR TITLE
Add FusionAuth provider

### DIFF
--- a/monorepo-builder.yml
+++ b/monorepo-builder.yml
@@ -61,6 +61,7 @@ parameters:
     src/Flickr: 'git@github.com:SocialiteProviders/Flickr.git'
     src/Foursquare: 'git@github.com:SocialiteProviders/Foursquare.git'
     src/FranceConnect: 'git@github.com:SocialiteProviders/FranceConnect.git'
+    src/FusionAuth: 'git@github.com:SocialiteProviders/FusionAuth.git'
     src/GarminConnect: 'git@github.com:SocialiteProviders/GarminConnect.git'
     src/GettyImages: 'git@github.com:SocialiteProviders/GettyImages.git'
     src/GitHub: 'git@github.com:SocialiteProviders/GitHub.git'

--- a/src/FusionAuth/FusionAuthExtendSocialite.php
+++ b/src/FusionAuth/FusionAuthExtendSocialite.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SocialiteProviders\FusionAuth;
+
+use SocialiteProviders\Manager\SocialiteWasCalled;
+
+class FusionAuthExtendSocialite
+{
+    /**
+     * Register the provider.
+     *
+     * @param  \SocialiteProviders\Manager\SocialiteWasCalled $socialiteWasCalled
+     */
+    public function handle(SocialiteWasCalled $socialiteWasCalled)
+    {
+        $socialiteWasCalled->extendSocialite('fusionauth', Provider::class);
+    }
+}

--- a/src/FusionAuth/FusionAuthExtendSocialite.php
+++ b/src/FusionAuth/FusionAuthExtendSocialite.php
@@ -9,7 +9,7 @@ class FusionAuthExtendSocialite
     /**
      * Register the provider.
      *
-     * @param  \SocialiteProviders\Manager\SocialiteWasCalled $socialiteWasCalled
+     * @param \SocialiteProviders\Manager\SocialiteWasCalled $socialiteWasCalled
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {

--- a/src/FusionAuth/Provider.php
+++ b/src/FusionAuth/Provider.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace SocialiteProviders\FusionAuth;
+
+use Illuminate\Support\Arr;
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
+use SocialiteProviders\Manager\OAuth2\User;
+
+class Provider extends AbstractProvider
+{
+    /**
+     * Unique Provider Identifier.
+     */
+    const IDENTIFIER = 'FUSIONAUTH';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopes = [
+        'openid',
+        'profile',
+        'email',
+    ];
+
+    protected $scopeSeparator = ' ';
+
+    protected function getFusionAuthUrl()
+    {
+        return $this->getConfig('base_url').'/oauth2';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function additionalConfigKeys()
+    {
+        return ['base_url'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAuthUrl($state)
+    {
+        return $this->buildAuthUrlFromBase($this->getFusionAuthUrl().'/authorize', $state);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenUrl()
+    {
+        return $this->getFusionAuthUrl().'/token';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByToken($token)
+    {
+        $response = $this->getHttpClient()->get($this->getFusionAuthUrl().'/userinfo', [
+            'headers' => [
+                'Authorization' => 'Bearer '.$token,
+            ],
+        ]);
+
+        return json_decode($response->getBody(), true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return (new User())->setRaw($user)->map([
+            'id'       => $user['sub'],
+            'nickname' => Arr::get($user, 'preferred_username'),
+            'name'     => $user['name'],
+            'email'    => $user['email'],
+            'avatar'   => $user['picture'],
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenFields($code)
+    {
+        return array_merge(parent::getTokenFields($code), [
+            'grant_type' => 'authorization_code'
+        ]);
+    }
+}

--- a/src/FusionAuth/Provider.php
+++ b/src/FusionAuth/Provider.php
@@ -51,7 +51,10 @@ class Provider extends AbstractProvider
      */
     public static function additionalConfigKeys()
     {
-        return ['base_url'];
+        return [
+            'base_url',
+            'tenant_id',
+        ];
     }
 
     /**
@@ -95,6 +98,16 @@ class Provider extends AbstractProvider
             'name'     => $user['name'],
             'email'    => $user['email'],
             'avatar'   => $user['picture'],
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getCodeFields($state = null)
+    {
+        return array_merge(parent::getCodeFields($state), [
+            'tenantId' => $this->getConfig('tenant_id'),
         ]);
     }
 }

--- a/src/FusionAuth/Provider.php
+++ b/src/FusionAuth/Provider.php
@@ -31,9 +31,9 @@ class Provider extends AbstractProvider
     /**
      * Get the base URL.
      *
-     * @return string
-     *
      * @throws \InvalidArgumentException
+     *
+     * @return string
      */
     protected function getFusionAuthUrl()
     {
@@ -103,11 +103,19 @@ class Provider extends AbstractProvider
 
     /**
      * {@inheritdoc}
+     *
+     * @throws \InvalidArgumentException
      */
     protected function getCodeFields($state = null)
     {
+        $tenantId = $this->getConfig('tenant_id');
+
+        if ($tenantId === null) {
+            throw new InvalidArgumentException('Missing tenant_id');
+        }
+
         return array_merge(parent::getCodeFields($state), [
-            'tenantId' => $this->getConfig('tenant_id'),
+            'tenantId' => $tenantId,
         ]);
     }
 }

--- a/src/FusionAuth/Provider.php
+++ b/src/FusionAuth/Provider.php
@@ -9,9 +9,6 @@ use SocialiteProviders\Manager\OAuth2\User;
 
 class Provider extends AbstractProvider
 {
-    /**
-     * Unique Provider Identifier.
-     */
     public const IDENTIFIER = 'FUSIONAUTH';
 
     /**

--- a/src/FusionAuth/README.md
+++ b/src/FusionAuth/README.md
@@ -42,3 +42,11 @@ You should now be able to use the provider like you would regularly use Socialit
 ```php
 return Socialite::driver('fusionauth')->redirect();
 ```
+
+### Returned User fields
+
+- ``id``
+- ``nickname``
+- ``name``
+- ``email``
+- ``avatar``

--- a/src/FusionAuth/README.md
+++ b/src/FusionAuth/README.md
@@ -1,0 +1,43 @@
+# FusionAuth
+
+```bash
+composer require socialiteproviders/fusionauth
+```
+
+## Installation & Basic Usage
+
+Please see the [Base Installation Guide](https://socialiteproviders.com/usage/), then follow the provider specific instructions below.
+
+### Add configuration to `config/services.php`
+
+```php
+'fusionauth' => [
+  'client_id' => env('FUSIONAUTH_CLIENT_ID'),
+  'client_secret' => env('FUSIONAUTH_CLIENT_SECRET'),
+  'redirect' => env('FUSIONAUTH_REDIRECT_URI'),
+  'base_url' => env('FUSIONAUTH_BASE_URL'),
+],
+```
+
+### Add provider event listener
+
+Configure the package's listener to listen for `SocialiteWasCalled` events.
+
+Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. See the [Base Installation Guide](https://socialiteproviders.com/usage/) for detailed instructions.
+
+```php
+protected $listen = [
+    \SocialiteProviders\Manager\SocialiteWasCalled::class => [
+        // ... other providers
+        'SocialiteProviders\\FusionAuth\\FusionAuthExtendSocialite@handle',
+    ],
+];
+```
+
+### Usage
+
+You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
+
+```php
+return Socialite::driver('fusionauth')->redirect();
+```

--- a/src/FusionAuth/README.md
+++ b/src/FusionAuth/README.md
@@ -12,10 +12,11 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
 
 ```php
 'fusionauth' => [
-  'client_id' => env('FUSIONAUTH_CLIENT_ID'),
-  'client_secret' => env('FUSIONAUTH_CLIENT_SECRET'),
-  'redirect' => env('FUSIONAUTH_REDIRECT_URI'),
-  'base_url' => env('FUSIONAUTH_BASE_URL'),
+    'client_id' => env('FUSIONAUTH_CLIENT_ID'),
+    'client_secret' => env('FUSIONAUTH_CLIENT_SECRET'),
+    'redirect' => env('FUSIONAUTH_REDIRECT_URI'),
+    'base_url' => env('FUSIONAUTH_BASE_URL'), // Base URL of your cloud instance or self hosted instance
+    'tenant_id' => env('FUSIONAUTH_TENANT_ID'), // Tenant ID of the client. Required since FusionAuth 1.8.0
 ],
 ```
 

--- a/src/FusionAuth/composer.json
+++ b/src/FusionAuth/composer.json
@@ -1,19 +1,33 @@
 {
     "name": "socialiteproviders/fusionauth",
     "description": "FusionAuth OAuth2 Provider for Laravel Socialite",
+    "keywords": [
+        "fusionauth",
+        "laravel",
+        "oauth",
+        "provider",
+        "socialite"
+    ],
     "license": "MIT",
-    "authors": [{
-        "name": "Danilo Polani",
-        "email": "danilo.polani@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "Danilo Polani",
+            "email": "danilo.polani@gmail.com"
+        }
+    ],
     "require": {
-        "php": "^7.2",
-        "socialiteproviders/manager": "^4.0",
-        "ext-json": "*"
+        "php": "^7.2 || ^8.0",
+        "ext-json": "*",
+        "socialiteproviders/manager": "^4.0"
     },
     "autoload": {
         "psr-4": {
             "SocialiteProviders\\FusionAuth\\": ""
         }
+    },
+    "support": {
+        "issues": "https://github.com/socialiteproviders/providers/issues",
+        "source": "https://github.com/socialiteproviders/providers",
+        "docs": "https://socialiteproviders.com/fusionauth"
     }
 }

--- a/src/FusionAuth/composer.json
+++ b/src/FusionAuth/composer.json
@@ -1,0 +1,19 @@
+{
+    "name": "socialiteproviders/fusionauth",
+    "description": "FusionAuth OAuth2 Provider for Laravel Socialite",
+    "license": "MIT",
+    "authors": [{
+        "name": "Danilo Polani",
+        "email": "danilo.polani@gmail.com"
+    }],
+    "require": {
+        "php": "^7.2",
+        "socialiteproviders/manager": "^4.0",
+        "ext-json": "*"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialiteProviders\\FusionAuth\\": ""
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a provider for [FusionAuth](https://fusionauth.io/).  

Docs: https://fusionauth.io/docs/v1/tech/oauth/endpoints

PS: I didn't add any "Add base_url to your .env" disclaimer like Auth0 because FusionAuth could be both self-hosted (99% of the times) or cloud, so it could be a bit misleading the example in that paragraph (?)