### PR TITLE
Saml2: Always provide the consumer URL in the AuthNRequest

### DIFF
--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -185,7 +185,8 @@ class Provider extends AbstractProvider implements SocialiteProvider
             ->setIssueInstant(new DateTime())
             ->setDestination($identityProviderConsumerService->getLocation())
             ->setNameIDPolicy((new NameIDPolicy())->setFormat(SamlConstants::NAME_ID_FORMAT_PERSISTENT))
-            ->setIssuer(new Issuer($this->getServiceProviderEntityDescriptor()->getEntityID()));
+            ->setIssuer(new Issuer($this->getServiceProviderEntityDescriptor()->getEntityID()))
+            ->setAssertionConsumerServiceURL($this->getServiceProviderAssertionConsumerUrl());
 
         if ($this->usesState()) {
             $this->request->session()->put('state', $state = $this->getState());


### PR DESCRIPTION
Fixes #893 - this adds the assertion consumer URL in the authentication request.