### PR TITLE
Use getHttpClient method

### DIFF
--- a/src/Adobe/Provider.php
+++ b/src/Adobe/Provider.php
@@ -43,7 +43,7 @@ class Provider extends AbstractProvider
         // Check if the credentials response body already has the data provided to us
         // If not, fetch the data from their API
         if (empty($this->credentialsResponseBody) || empty($this->credentialsResponseBody['sub'])) {
-            $response = $this->httpClient->post(self::BASE_URL.'/userinfo', [
+            $response = $this->getHttpClient()->post(self::BASE_URL.'/userinfo', [
                 RequestOptions::HEADERS => [
                     'Authorization' => "Bearer $token",
                     'Accept'        => 'application/json',

--- a/src/Monday/Provider.php
+++ b/src/Monday/Provider.php
@@ -48,7 +48,7 @@ class Provider extends AbstractProvider
      */
     protected function getUserByToken($token)
     {
-        $response = $this->httpClient
+        $response = $this->getHttpClient()
             ->post('https://api.monday.com/v2', [
                 RequestOptions::HEADERS => [
                     'Content-Type'  => 'application/json',


### PR DESCRIPTION
This PR enforces the use of `getHttpClient` method.