### PR TITLE
Always use ::class notation

### DIFF
--- a/src/Authentik/README.md
+++ b/src/Authentik/README.md
@@ -37,7 +37,7 @@ detailed instructions.
 protected $listen = [
     \SocialiteProviders\Manager\SocialiteWasCalled::class => [
         // ... other providers
-        'SocialiteProviders\\Authentik\\AuthentikExtendSocialite@handle',
+        \SocialiteProviders\Authentik\AuthentikExtendSocialite::class.'@handle',
     ],
 ];
 ```

--- a/src/AzureADB2C/README.md
+++ b/src/AzureADB2C/README.md
@@ -30,7 +30,7 @@ Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. 
 protected $listen = [
     \SocialiteProviders\Manager\SocialiteWasCalled::class => [
         // ... other providers
-        'SocialiteProviders\\AzureADB2C\\AzureADB2CExtendSocialite@handle',
+        \SocialiteProviders\AzureADB2C\AzureADB2CExtendSocialite::class.'@handle',
     ],
 ];
 ```

--- a/src/Bexio/README.md
+++ b/src/Bexio/README.md
@@ -34,7 +34,7 @@ Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. 
 protected $listen = [
     \SocialiteProviders\Manager\SocialiteWasCalled::class => [
         // ... other providers
-        'SocialiteProviders\\Bexio\\BexioExtendSocialite@handle',
+        \SocialiteProviders\Bexio\BexioExtendSocialite::class.'@handle',
     ],
 ];
 ```

--- a/src/FusionAuth/README.md
+++ b/src/FusionAuth/README.md
@@ -30,7 +30,7 @@ Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. 
 protected $listen = [
     \SocialiteProviders\Manager\SocialiteWasCalled::class => [
         // ... other providers
-        'SocialiteProviders\\FusionAuth\\FusionAuthExtendSocialite@handle',
+        \SocialiteProviders\FusionAuth\FusionAuthExtendSocialite:class.'@handle',
     ],
 ];
 ```

--- a/src/Imis/README.md
+++ b/src/Imis/README.md
@@ -32,7 +32,7 @@ Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. 
 protected $listen = [
     \SocialiteProviders\Manager\SocialiteWasCalled::class => [
         // add your listeners (aka providers) here
-        'SocialiteProviders\\Imis\\ImisExtendSocialite@handle',
+        \SocialiteProviders\Imis\ImisExtendSocialite::class.'@handle',
     ],
 ];
 ```

--- a/src/Lichess/README.md
+++ b/src/Lichess/README.md
@@ -30,7 +30,7 @@ Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. 
 protected $listen = [
     \SocialiteProviders\Manager\SocialiteWasCalled::class => [
         // ... other providers
-        'SocialiteProviders\\Lichess\\LichessExtendSocialite@handle',
+        \SocialiteProviders\Lichess\LichessExtendSocialite::class.'@handle',
     ],
 ];
 ```

--- a/src/Toyhouse/README.md
+++ b/src/Toyhouse/README.md
@@ -28,7 +28,7 @@ Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. 
 protected $listen = [
     \SocialiteProviders\Manager\SocialiteWasCalled::class => [
         // ... other providers
-        'SocialiteProviders\\Toyhouse\\ToyhouseExtendSocialite@handle',
+        \SocialiteProviders\Toyhouse\ToyhouseExtendSocialite::class.'@handle',
     ],
 ];
 ```

--- a/src/TwitCasting/README.md
+++ b/src/TwitCasting/README.md
@@ -32,7 +32,7 @@ Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. 
 protected $listen = [
     \SocialiteProviders\Manager\SocialiteWasCalled::class => [
         // ... other providers
-        'SocialiteProviders\\TwitCasting\\TwitCastingExtendSocialite@handle',
+        \SocialiteProviders\TwitCasting\TwitCastingExtendSocialite::class.'@handle',
     ],
 ];
 ```

--- a/src/Webex/README.md
+++ b/src/Webex/README.md
@@ -28,7 +28,7 @@ Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. 
 protected $listen = [
     \SocialiteProviders\Manager\SocialiteWasCalled::class => [
         // ... other providers
-        'SocialiteProviders\\Webex\\WebexExtendSocialite@handle',
+        \SocialiteProviders\Webex\WebexExtendSocialite::class.'@handle',
     ],
 ];
 ```


### PR DESCRIPTION
This PR enforces the use of `::class` notation.