### PR TITLE
depency fix in monday provider

### DIFF
--- a/src/Monday/Provider.php
+++ b/src/Monday/Provider.php
@@ -3,7 +3,7 @@
 namespace SocialiteProviders\Monday;
 
 use GuzzleHttp\RequestOptions;
-use Laravel\Socialite\Two\AbstractProvider;
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
 class Provider extends AbstractProvider


### PR DESCRIPTION
the monday provider uses the wrong AbstractProvider class. The old class throws a Call to undefined method `SocialiteProviders\Monday\Provider::additionalConfigKeys()` error. Using the SocialiteProviders\Manager\OAuth2\AbstractProvider solves this problem.