### PR TITLE
Updates Todoist API to use Auth Header

### DIFF
--- a/src/Todoist/Provider.php
+++ b/src/Todoist/Provider.php
@@ -46,10 +46,12 @@ class Provider extends AbstractProvider
     protected function getUserByToken($token)
     {
         $response = $this->getHttpClient()->get(self::SYNC_URL, [
+            'headers' => [
+            'Authorization' => 'Bearer '.$token,
+            ],
             RequestOptions::QUERY => [
-                'token'          => $token,
-                'sync_token'     => '*',
-                'resource_types' => json_encode(['user']),
+            'sync_token' => '*',
+            'resource_types' => json_encode(['user']),
             ],
         ]);
 

--- a/src/Todoist/Provider.php
+++ b/src/Todoist/Provider.php
@@ -47,11 +47,11 @@ class Provider extends AbstractProvider
     {
         $response = $this->getHttpClient()->get(self::SYNC_URL, [
             'headers' => [
-            'Authorization' => 'Bearer '.$token,
+                'Authorization' => 'Bearer '.$token,
             ],
             RequestOptions::QUERY => [
-            'sync_token' => '*',
-            'resource_types' => json_encode(['user']),
+                'sync_token' => '*',
+                'resource_types' => json_encode(['user']),
             ],
         ]);
 


### PR DESCRIPTION
- Migrates the integration from passing the token by parameter (deprecated) to providing it via Auth Header