### PR TITLE
Update PayPal to use latest endpoints / user info

### DIFF
--- a/src/PayPal/Provider.php
+++ b/src/PayPal/Provider.php
@@ -68,7 +68,7 @@ class Provider extends AbstractProvider
             'id'       => str_replace('https://www.paypal.com/webapps/auth/identity/user/', null, $user['user_id']),
             'nickname' => null, 'name' => $user['name'],
             'email'    => !empty($user['emails']) ? $user['emails'][0]['value'] : null,
-            'avatar' => null,
+            'avatar'   => null,
         ]);
     }
 

--- a/src/PayPal/Provider.php
+++ b/src/PayPal/Provider.php
@@ -79,7 +79,7 @@ class Provider extends AbstractProvider
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             RequestOptions::HEADERS => [
-                'Accept' => 'application/json',
+                'Accept'        => 'application/json',
                 'Authorization' => 'Basic ' . base64_encode("{$this->clientId}:{$this->clientSecret}")
             ],
             RequestOptions::FORM_PARAMS => $this->getTokenFields($code),

--- a/src/PayPal/Provider.php
+++ b/src/PayPal/Provider.php
@@ -80,7 +80,7 @@ class Provider extends AbstractProvider
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             RequestOptions::HEADERS => [
                 'Accept'        => 'application/json',
-                'Authorization' => 'Basic '.base64_encode("{$this->clientId}:{$this->clientSecret}")
+                'Authorization' => 'Basic '.base64_encode("{$this->clientId}:{$this->clientSecret}"),
             ],
             RequestOptions::FORM_PARAMS => $this->getTokenFields($code),
         ]);

--- a/src/PayPal/Provider.php
+++ b/src/PayPal/Provider.php
@@ -6,6 +6,10 @@ use GuzzleHttp\RequestOptions;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
+/**
+ * @see https://developer.paypal.com/docs/api/identity/v1/
+ * @see https://developer.paypal.com/api/rest/authentication/
+ */
 class Provider extends AbstractProvider
 {
     /**

--- a/src/PayPal/Provider.php
+++ b/src/PayPal/Provider.php
@@ -71,7 +71,7 @@ class Provider extends AbstractProvider
         return (new User())->setRaw($user)->map([
             'id'       => str_replace('https://www.paypal.com/webapps/auth/identity/user/', null, $user['user_id']),
             'nickname' => null, 'name' => $user['name'],
-            'email'    => !empty($user['emails']) ? $user['emails'][0]['value'] : null,
+            'email'    => collect($user['emails'] ?? [])->firstWhere('primary')['value'] ?? null,
             'avatar'   => null,
         ]);
     }

--- a/src/PayPal/Provider.php
+++ b/src/PayPal/Provider.php
@@ -80,7 +80,7 @@ class Provider extends AbstractProvider
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             RequestOptions::HEADERS => [
                 'Accept'        => 'application/json',
-                'Authorization' => 'Basic '. base64_encode("{$this->clientId}:{$this->clientSecret}")
+                'Authorization' => 'Basic '.base64_encode("{$this->clientId}:{$this->clientSecret}")
             ],
             RequestOptions::FORM_PARAMS => $this->getTokenFields($code),
         ]);

--- a/src/PayPal/Provider.php
+++ b/src/PayPal/Provider.php
@@ -80,7 +80,7 @@ class Provider extends AbstractProvider
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             RequestOptions::HEADERS => [
                 'Accept'        => 'application/json',
-                'Authorization' => 'Basic ' . base64_encode("{$this->clientId}:{$this->clientSecret}")
+                'Authorization' => 'Basic '. base64_encode("{$this->clientId}:{$this->clientSecret}")
             ],
             RequestOptions::FORM_PARAMS => $this->getTokenFields($code),
         ]);


### PR DESCRIPTION
PayPal have updated their documentation and the previous endpoints are no longer documented anywhere.

They've also made some slight changes to the data being returned: https://developer.paypal.com/docs/api/identity/v1/

