### PR TITLE
PayPal - Catch missing user data error

### DIFF
--- a/src/PayPal/Provider.php
+++ b/src/PayPal/Provider.php
@@ -67,7 +67,7 @@ class Provider extends AbstractProvider
     {
         return (new User())->setRaw($user)->map([
             'id'       => str_replace('https://www.paypal.com/webapps/auth/identity/user/', null, $user['user_id']),
-            'nickname' => null, 'name' => $user['name'],
+            'nickname' => null, 'name' => $user['name'] ?? '',
             'email'    => collect($user['emails'] ?? [])->firstWhere('primary')['value'] ?? null,
             'avatar'   => null,
         ]);


### PR DESCRIPTION
It's possible "name" isn't returned from the API, so should default to an empty string

