### PR TITLE
Cast the body to string

### DIFF
--- a/src/Monday/Provider.php
+++ b/src/Monday/Provider.php
@@ -90,7 +90,7 @@ GQL
                 ]),
             ]);
 
-        return json_decode($response->getBody()->getContents(), true)['data']['me'];
+        return json_decode((string) $response->getBody(), true)['data']['me'];
     }
 
     /**

--- a/src/Okta/Provider.php
+++ b/src/Okta/Provider.php
@@ -141,7 +141,7 @@ class Provider extends AbstractProvider
             ],
         ]);
 
-        return json_decode($response->getBody()->getContents(), true);
+        return json_decode((string) $response->getBody(), true);
     }
 
     /**
@@ -232,6 +232,6 @@ class Provider extends AbstractProvider
             ],
         ]);
 
-        return json_decode($resp->getBody()->getContents(), true);
+        return json_decode((string) $resp->getBody(), true);
     }
 }

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -283,10 +283,9 @@ class Provider extends AbstractProvider implements SocialiteProvider
         Cache::forever(self::CACHE_KEY_TTL, time());
 
         try {
-            $xml = $this->getHttpClient()
+            $xml = (string) $this->getHttpClient()
                 ->get($metadataUrl)
-                ->getBody()
-                ->getContents();
+                ->getBody();
 
             Cache::forever(self::CACHE_KEY, $xml);
         } catch (GuzzleException $e) {


### PR DESCRIPTION
Stay consistant, and cast the body to string instead of using `getContents()`.