### PR TITLE
Elevate socialiteproviders/manager requirements

### DIFF
--- a/src/Acclaim/composer.json
+++ b/src/Acclaim/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Admitad/composer.json
+++ b/src/Admitad/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Adobe/composer.json
+++ b/src/Adobe/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Amazon/composer.json
+++ b/src/Amazon/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/AmoCRM/composer.json
+++ b/src/AmoCRM/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/AngelList/composer.json
+++ b/src/AngelList/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/AppNet/composer.json
+++ b/src/AppNet/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Apple/composer.json
+++ b/src/Apple/composer.json
@@ -41,7 +41,7 @@
         "ext-openssl": "*",
         "firebase/php-jwt": "^6.2",
         "lcobucci/jwt": "^4.1.5",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "suggest": {
         "ahilmurugesan/socialite-apple-helper": "Automatic Apple client key generation and management."

--- a/src/ArcGIS/composer.json
+++ b/src/ArcGIS/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Asana/composer.json
+++ b/src/Asana/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Atlassian/composer.json
+++ b/src/Atlassian/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "^4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Auth0/composer.json
+++ b/src/Auth0/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Authentik/composer.json
+++ b/src/Authentik/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "^4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Aweber/composer.json
+++ b/src/Aweber/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Azure/composer.json
+++ b/src/Azure/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/AzureADB2C/composer.json
+++ b/src/AzureADB2C/composer.json
@@ -3,16 +3,18 @@
     "description": "AzureADB2C OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
     "keywords": [
-        "Azure Active Directory",
         "Azure AD",
-        "Azure Active Directory B2C",
         "Azure AD B2C",
+        "Azure Active Directory",
+        "Azure Active Directory B2C",
         "OpenID Connect",
+        "laravel",
         "laravel Azure AD B2C",
         "laravel socialite",
-        "laravel",
-        "socialite Azure AD B2C",
-        "socialite"
+        "oauth",
+        "provider",
+        "socialite",
+        "socialite Azure AD B2C"
     ],
     "authors": [
         {

--- a/src/AzureADB2C/composer.json
+++ b/src/AzureADB2C/composer.json
@@ -25,7 +25,7 @@
         "ext-json": "*",
         "ext-openssl": "*",
         "firebase/php-jwt": "^5.2",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Battlenet/composer.json
+++ b/src/Battlenet/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Bexio/composer.json
+++ b/src/Bexio/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "^4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Binance/composer.json
+++ b/src/Binance/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Bitbucket/composer.json
+++ b/src/Bitbucket/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Bitly/composer.json
+++ b/src/Bitly/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Bitrix24/composer.json
+++ b/src/Bitrix24/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "^4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Blackboard/composer.json
+++ b/src/Blackboard/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "^4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Box/composer.json
+++ b/src/Box/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Buffer/composer.json
+++ b/src/Buffer/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/CampaignMonitor/composer.json
+++ b/src/CampaignMonitor/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Cheddar/composer.json
+++ b/src/Cheddar/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/ClaveUnica/composer.json
+++ b/src/ClaveUnica/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Cognito/composer.json
+++ b/src/Cognito/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Coinbase/composer.json
+++ b/src/Coinbase/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/ConstantContact/composer.json
+++ b/src/ConstantContact/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Coursera/composer.json
+++ b/src/Coursera/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Dailymotion/composer.json
+++ b/src/Dailymotion/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Dataporten/composer.json
+++ b/src/Dataporten/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Deezer/composer.json
+++ b/src/Deezer/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Deviantart/composer.json
+++ b/src/Deviantart/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/DigitalOcean/composer.json
+++ b/src/DigitalOcean/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Discogs/composer.json
+++ b/src/Discogs/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Discord/composer.json
+++ b/src/Discord/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Disqus/composer.json
+++ b/src/Disqus/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Douban/composer.json
+++ b/src/Douban/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Dribbble/composer.json
+++ b/src/Dribbble/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Dropbox/composer.json
+++ b/src/Dropbox/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Envato/composer.json
+++ b/src/Envato/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Etsy/composer.json
+++ b/src/Etsy/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Eventbrite/composer.json
+++ b/src/Eventbrite/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Eveonline/composer.json
+++ b/src/Eveonline/composer.json
@@ -24,7 +24,7 @@
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "firebase/php-jwt": "^6.0",
-        "socialiteproviders/manager": "^4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Exment/composer.json
+++ b/src/Exment/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/EyeEm/composer.json
+++ b/src/EyeEm/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Fablabs/composer.json
+++ b/src/Fablabs/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Facebook/composer.json
+++ b/src/Facebook/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Faceit/composer.json
+++ b/src/Faceit/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Figma/composer.json
+++ b/src/Figma/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Fitbit/composer.json
+++ b/src/Fitbit/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/FiveHundredPixel/composer.json
+++ b/src/FiveHundredPixel/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Flattr/composer.json
+++ b/src/Flattr/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Flexkids/composer.json
+++ b/src/Flexkids/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Flexmls/composer.json
+++ b/src/Flexmls/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "^4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Flickr/composer.json
+++ b/src/Flickr/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Foursquare/composer.json
+++ b/src/Foursquare/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/FranceConnect/composer.json
+++ b/src/FranceConnect/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/FusionAuth/composer.json
+++ b/src/FusionAuth/composer.json
@@ -21,9 +21,9 @@
         "docs": "https://socialiteproviders.com/fusionauth"
     },
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "^4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/GarminConnect/composer.json
+++ b/src/GarminConnect/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/GettyImages/composer.json
+++ b/src/GettyImages/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/GitHub/composer.json
+++ b/src/GitHub/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/GitLab/composer.json
+++ b/src/GitLab/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Gitea/composer.json
+++ b/src/Gitea/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Gitee/composer.json
+++ b/src/Gitee/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Goodreads/composer.json
+++ b/src/Goodreads/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Google/composer.json
+++ b/src/Google/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Graph/composer.json
+++ b/src/Graph/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Gumroad/composer.json
+++ b/src/Gumroad/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "^4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/HabrCareer/composer.json
+++ b/src/HabrCareer/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/HarID/composer.json
+++ b/src/HarID/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Harvest/composer.json
+++ b/src/Harvest/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/HeadHunter/composer.json
+++ b/src/HeadHunter/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Heroku/composer.json
+++ b/src/Heroku/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/HubSpot/composer.json
+++ b/src/HubSpot/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/HumanApi/composer.json
+++ b/src/HumanApi/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/IFSP/composer.json
+++ b/src/IFSP/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Imgur/composer.json
+++ b/src/Imgur/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Imis/composer.json
+++ b/src/Imis/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Instagram/composer.json
+++ b/src/Instagram/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/InstagramBasic/composer.json
+++ b/src/InstagramBasic/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Instructure/composer.json
+++ b/src/Instructure/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Intercom/composer.json
+++ b/src/Intercom/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Jira/composer.json
+++ b/src/Jira/composer.json
@@ -24,7 +24,7 @@
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "ext-openssl": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Kakao/composer.json
+++ b/src/Kakao/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Keycloak/composer.json
+++ b/src/Keycloak/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/LaravelPassport/composer.json
+++ b/src/LaravelPassport/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Lichess/composer.json
+++ b/src/Lichess/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Line/composer.json
+++ b/src/Line/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/LinkedIn/composer.json
+++ b/src/LinkedIn/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Linode/composer.json
+++ b/src/Linode/composer.json
@@ -3,8 +3,8 @@
     "description": "Linode OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
     "keywords": [
-        "linode",
         "laravel",
+        "linode",
         "oauth",
         "provider",
         "socialite"

--- a/src/Linode/composer.json
+++ b/src/Linode/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Live/composer.json
+++ b/src/Live/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/MailChimp/composer.json
+++ b/src/MailChimp/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Mailru/composer.json
+++ b/src/Mailru/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/MakerLog/composer.json
+++ b/src/MakerLog/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Mattermost/composer.json
+++ b/src/Mattermost/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/MediaCube/composer.json
+++ b/src/MediaCube/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Mediawiki/composer.json
+++ b/src/Mediawiki/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Mediawiki/composer.json
+++ b/src/Mediawiki/composer.json
@@ -3,8 +3,8 @@
     "description": "Mediawiki OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
     "keywords": [
-        "mediawiki",
         "laravel",
+        "mediawiki",
         "oauth",
         "provider",
         "socialite"

--- a/src/Medium/composer.json
+++ b/src/Medium/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Meetup/composer.json
+++ b/src/Meetup/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/MercadoLibre/composer.json
+++ b/src/MercadoLibre/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Microsoft/composer.json
+++ b/src/Microsoft/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Minecraft/composer.json
+++ b/src/Minecraft/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Mixcloud/composer.json
+++ b/src/Mixcloud/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Mollie/composer.json
+++ b/src/Mollie/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Monday/composer.json
+++ b/src/Monday/composer.json
@@ -4,11 +4,11 @@
     "license": "MIT",
     "keywords": [
         "laravel",
-        "socialite",
+        "monday",
         "oauth",
         "oauth2",
         "provider",
-        "monday"
+        "socialite"
     ],
     "authors": [
         {

--- a/src/Monday/composer.json
+++ b/src/Monday/composer.json
@@ -32,7 +32,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Monzo/composer.json
+++ b/src/Monzo/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "^4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/MusicBrainz/composer.json
+++ b/src/MusicBrainz/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "^4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Naver/composer.json
+++ b/src/Naver/composer.json
@@ -25,7 +25,7 @@
         "ext-json": "*",
         "ext-libxml": "*",
         "ext-simplexml": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Netlify/composer.json
+++ b/src/Netlify/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Neto/composer.json
+++ b/src/Neto/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "^4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Nextcloud/composer.json
+++ b/src/Nextcloud/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Nocks/composer.json
+++ b/src/Nocks/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Notion/composer.json
+++ b/src/Notion/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/OAuthgen/composer.json
+++ b/src/OAuthgen/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/OSChina/composer.json
+++ b/src/OSChina/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Odnoklassniki/composer.json
+++ b/src/Odnoklassniki/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Okta/composer.json
+++ b/src/Okta/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/OpenStreetMap/composer.json
+++ b/src/OpenStreetMap/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/OpenStreetMap/composer.json
+++ b/src/OpenStreetMap/composer.json
@@ -3,9 +3,9 @@
     "description": "OpenStreetMap OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
     "keywords": [
-        "openstreetmap",
         "laravel",
         "oauth",
+        "openstreetmap",
         "provider",
         "socialite"
     ],

--- a/src/Orcid/composer.json
+++ b/src/Orcid/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Ovh/composer.json
+++ b/src/Ovh/composer.json
@@ -24,7 +24,7 @@
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "ovh/ovh": "^2.0",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Patreon/composer.json
+++ b/src/Patreon/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/PayPal/composer.json
+++ b/src/PayPal/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/PayPalSandbox/composer.json
+++ b/src/PayPalSandbox/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Paymill/composer.json
+++ b/src/Paymill/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/PeeringDB/composer.json
+++ b/src/PeeringDB/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Pinterest/composer.json
+++ b/src/Pinterest/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Pipedrive/composer.json
+++ b/src/Pipedrive/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Pixnet/composer.json
+++ b/src/Pixnet/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/PlanningCenter/composer.json
+++ b/src/PlanningCenter/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "^4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Podio/composer.json
+++ b/src/Podio/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Procore/composer.json
+++ b/src/Procore/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/ProductHunt/composer.json
+++ b/src/ProductHunt/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/ProjectV/composer.json
+++ b/src/ProjectV/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Pushbullet/composer.json
+++ b/src/Pushbullet/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/QQ/composer.json
+++ b/src/QQ/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/QuickBooks/composer.json
+++ b/src/QuickBooks/composer.json
@@ -31,7 +31,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Readability/composer.json
+++ b/src/Readability/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Redbooth/composer.json
+++ b/src/Redbooth/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Reddit/composer.json
+++ b/src/Reddit/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Rekono/composer.json
+++ b/src/Rekono/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/RunKeeper/composer.json
+++ b/src/RunKeeper/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/SURFconext/composer.json
+++ b/src/SURFconext/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Sage/composer.json
+++ b/src/Sage/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/SalesForce/composer.json
+++ b/src/SalesForce/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Saml2/composer.json
+++ b/src/Saml2/composer.json
@@ -24,7 +24,7 @@
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "litesaml/lightsaml": "^3.0",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/SciStarter/composer.json
+++ b/src/SciStarter/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/SharePoint/composer.json
+++ b/src/SharePoint/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Shopify/composer.json
+++ b/src/Shopify/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Slack/composer.json
+++ b/src/Slack/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Smashcast/composer.json
+++ b/src/Smashcast/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Snapchat/composer.json
+++ b/src/Snapchat/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/SoundCloud/composer.json
+++ b/src/SoundCloud/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Spotify/composer.json
+++ b/src/Spotify/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/StackExchange/composer.json
+++ b/src/StackExchange/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Starling/composer.json
+++ b/src/Starling/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Steam/composer.json
+++ b/src/Steam/composer.json
@@ -4,6 +4,7 @@
     "license": "MIT",
     "keywords": [
         "laravel",
+        "oauth",
         "openid",
         "provider",
         "socialite",

--- a/src/Steam/composer.json
+++ b/src/Steam/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Steem/composer.json
+++ b/src/Steem/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/StockTwits/composer.json
+++ b/src/StockTwits/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Strava/composer.json
+++ b/src/Strava/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/StreamElements/composer.json
+++ b/src/StreamElements/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Streamlabs/composer.json
+++ b/src/Streamlabs/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Stripe/composer.json
+++ b/src/Stripe/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/TVShowTime/composer.json
+++ b/src/TVShowTime/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/TeamService/composer.json
+++ b/src/TeamService/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Teamleader/composer.json
+++ b/src/Teamleader/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Teamweek/composer.json
+++ b/src/Teamweek/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Telegram/composer.json
+++ b/src/Telegram/composer.json
@@ -22,6 +22,7 @@
     },
     "require": {
         "php": "^7.4 || ^8.0",
+        "ext-json": "*",
         "socialiteproviders/manager": "^4.2"
     },
     "autoload": {

--- a/src/Telegram/composer.json
+++ b/src/Telegram/composer.json
@@ -22,7 +22,7 @@
     },
     "require": {
         "php": "^7.4 || ^8.0",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/ThirtySevenSignals/composer.json
+++ b/src/ThirtySevenSignals/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/TikTok/composer.json
+++ b/src/TikTok/composer.json
@@ -22,6 +22,7 @@
     },
     "require": {
         "php": "^7.4 || ^8.0",
+        "ext-json": "*",
         "socialiteproviders/manager": "^4.2"
     },
     "autoload": {

--- a/src/TikTok/composer.json
+++ b/src/TikTok/composer.json
@@ -22,7 +22,7 @@
     },
     "require": {
         "php": "^7.4 || ^8.0",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Todoist/composer.json
+++ b/src/Todoist/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Toyhouse/composer.json
+++ b/src/Toyhouse/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Trakt/composer.json
+++ b/src/Trakt/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Trello/composer.json
+++ b/src/Trello/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Tumblr/composer.json
+++ b/src/Tumblr/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/TwentyThreeAndMe/composer.json
+++ b/src/TwentyThreeAndMe/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/TwitCasting/composer.json
+++ b/src/TwitCasting/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Twitch/composer.json
+++ b/src/Twitch/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Twitter/composer.json
+++ b/src/Twitter/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/UCL/composer.json
+++ b/src/UCL/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/UFS/composer.json
+++ b/src/UFS/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Uber/composer.json
+++ b/src/Uber/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Ufutx/composer.json
+++ b/src/Ufutx/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Unsplash/composer.json
+++ b/src/Unsplash/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Untappd/composer.json
+++ b/src/Untappd/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/VKontakte/composer.json
+++ b/src/VKontakte/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Venmo/composer.json
+++ b/src/Venmo/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Vercel/composer.json
+++ b/src/Vercel/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/VersionOne/composer.json
+++ b/src/VersionOne/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Vimeo/composer.json
+++ b/src/Vimeo/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/WeChatServiceAccount/composer.json
+++ b/src/WeChatServiceAccount/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/WeChatWeb/composer.json
+++ b/src/WeChatWeb/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Webex/composer.json
+++ b/src/Webex/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "^4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Weibo/composer.json
+++ b/src/Weibo/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Weixin/composer.json
+++ b/src/Weixin/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/WeixinWeb/composer.json
+++ b/src/WeixinWeb/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Whmcs/composer.json
+++ b/src/Whmcs/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Withings/composer.json
+++ b/src/Withings/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/WordPress/composer.json
+++ b/src/WordPress/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Xero/composer.json
+++ b/src/Xero/composer.json
@@ -24,7 +24,7 @@
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "firebase/php-jwt": "^5.2",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Xing/composer.json
+++ b/src/Xing/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Yahoo/composer.json
+++ b/src/Yahoo/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Yammer/composer.json
+++ b/src/Yammer/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Yandex/composer.json
+++ b/src/Yandex/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Yiban/composer.json
+++ b/src/Yiban/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/YouTube/composer.json
+++ b/src/YouTube/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Zalo/composer.json
+++ b/src/Zalo/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Zendesk/composer.json
+++ b/src/Zendesk/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Zoho/composer.json
+++ b/src/Zoho/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "minimum-stability": "stable",
     "autoload": {

--- a/src/Zoom/composer.json
+++ b/src/Zoom/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "^4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/xREL/composer.json
+++ b/src/xREL/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "^4.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR elevates `socialiteproviders/manager` requirements to `^4.2`
It also drops the support for FutsionAuth support for PHP < 7.4 and add some extra adjustments - see [`574cdac` (#899)](https://github.com/SocialiteProviders/Providers/pull/899/commits/574cdac294f89bce193e58c50070fd915d30c9c6)

---

See https://github.com/SocialiteProviders/Providers/pull/882