### PR TITLE
Add VATSIM OAuth2 provider

### DIFF
--- a/monorepo-builder.yml
+++ b/monorepo-builder.yml
@@ -191,6 +191,7 @@ parameters:
     src/Unsplash: 'git@github.com:SocialiteProviders/Unsplash.git'
     src/Untappd: 'git@github.com:SocialiteProviders/Untappd.git'
     src/VKontakte: 'git@github.com:SocialiteProviders/VKontakte.git'
+    src/Vatsim: 'git@github.com:SocialiteProviders/Vatsim.git'
     src/Venmo: 'git@github.com:SocialiteProviders/Venmo.git'
     src/Vercel: 'git@github.com:SocialiteProviders/Vercel.git'
     src/VersionOne: 'git@github.com:SocialiteProviders/VersionOne.git'

--- a/src/Vatsim/Provider.php
+++ b/src/Vatsim/Provider.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace SocialiteProviders\Vatsim;
+
+use GuzzleHttp\RequestOptions;
+use Illuminate\Support\Arr;
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
+use SocialiteProviders\Manager\OAuth2\User;
+
+class Provider extends AbstractProvider
+{
+    public const IDENTIFIER = 'VATSIM';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopeSeparator = ' ';
+
+    /**
+     * The scopes being requested that are mandatory.
+     *
+     * @var array
+     */
+    protected $requiredScopes = [];
+
+    /**
+     * @see https://github.com/vatsimnetwork/developer-info/wiki/Connect-Development-Environment
+     *
+     * @return string
+     */
+    protected function getHostname()
+    {
+        if ($this->getConfig('test')) {
+            return 'auth-dev.vatsim.net';
+        }
+
+        return 'auth.vatsim.net';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getAuthUrl($state)
+    {
+        return $this->buildAuthUrlFromBase('https://'.$this->getHostname().'/oauth/authorize', $state);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getTokenUrl()
+    {
+        return 'https://'.$this->getHostname().'/oauth/token';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getUserByToken($token)
+    {
+        $response = $this->getHttpClient()->get(
+            'https://'.$this->getHostname().'/api/user',
+            [
+                RequestOptions::HEADERS => [
+                    'Authorization' => 'Bearer '.$token,
+                ],
+            ]
+        );
+
+        return json_decode((string) $response->getBody(), true);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return (new User())->setRaw($user)->map([
+            'id'    => Arr::get($user, 'data.cid'),
+            'name'  => Arr::get($user, 'data.personal.name_full'),
+            'email' => Arr::get($user, 'data.personal.email'),
+        ]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function additionalConfigKeys()
+    {
+        return ['test'];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getScopes()
+    {
+        return array_unique(array_merge(parent::getScopes(), $this->getRequiredScopes()));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getCodeFields($state = null)
+    {
+        $fields = parent::getCodeFields($state);
+
+        if ($requiredScopes = $this->getRequiredScopes()) {
+            $fields['required_scopes'] = $this->formatScopes($requiredScopes, $this->scopeSeparator);
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Merge the required scopes of the requested access.
+     *
+     * @param array|string $scopes
+     *
+     * @return $this
+     */
+    public function requiredScopes($scopes)
+    {
+        $this->requiredScopes = array_unique(array_merge($this->requiredScopes, (array) $scopes));
+
+        return $this;
+    }
+
+    /**
+     * Set the required scopes of the requested access.
+     *
+     * @param array|string $scopes
+     *
+     * @return $this
+     */
+    public function setRequiredScopes($scopes)
+    {
+        $this->requiredScopes = array_unique((array) $scopes);
+
+        return $this;
+    }
+
+    /**
+     * Get the current required scopes.
+     *
+     * @return array
+     */
+    public function getRequiredScopes()
+    {
+        return $this->requiredScopes;
+    }
+}

--- a/src/Vatsim/README.md
+++ b/src/Vatsim/README.md
@@ -1,0 +1,63 @@
+# VATSIM
+
+```bash
+composer require socialiteproviders/vatsim
+```
+
+## Installation & Basic Usage
+
+Please see the [Base Installation Guide](https://socialiteproviders.com/usage/), then follow the provider specific instructions below.
+
+### Add configuration to `config/services.php`
+
+```php
+'vatsim' => [
+  'client_id' => env('VATSIM_CLIENT_ID'),
+  'client_secret' => env('VATSIM_CLIENT_SECRET'),
+  'redirect' => env('VATSIM_REDIRECT_URI'),
+  'test' => env('VATSIM_TEST'),
+],
+```
+
+See [Configure VATSIM Connect Authentication](https://github.com/vatsimnetwork/developer-info/wiki/Connect)
+
+### Add provider event listener
+
+Configure the package's listener to listen for `SocialiteWasCalled` events.
+
+Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. See the [Base Installation Guide](https://socialiteproviders.com/usage/) for detailed instructions.
+
+```php
+protected $listen = [
+    \SocialiteProviders\Manager\SocialiteWasCalled::class => [
+        // ... other providers
+        \SocialiteProviders\Vatsim\VatsimExtendSocialite::class.'@handle',
+    ],
+];
+```
+
+### Usage
+
+You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
+
+```php
+return Socialite::driver('vatsim')->redirect();
+```
+
+To add scopes to your Authentication you can use the below:
+
+```php
+return Socialite::driver('vatsim')->scopes(['full_name', 'email', 'vatsim_details', 'country'])->redirect();
+```
+
+To add required scopes (those the user cannot opt out from) to your Authentication you can use the below:
+
+```php
+return Socialite::driver('vatsim')->requiredScopes(['email'])->redirect();
+```
+
+### Returned User fields
+
+- ``id``
+- ``name``
+- ``email``

--- a/src/Vatsim/VatsimExtendSocialite.php
+++ b/src/Vatsim/VatsimExtendSocialite.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SocialiteProviders\Vatsim;
+
+use SocialiteProviders\Manager\SocialiteWasCalled;
+
+class VatsimExtendSocialite
+{
+    /**
+     * Register the provider.
+     *
+     * @param \SocialiteProviders\Manager\SocialiteWasCalled $socialiteWasCalled
+     */
+    public function handle(SocialiteWasCalled $socialiteWasCalled)
+    {
+        $socialiteWasCalled->extendSocialite('vatsim', Provider::class);
+    }
+}

--- a/src/Vatsim/composer.json
+++ b/src/Vatsim/composer.json
@@ -1,0 +1,35 @@
+{
+    "name": "socialiteproviders/vatsim",
+    "description": "VATSIM OAuth2 Provider for Laravel Socialite",
+    "license": "MIT",
+    "keywords": [
+        "laravel",
+        "socialite",
+        "oauth",
+        "oauth2",
+        "provider",
+        "vatsim"
+    ],
+    "authors": [
+        {
+            "name": "Roy de Vos Burchart",
+            "email": "dev@bonroyage.com",
+            "role": "Developer"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/socialiteproviders/providers/issues",
+        "source": "https://github.com/socialiteproviders/providers",
+        "docs": "https://socialiteproviders.com/vatsim"
+    },
+    "require": {
+        "php": "^7.4 || ^8.0",
+        "ext-json": "*",
+        "socialiteproviders/manager": "~4.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialiteProviders\\Vatsim\\": ""
+        }
+    }
+}

--- a/src/Vatsim/composer.json
+++ b/src/Vatsim/composer.json
@@ -23,9 +23,9 @@
         "docs": "https://socialiteproviders.com/vatsim"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
-        "socialiteproviders/manager": "~4.0"
+        "socialiteproviders/manager": "~4.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Provider for [VATSIM](https://vatsim.net/), a flight simulation network

Documentation: https://github.com/vatsimnetwork/developer-info/wiki/Connect

## Scopes

List of scopes available here: [Connect Redirect the User](https://github.com/vatsimnetwork/developer-info/wiki/Connect-Redirect-the-User)

### Required scopes

The OAuth servers support required scopes. These are scopes the user cannot opt out from upon approving the application. The methods for setting the required scopes are pretty much an identical copy of the default scopes methods.

## Test mode

Set `services.vatsim.test` to `true` to use the auth-dev.vatsim.net endpoints.

Credentials for the test mode are available here: [Connect Development Environment](https://github.com/vatsimnetwork/developer-info/wiki/Connect-Development-Environment).
