### PR TITLE
Ability to set leeway

### DIFF
--- a/src/AzureADB2C/Provider.php
+++ b/src/AzureADB2C/Provider.php
@@ -48,6 +48,17 @@ class Provider extends AbstractProvider
 
         return $policy;
     }
+    
+    /**
+     * Set the leeway.
+     *
+     * @return void
+     */
+    private function setLeeway($leeway)
+    {
+        JWT::$leeway = 60;
+        return;
+    }
 
     /**
      * Set the redirect URL.


### PR DESCRIPTION
Added this public function setLeeway in order to help with the error "Cannot handle token prior to" as described here https://github.com/googleapis/google-api-php-client/issues/1630

