### PR TITLE
[Dataporten] add openid scope and add logout functionality

### DIFF
--- a/src/Dataporten/Provider.php
+++ b/src/Dataporten/Provider.php
@@ -12,7 +12,7 @@ class Provider extends AbstractProvider
 
     /**
      * {@inheritdoc}
-    */
+     */
     protected $scopes = ['openid'];
 
     /**
@@ -75,5 +75,4 @@ class Provider extends AbstractProvider
 
         return "$endpointUri?$params";
     }
-
 }

--- a/src/Dataporten/Provider.php
+++ b/src/Dataporten/Provider.php
@@ -12,6 +12,11 @@ class Provider extends AbstractProvider
 
     /**
      * {@inheritdoc}
+    */
+    protected $scopes = ['openid'];
+
+    /**
+     * {@inheritdoc}
      */
     protected function getAuthUrl($state)
     {
@@ -57,4 +62,18 @@ class Provider extends AbstractProvider
             'grant_type' => 'authorization_code',
         ]);
     }
+
+    /**
+     *  Get the endsession endpoint URL.
+     */
+    public function getLogoutUrl($idToken, $endpointUri, $redirectUri)
+    {
+        $params = http_build_query(array_filter([
+            'id_token_hint'            => $idToken,
+            'post_logout_redirect_uri' => $redirectUri,
+        ]));
+
+        return "$endpointUri?$params";
+    }
+
 }

--- a/src/Dataporten/README.md
+++ b/src/Dataporten/README.md
@@ -11,10 +11,10 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
 ### Add configuration to `config/services.php`
 
 ```php
-'dataporten' => [    
-  'client_id' => env('DATAPORTEN_CLIENT_ID'),  
-  'client_secret' => env('DATAPORTEN_CLIENT_SECRET'),  
-  'redirect' => env('DATAPORTEN_REDIRECT_URI') 
+'dataporten' => [
+  'client_id' => env('DATAPORTEN_CLIENT_ID'),
+  'client_secret' => env('DATAPORTEN_CLIENT_SECRET'),
+  'redirect' => env('DATAPORTEN_REDIRECT_URI')
 ],
 ```
 
@@ -39,4 +39,25 @@ You should now be able to use the provider like you would regularly use Socialit
 
 ```php
 return Socialite::driver('dataporten')->redirect();
+```
+
+Example on how to end session for application AND dataporten.
+
+```php
+$idToken = auth()->user()->dataporten_id_token;
+
+Auth::guard('web')->logout();
+
+$request->session()->invalidate();
+
+$request->session()->regenerateToken();
+
+if($idToken) {
+    $endpointUri = env('DATAPORTEN_ENDSESSION_ENDPOINT');
+    $redirectUri = env('DATAPORTEN_LOGOUT_REDIRECT_URI');
+    $logoutUri = Socialite::driver('dataporten')->getLogoutUrl($idToken, $endpointUri, $redirectUri);
+    return redirect()->away($logoutUri);
+}
+
+return redirect('/');
 ```


### PR DESCRIPTION
Relevant docs for "openid" scope (see "Authorization Request"):
[Obtaining tokens](https://docs.feide.no/service_providers/openid_connect/feide_obtaining_tokens.html)
If scope not present, you will not obtain "id_token" which is needed for logout functionality.

Relevant docs for logout:
[Redirection after logout](https://docs.feide.no/service_providers/manage/openid_connect/redir_etter_logout.html)