### PR TITLE
[Apple] Adding method to return SocialiteUser by JWT token

### DIFF
--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -122,6 +122,7 @@ class Provider extends AbstractProvider
      * side by Apple.
      *
      * @param string $token
+     * 
      * @throws InvalidStateException when token can't be parsed
      *
      * @return User $user

--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -122,7 +122,7 @@ class Provider extends AbstractProvider
      * side by Apple.
      *
      * @param string $token
-     * 
+     *
      * @throws InvalidStateException when token can't be parsed
      *
      * @return User $user

--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -118,6 +118,21 @@ class Provider extends AbstractProvider
     }
 
     /**
+     * Return the user given the identity token provided on the client
+     * side by Apple.
+     *
+     * @param String $token
+     * @return User
+     * @throws InvalidStateException when token can't be parsed
+     */
+    public function userByIdentityToken(String $token) : SocialiteUser
+    {
+        $array = $this->getUserByToken($token);
+
+        return $this->mapUserToObject($array);
+    }
+
+    /**
      * Verify Apple jwt.
      *
      * @param string $jwt

--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -121,11 +121,12 @@ class Provider extends AbstractProvider
      * Return the user given the identity token provided on the client
      * side by Apple.
      *
-     * @param String $token
-     * @return User
+     * @param string $token
      * @throws InvalidStateException when token can't be parsed
+     *
+     * @return User $user
      */
-    public function userByIdentityToken(String $token) : SocialiteUser
+    public function userByIdentityToken(string $token): SocialiteUser
     {
         $array = $this->getUserByToken($token);
 


### PR DESCRIPTION
Because `getUserByToken()` is a protected function, you cannot check an identity token directly from the Socialite driver. This PR intend to allow the verification of a JWT by a public function, returning a SocialiteUser, or throwing an InvalidStateException when the given JWT is incorrect 