### PR TITLE
Replaced missing key in the user data array in Etsy provider

### DIFF
--- a/src/Etsy/Provider.php
+++ b/src/Etsy/Provider.php
@@ -67,8 +67,8 @@ class Provider extends AbstractProvider
     {
         return (new User())->setRaw($user)->map([
             'id'       => $user['user_id'],
-            'nickname' => $user['login_name'],
-            'name'     => $user['first_name'],
+            'nickname' => $user['first_name'],
+            'name'     => trim($user['first_name'] . ' ' . $user['last_name']),
             'email'    => $user['primary_email'],
             'avatar'   => $user['image_url_75x75'],
         ]);


### PR DESCRIPTION
When trying to obtain an access token with the Etsy provider, the Provider::mapUserToObject method tries to map the user's nickname property to the 'login_name' key from the array which is no longer provided by Etsy. It is now replaced by the first name of the users.