### PR TITLE
[Saml2] Allow combined keydescriptors for signing

### DIFF
--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -497,9 +497,12 @@ class Provider extends AbstractProvider implements SocialiteProvider
 
     protected function validateSignature(): void
     {
-        $keyDescriptors = $this->getIdentityProviderEntityDescriptor()
-            ->getFirstIdpSsoDescriptor()
-            ->getAllKeyDescriptorsByUse(KeyDescriptor::USE_SIGNING);
+        $idpSsoDescriptor = $this->getIdentityProviderEntityDescriptor()->getFirstIdpSsoDescriptor();
+
+        $keyDescriptors = array_merge(
+            $idpSsoDescriptor->getAllKeyDescriptorsByUse(KeyDescriptor::USE_SIGNING),
+            $idpSsoDescriptor->getAllKeyDescriptorsByUse(null),
+        );
 
         /** @var SignatureXmlReader $signatureReader */
         $signatureReader = $this->messageContext->getMessage()->getSignature() ?: $this->getFirstAssertion()->getSignature();


### PR DESCRIPTION
Based on [this document](https://shibboleth.atlassian.net/wiki/spaces/CONCEPT/pages/948470554/SAMLKeysAndCertificates) KeyDescriptors without use tag should be used as both signing and encryption key. The official [metadata standard](https://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf) also describes the use attribute as optional.

We already had to deal with such a configuration so this pull request allows the usage of such key descriptors.