### PR TITLE
[Microsoft] Added ability to retrieve tenant information when using multi-tenant auth

### DIFF
--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -79,7 +79,7 @@ class Provider extends AbstractProvider
 
         $formatted_response = json_decode((string) $responseUser->getBody(), true);
 
-        if (($this->getConfig('tenant', 'common') === 'common') && ($this->getConfig('include_tenant_info', 'false') === 'true')) {
+        if (($this->getConfig('tenant', 'common') === 'common') && ($this->getConfig('include_tenant_info', false) === true)) {
             $responseTenant = $this->getHttpClient()->get(
                 'https://graph.microsoft.com/v1.0/organization',
                 [

--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -72,7 +72,7 @@ class Provider extends AbstractProvider
                     'Authorization' => 'Bearer '.$token,
                 ],
                 RequestOptions::QUERY => [
-                    '$select' => implode(',', array_merge(self::DEFAULT_FIELDS_USER, ($this->config['fields'] ?: []))),
+                    '$select' => implode(',', array_merge(self::DEFAULT_FIELDS_USER, $this->getConfig('fields'))),
                 ],
             ]
         );

--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -88,7 +88,7 @@ class Provider extends AbstractProvider
                         'Authorization' => 'Bearer '.$token,
                     ],
                     RequestOptions::QUERY => [
-                        '$select' => implode(',', array_merge(self::DEFAULT_FIELDS_TENANT, ($this->config['tenant_fields'] ?: []))),
+                        '$select' => implode(',', array_merge(self::DEFAULT_FIELDS_TENANT, $this->getConfig('tenant_fields'))),
                     ],
                 ]
             );

--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -79,7 +79,7 @@ class Provider extends AbstractProvider
 
         $formatted_response = json_decode((string) $response_user->getBody(), true);
 
-        if($this->getConfig('tenant','common') === 'common'){
+        if($this->getConfig('tenant','common') === 'common') {
             $response_tenant = $this->getHttpClient()->get(
                 'https://graph.microsoft.com/v1.0/organization',
                 [

--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -79,7 +79,7 @@ class Provider extends AbstractProvider
 
         $formattedResponse = json_decode((string) $responseUser->getBody(), true);
 
-        if ($this->getConfig('tenant', 'common') === 'common' && $this->getConfig('include_tenant_info', false) {
+        if ($this->getConfig('tenant', 'common') === 'common' && $this->getConfig('include_tenant_info', false)) {
             $responseTenant = $this->getHttpClient()->get(
                 'https://graph.microsoft.com/v1.0/organization',
                 [

--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -77,10 +77,10 @@ class Provider extends AbstractProvider
             ]
         );
 
-        $formatted_response = json_decode((string) $response_user->getBody(), true);
+        $formatted_response = json_decode((string) $responseUser->getBody(), true);
 
         if ($this->getConfig('tenant', 'common') === 'common') {
-            $response_tenant = $this->getHttpClient()->get(
+            $responseTenant = $this->getHttpClient()->get(
                 'https://graph.microsoft.com/v1.0/organization',
                 [
                     RequestOptions::HEADERS => [
@@ -93,7 +93,7 @@ class Provider extends AbstractProvider
                 ]
             );
 
-            $formatted_response['tenant'] = json_decode((string) $response_tenant->getBody(), true)['value'][0];
+            $formatted_response['tenant'] = json_decode((string) $responseTenant->getBody(), true)['value'][0];
         }
 
         return $formatted_response;

--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -72,7 +72,7 @@ class Provider extends AbstractProvider
                     'Authorization' => 'Bearer '.$token,
                 ],
                 RequestOptions::QUERY => [
-                    '$select' => implode(',', array_merge(self::DEFAULT_FIELDS_USER, ($this->config['user_fields'] ?: []))),
+                    '$select' => implode(',', array_merge(self::DEFAULT_FIELDS_USER, ($this->config['fields'] ?: []))),
                 ],
             ]
         );
@@ -145,6 +145,6 @@ class Provider extends AbstractProvider
      */
     public static function additionalConfigKeys()
     {
-        return ['tenant', 'user_fields', 'tenant_fields'];
+        return ['tenant', 'fields', 'tenant_fields'];
     }
 }

--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -79,7 +79,7 @@ class Provider extends AbstractProvider
 
         $formatted_response = json_decode((string) $responseUser->getBody(), true);
 
-        if ($this->getConfig('tenant', 'common') === 'common') {
+        if (($this->getConfig('tenant', 'common') === 'common') && ($this->getConfig('include_tenant_info', 'false') === 'true')) {
             $responseTenant = $this->getHttpClient()->get(
                 'https://graph.microsoft.com/v1.0/organization',
                 [
@@ -145,6 +145,6 @@ class Provider extends AbstractProvider
      */
     public static function additionalConfigKeys()
     {
-        return ['tenant', 'fields', 'tenant_fields'];
+        return ['tenant', 'include_tenant_info', 'fields', 'tenant_fields'];
     }
 }

--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -77,7 +77,7 @@ class Provider extends AbstractProvider
             ]
         );
 
-        $formatted_response = json_decode((string) $responseUser->getBody(), true);
+        $formattedResponse = json_decode((string) $responseUser->getBody(), true);
 
         if ($this->getConfig('tenant', 'common') === 'common' && $this->getConfig('include_tenant_info', false) {
             $responseTenant = $this->getHttpClient()->get(
@@ -93,11 +93,11 @@ class Provider extends AbstractProvider
                 ]
             );
 
-            $formatted_response['tenant'] = json_decode((string) $responseTenant->getBody(), true)['value'][0] 
+            $formattedResponse['tenant'] = json_decode((string) $responseTenant->getBody(), true)['value'][0] 
             ?? null;
         }
 
-        return $formatted_response;
+        return $formattedResponse;
     }
 
     /**

--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -72,7 +72,7 @@ class Provider extends AbstractProvider
                     'Authorization' => 'Bearer '.$token,
                 ],
                 RequestOptions::QUERY => [
-                    '$select' => implode(',', array_merge(self::DEFAULT_FIELDS_USER, $this->getConfig('fields'))),
+                    '$select' => implode(',', array_merge(self::DEFAULT_FIELDS_USER, $this->getConfig('fields', []))),
                 ],
             ]
         );
@@ -88,7 +88,7 @@ class Provider extends AbstractProvider
                         'Authorization' => 'Bearer '.$token,
                     ],
                     RequestOptions::QUERY => [
-                        '$select' => implode(',', array_merge(self::DEFAULT_FIELDS_TENANT, $this->getConfig('tenant_fields'))),
+                        '$select' => implode(',', array_merge(self::DEFAULT_FIELDS_TENANT, $this->getConfig('tenant_fields', []))),
                     ],
                 ]
             );

--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -64,7 +64,7 @@ class Provider extends AbstractProvider
      */
     protected function getUserByToken($token)
     {
-        $response_user = $this->getHttpClient()->get(
+        $responseUser = $this->getHttpClient()->get(
             'https://graph.microsoft.com/v1.0/me',
             [
                 RequestOptions::HEADERS => [

--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -93,8 +93,7 @@ class Provider extends AbstractProvider
                 ]
             );
 
-            $formattedResponse['tenant'] = json_decode((string) $responseTenant->getBody(), true)['value'][0] 
-            ?? null;
+            $formattedResponse['tenant'] = json_decode((string) $responseTenant->getBody(), true)['value'][0] ?? null;
         }
 
         return $formattedResponse;

--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -79,7 +79,7 @@ class Provider extends AbstractProvider
 
         $formatted_response = json_decode((string) $response_user->getBody(), true);
 
-        if($this->getConfig('tenant','common') === 'common') {
+        if ($this->getConfig('tenant', 'common') === 'common') {
             $response_tenant = $this->getHttpClient()->get(
                 'https://graph.microsoft.com/v1.0/organization',
                 [

--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -93,7 +93,8 @@ class Provider extends AbstractProvider
                 ]
             );
 
-            $formatted_response['tenant'] = json_decode((string) $responseTenant->getBody(), true)['value'][0];
+            $formatted_response['tenant'] = json_decode((string) $responseTenant->getBody(), true)['value'][0] 
+            ?? null;
         }
 
         return $formatted_response;

--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -79,7 +79,7 @@ class Provider extends AbstractProvider
 
         $formatted_response = json_decode((string) $responseUser->getBody(), true);
 
-        if (($this->getConfig('tenant', 'common') === 'common') && ($this->getConfig('include_tenant_info', false) === true)) {
+        if ($this->getConfig('tenant', 'common') === 'common' && $this->getConfig('include_tenant_info', false) {
             $responseTenant = $this->getHttpClient()->get(
                 'https://graph.microsoft.com/v1.0/organization',
                 [


### PR DESCRIPTION
Added ability to retrieve tenant information when using multi-tenant auth to allow for tenant filtering for any apps that may wish to form allow/blocklists or who may want to only allow access to "internal" tenants.