### PR TITLE
[FusionAuth] Changing required properties and better handling API responses

### DIFF
--- a/src/FusionAuth/Provider.php
+++ b/src/FusionAuth/Provider.php
@@ -89,10 +89,19 @@ class Provider extends AbstractProvider
      */
     protected function mapUserToObject(array $user)
     {
+        $name = null;
+        if (!empty($user['name'])) {
+            $name = $user['name'];
+        } elseif (!empty($user['given_name'])) {
+            $name = $user['given_name'];
+            if (!empty($user['family_name'])) {
+                $name .= " {$user['family_name']}";
+            }
+        }
         return (new User())->setRaw($user)->map([
             'id'       => $user['sub'],
             'nickname' => $user['preferred_username'] ?? null,
-            'name'     => $user['name'],
+            'name'     => $name,
             'email'    => $user['email'],
             'avatar'   => $user['picture'] ?? null,
         ]);

--- a/src/FusionAuth/Provider.php
+++ b/src/FusionAuth/Provider.php
@@ -90,7 +90,7 @@ class Provider extends AbstractProvider
     protected function mapUserToObject(array $user)
     {
         $name = null;
-        if (!empty($user['name'])) {
+        $user['name'] ?? trim($user['given_name'] ?? '' . ' ' . $user['family_name'] ?? '')
             $name = $user['name'];
         } elseif (!empty($user['given_name'])) {
             $name = $user['given_name'];

--- a/src/FusionAuth/Provider.php
+++ b/src/FusionAuth/Provider.php
@@ -105,14 +105,13 @@ class Provider extends AbstractProvider
      */
     protected function getCodeFields($state = null)
     {
-        $tenantId = $this->getConfig('tenant_id');
+        $fields = parent::getCodeFields($state);
 
-        if ($tenantId === null) {
-            throw new InvalidArgumentException('Missing tenant_id');
+        $tenantId = $this->getConfig('tenant_id');
+        if (!empty($tenantId)) {
+            $fields['tenantId'] = $tenantId;
         }
 
-        return array_merge(parent::getCodeFields($state), [
-            'tenantId' => $tenantId,
-        ]);
+        return $fields;
     }
 }

--- a/src/FusionAuth/Provider.php
+++ b/src/FusionAuth/Provider.php
@@ -89,19 +89,10 @@ class Provider extends AbstractProvider
      */
     protected function mapUserToObject(array $user)
     {
-        $name = null;
-        $user['name'] ?? trim($user['given_name'] ?? '' . ' ' . $user['family_name'] ?? '')
-            $name = $user['name'];
-        } elseif (!empty($user['given_name'])) {
-            $name = $user['given_name'];
-            if (!empty($user['family_name'])) {
-                $name .= " {$user['family_name']}";
-            }
-        }
         return (new User())->setRaw($user)->map([
             'id'       => $user['sub'],
             'nickname' => $user['preferred_username'] ?? null,
-            'name'     => $name,
+            'name'     => $user['name'] ?? trim($user['given_name'] ?? '' . ' ' . $user['family_name'] ?? ''),
             'email'    => $user['email'],
             'avatar'   => $user['picture'] ?? null,
         ]);

--- a/src/FusionAuth/README.md
+++ b/src/FusionAuth/README.md
@@ -16,7 +16,7 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
     'client_secret' => env('FUSIONAUTH_CLIENT_SECRET'),
     'redirect' => env('FUSIONAUTH_REDIRECT_URI'),
     'base_url' => env('FUSIONAUTH_BASE_URL'), // Base URL of your cloud instance or self hosted instance
-    'tenant_id' => env('FUSIONAUTH_TENANT_ID'), // Tenant ID of the client. Required since FusionAuth 1.8.0
+    'tenant_id' => env('FUSIONAUTH_TENANT_ID'), // Tenant ID of the client (leave blank if you only have one)
 ],
 ```
 

--- a/src/FusionAuth/README.md
+++ b/src/FusionAuth/README.md
@@ -30,7 +30,7 @@ Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. 
 protected $listen = [
     \SocialiteProviders\Manager\SocialiteWasCalled::class => [
         // ... other providers
-        \SocialiteProviders\FusionAuth\FusionAuthExtendSocialite:class.'@handle',
+        \SocialiteProviders\FusionAuth\FusionAuthExtendSocialite::class.'@handle',
     ],
 ];
 ```


### PR DESCRIPTION
Minor changes to the FusionAuth provider:

- :alien: Checking for either `name` or `given_name`/`family_name` attributes when building `User` object (the API may return both)
- :necktie: Making `tenant_id` optional (you can leave it blank if you only have one)
- :pencil2: Fixing typo with the `::class` constant in the README file (it was missing one `:`)

