### PR TITLE
Saml2: Fix route matching

### DIFF
--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -52,6 +52,7 @@ use RuntimeException;
 use SocialiteProviders\Manager\Contracts\ConfigInterface;
 use SocialiteProviders\Manager\Exception\MissingConfigException;
 use Symfony\Component\HttpFoundation\Response as HttpFoundationResponse;
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 
 class Provider extends AbstractProvider implements SocialiteProvider
 {
@@ -419,7 +420,13 @@ class Provider extends AbstractProvider implements SocialiteProvider
             return false;
         }
 
-        return Arr::has(Route::getRoutes()->getRoutesByMethod(), $methods[$bindingType].'.'.$route);
+        try {
+            Route::getRoutes()->match(Request::create($route, $methods[$bindingType]));
+        } catch (MethodNotAllowedHttpException $e) {
+            return false;
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
The technique the provider uses at the moment for route matching is very basic, this PR uses the same code Laravel does to do route matching and is much more reliable. Fixes #906 