### PR TITLE
Use get and post methods

### DIFF
--- a/src/Flickr/Server.php
+++ b/src/Flickr/Server.php
@@ -111,7 +111,7 @@ class Server extends BaseServer
 
         $client = $this->createHttpClient();
 
-        $response = $client->request('GET', $url);
+        $response = $client->get($url);
 
         return json_decode((string) $response->getBody(), true);
     }

--- a/src/Kakao/KakaoProvider.php
+++ b/src/Kakao/KakaoProvider.php
@@ -45,7 +45,7 @@ class KakaoProvider extends AbstractProvider
      */
     public function getAccessToken($code)
     {
-        $response = $this->getHttpClient()->request('POST', $this->getTokenUrl(), [
+        $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             RequestOptions::FORM_PARAMS => $this->getTokenFields($code),
         ]);
 
@@ -86,7 +86,7 @@ class KakaoProvider extends AbstractProvider
      */
     protected function getUserByToken($token)
     {
-        $response = $this->getHttpClient()->request('POST', 'https://kapi.kakao.com/v2/user/me', [
+        $response = $this->getHttpClient()->post('https://kapi.kakao.com/v2/user/me', [
             RequestOptions::HEADERS => ['Authorization' => 'Bearer '.$token],
         ]);
 

--- a/src/Steam/Provider.php
+++ b/src/Steam/Provider.php
@@ -113,8 +113,7 @@ class Provider extends AbstractProvider
             throw new RuntimeException('The Steam API key has not been specified.');
         }
 
-        $response = $this->getHttpClient()->request(
-            'GET',
+        $response = $this->getHttpClient()->get(
             sprintf(self::STEAM_INFO_URL, $this->clientSecret, $token)
         );
 
@@ -182,7 +181,7 @@ class Provider extends AbstractProvider
             $requestOptions = array_merge($requestOptions, $customOptions);
         }
 
-        $response = $this->getHttpClient()->request('POST', self::OPENID_URL, $requestOptions);
+        $response = $this->getHttpClient()->post(self::OPENID_URL, $requestOptions);
 
         $results = $this->parseResults((string) $response->getBody());
 


### PR DESCRIPTION
Prefer the consistant use of `get` and `post` methods, over `request`.