### PR TITLE
Use Str::random

### DIFF
--- a/src/FranceConnect/Provider.php
+++ b/src/FranceConnect/Provider.php
@@ -4,6 +4,7 @@ namespace SocialiteProviders\FranceConnect;
 
 use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Laravel\Socialite\Two\InvalidStateException;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 
@@ -62,7 +63,7 @@ class Provider extends AbstractProvider
     protected function getAuthUrl($state)
     {
         //It is used to prevent replay attacks
-        $this->parameters['nonce'] = str_random(20);
+        $this->parameters['nonce'] = Str::random(20);
 
         return $this->buildAuthUrlFromBase($this->getBaseUrl().'/authorize', $state);
     }


### PR DESCRIPTION
Use `Str::random` instead of the deprecated `str_random()` helper.