### PR TITLE
adjust Starling token url options

### DIFF
--- a/src/Starling/Provider.php
+++ b/src/Starling/Provider.php
@@ -55,9 +55,15 @@ class Provider extends AbstractProvider
      */
     protected function getTokenUrl()
     {
+        if ($this->useMTLS()) {
+            return $this->isSandbox() ?
+                'https://token-api-sandbox.starlingbank.com/oauth/access-token' :
+                'https://token-api.starlingbank.com/oauth/access-token';
+        }
+
         return $this->isSandbox() ?
             'https://api-sandbox.starlingbank.com/oauth/access-token' :
-            'https://token-api.starlingbank.com/oauth/access-token';
+            'https://api.starlingbank.com/oauth/access-token';
     }
 
     /**
@@ -116,10 +122,20 @@ class Provider extends AbstractProvider
     }
 
     /**
+     * Checks if mTLS token endpoints should be used
+     *
+     * @return bool
+     */
+    protected function useMTLS()
+    {
+        return $this->getConfig('use_mtls', false);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public static function additionalConfigKeys()
     {
-        return ['env'];
+        return ['env', 'use_mtls'];
     }
 }

--- a/src/Starling/Provider.php
+++ b/src/Starling/Provider.php
@@ -122,7 +122,7 @@ class Provider extends AbstractProvider
     }
 
     /**
-     * Checks if mTLS token endpoints should be used
+     * Checks if mTLS token endpoints should be used.
      *
      * @return bool
      */

--- a/src/Starling/README.md
+++ b/src/Starling/README.md
@@ -16,9 +16,12 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
   'client_secret' => env('STARLING_CLIENT_SECRET'),
   'redirect' => env('STARLING_REDIRECT_URI'),
   'env' => env('STARLING_ENV'),
+  'use_mtls' => env('STARLING_USE_MTLS')
 ],
 ```
 The `env` value should be `sandbox` for the sandbox environment and `production` for production environment.
+The `use_mtls` value should be `true` if you have an OBIE or eIDAS certificate to attach to token API calls.
+Add `guzzle` options here to configure the certificates as curl settings.
 
 ### Add provider event listener
 
@@ -48,3 +51,5 @@ return Socialite::driver('starling')->redirect();
 - ``id``
 - ``name``
 - ``email``
+- ``phone``
+- ``dateOfBirth``


### PR DESCRIPTION
The current Starling provider uses a non-mTLS token endpoint on the staging environment, and the mTLS endpoint for production. Ideally these should align to prevent unexpected surprises on production.

This adds support for a `use_mtls` config variable, allowing the user to toggle mTLS, and adds the missing urls for both staging and production, so you can use one or the other.