### PR TITLE
feat(fusionauth): picture can be null

### DIFF
--- a/src/FusionAuth/Provider.php
+++ b/src/FusionAuth/Provider.php
@@ -94,7 +94,7 @@ class Provider extends AbstractProvider
             'nickname' => $user['preferred_username'] ?? null,
             'name'     => $user['name'],
             'email'    => $user['email'],
-            'avatar'   => $user['picture'],
+            'avatar'   => $user['picture'] ?? null,
         ]);
     }
 


### PR DESCRIPTION
Picture can also be null if no image is used in fusionauth. Currently if no avatar is set, this will break.

