### PR TITLE
[bugfix] Yandex OAuth 2.0 provider requires "space" as a scope separator

### DIFF
--- a/src/Yandex/Provider.php
+++ b/src/Yandex/Provider.php
@@ -10,6 +10,11 @@ use SocialiteProviders\Manager\OAuth2\User;
 class Provider extends AbstractProvider
 {
     public const IDENTIFIER = 'YANDEX';
+    
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopeSeparator = ' ';
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
Dear Developers,

Thank you very much for the project!

Apparently, it seems the provider only supports a `space` character as a OAuth 2.0 scope separator, yet the current solution or [Provider](https://github.com/SocialiteProviders/Yandex/blob/master/Provider.php#L10) class inherits/states the [comma](https://github.com/laravel/socialite/blob/master/src/Two/AbstractProvider.php#L68) - request explicitly fails.

---

> `scope` - A list of permissions that the application currently needs, separated by a space. 

Source: [Yandex OAuth 2.0 docs (Google translated)](https://yandex-ru.translate.goog/dev/id/doc/dg/oauth/reference/auto-code-client.html?_x_tr_sl=ru&_x_tr_tl=en&_x_tr_hl=lt&_x_tr_pto=wapp#auto-code-client__get-code)

---

Best and kind regards