### PR TITLE
Updates for Auth Header usage in Todoist API

### DIFF
--- a/src/Todoist/Provider.php
+++ b/src/Todoist/Provider.php
@@ -46,10 +46,12 @@ class Provider extends AbstractProvider
     protected function getUserByToken($token)
     {
         $response = $this->getHttpClient()->get(self::SYNC_URL, [
+            'headers' => [
+            'Authorization' => 'Bearer '.$token,
+            ],
             RequestOptions::QUERY => [
-                'token'          => $token,
-                'sync_token'     => '*',
-                'resource_types' => json_encode(['user']),
+            'sync_token' => '*',
+            'resource_types' => json_encode(['user']),
             ],
         ]);
 


### PR DESCRIPTION
- Fixes the Todoist integration by migrating from passing the token by parameter (now deprecated) and instead providing the token via Auth header.