### PR TITLE
Update KakaoProvider.php to fIx getAccessToken return value

### DIFF
--- a/src/Kakao/KakaoProvider.php
+++ b/src/Kakao/KakaoProvider.php
@@ -48,7 +48,7 @@ class KakaoProvider extends AbstractProvider
 
         $this->credentialsResponseBody = json_decode((string) $response->getBody(), true);
 
-        return $this->parseAccessToken($response->getBody());
+        return $this->parseAccessToken($this->credentialsResponseBody);
     }
 
     /**


### PR DESCRIPTION
Hi

i am a user appreciate your effort to keep this repository.

i think i found a code to need fix it.

"getAccessToken" function need to return string($code) so it using "parseAccessToken" function. but "parseAccessToken" function get need array but string before parsing json.

it might be a mistake because above the return code, there are already declare array to parse
($this->credentialsResponseBody).

could you please fix this issue?

sorry for my poor english.

sincerely