### PR TITLE
Some array keys may be undefined in the "Microsoft" Provider

### DIFF
--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -3,6 +3,7 @@
 namespace SocialiteProviders\Microsoft;
 
 use GuzzleHttp\RequestOptions;
+use Illuminate\Support\Arr;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Microsoft\MicrosoftUser as User;
 
@@ -85,16 +86,16 @@ class Provider extends AbstractProvider
             'email'    => $user['userPrincipalName'],
             'avatar'   => null,
 
-            'businessPhones'    => $user['businessPhones'],
-            'displayName'       => $user['displayName'],
-            'givenName'         => $user['givenName'],
-            'jobTitle'          => $user['jobTitle'],
-            'mail'              => $user['mail'],
-            'mobilePhone'       => $user['mobilePhone'],
-            'officeLocation'    => $user['officeLocation'],
-            'preferredLanguage' => $user['preferredLanguage'],
-            'surname'           => $user['surname'],
-            'userPrincipalName' => $user['userPrincipalName'],
+            'businessPhones'    => Arr::get($user, 'businessPhones'),
+            'displayName'       => Arr::get($user, 'displayName'),
+            'givenName'         => Arr::get($user, 'givenName'),
+            'jobTitle'          => Arr::get($user, 'jobTitle'),
+            'mail'              => Arr::get($user, 'mail'),
+            'mobilePhone'       => Arr::get($user, 'mobilePhone'),
+            'officeLocation'    => Arr::get($user, 'officeLocation'),
+            'preferredLanguage' => Arr::get($user, 'preferredLanguage'),
+            'surname'           => Arr::get($user, 'surname'),
+            'userPrincipalName' => Arr::get($user, 'userPrincipalName'),
         ]);
     }
 


### PR DESCRIPTION
As mentionned in SocialiteProviders/Providers#333, users will not necessarily have all fields filled (givenName is not guaranteed, for instance). Had this bug occur with a new Microsoft user that was made by an admin and without a name given to them.

This PR follows the same solution as the one mentionned previously. This also resolves the PR in the read-only repo SocialiteProviders/Microsoft#3.

Currently, this bug prevents correct use of this package for us. I'm open to any changes!

