### PR TITLE
Use Todoist's Sync API v9

### DIFF
--- a/src/Todoist/Provider.php
+++ b/src/Todoist/Provider.php
@@ -12,7 +12,7 @@ class Provider extends AbstractProvider
 
     public const AUTH_URL = 'https://todoist.com/oauth/authorize';
     public const TOKEN_URL = 'https://todoist.com/oauth/access_token';
-    public const SYNC_URL = 'https://api.todoist.com/sync/v8/sync';
+    public const SYNC_URL = 'https://api.todoist.com/sync/v9/sync';
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
v8 was deprecated on December 5 2022 and doesn't work anymore.

I didn't notice any incompatibility, but here's the migration guide from v8: https://developer.todoist.com/sync/v9/#migrating-from-v8

