### PR TITLE
add GovBR oauth2 provider

### DIFF
--- a/monorepo-builder.yml
+++ b/monorepo-builder.yml
@@ -70,6 +70,7 @@ parameters:
     src/Gitee: 'git@github.com:SocialiteProviders/Gitee.git'
     src/Goodreads: 'git@github.com:SocialiteProviders/Goodreads.git'
     src/Google: 'git@github.com:SocialiteProviders/Google-Plus.git'
+    src/GovBR: 'git@github.com:SocialiteProviders/GovBR.git'
     src/Graph: 'git@github.com:SocialiteProviders/Microsoft-Graph.git'
     src/Gumroad: 'git@github.com:SocialiteProviders/Gumroad.git'
     src/HabrCareer: 'git@github.com:SocialiteProviders/HabrCareer.git'

--- a/src/GovBR/GovBRExtendSocialite.php
+++ b/src/GovBR/GovBRExtendSocialite.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SocialiteProviders\GovBR;
+
+use SocialiteProviders\Manager\SocialiteWasCalled;
+
+class GovBRExtendSocialite
+{
+    /**
+     * Register the provider.
+     *
+     * @param \SocialiteProviders\Manager\SocialiteWasCalled $socialiteWasCalled
+     */
+    public function handle(SocialiteWasCalled $socialiteWasCalled)
+    {
+        $socialiteWasCalled->extendSocialite('govbr', Provider::class);
+    }
+}

--- a/src/GovBR/Provider.php
+++ b/src/GovBR/Provider.php
@@ -25,14 +25,14 @@ class Provider extends AbstractProvider implements ProviderInterface
     const SCOPE_GOVBR_CONFIABILIDADES = 'govbr_confiabilidades';
 
     /**
-     * Staging URL
+     * Staging URL.
      *
      * @var string
      */
     protected $stagingUrl = 'https://sso.staging.acesso.gov.br';
 
     /**
-     * Production URL
+     * Production URL.
      *
      * @var string
      */
@@ -63,7 +63,7 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     protected function getAuthUrl($state)
     {
-        return $this->buildAuthUrlFromBase($this->getBaseUrlForEnvironment() . '/authorize', $state);
+        return $this->buildAuthUrlFromBase($this->getBaseUrlForEnvironment().'/authorize', $state);
     }
 
     /**
@@ -71,7 +71,7 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     protected function getTokenUrl()
     {
-        return $this->getBaseUrlForEnvironment() . '/token';
+        return $this->getBaseUrlForEnvironment().'/token';
     }
 
     /**
@@ -79,9 +79,9 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     protected function getUserByToken($token)
     {
-        $response = $this->getHttpClient()->get($this->getBaseUrlForEnvironment() . '/userinfo', [
+        $response = $this->getHttpClient()->get($this->getBaseUrlForEnvironment().'/userinfo', [
             'headers' => [
-                'Authorization' => 'Bearer ' . $token,
+                'Authorization' => 'Bearer '.$token,
             ],
         ]);
 
@@ -94,15 +94,15 @@ class Provider extends AbstractProvider implements ProviderInterface
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([
-            'id' => $user['sub'],
-            'cpf' => $user['sub'],
-            'name' => $user['name'],
-            'email' => $user['email'] ?? null,
-            'email_verified' => $user['email_verified'] ?? null,
-            'phone_number' => $user['phone_number'] ?? null,
+            'id'                    => $user['sub'],
+            'cpf'                   => $user['sub'],
+            'name'                  => $user['name'],
+            'email'                 => $user['email'] ?? null,
+            'email_verified'        => $user['email_verified'] ?? null,
+            'phone_number'          => $user['phone_number'] ?? null,
             'phone_number_verified' => $user['phone_number_verified'] ?? null,
-            'avatar_url' => $user['picture'] ?? null,
-            'profile' => $user['profile'] ?? null,
+            'avatar_url'            => $user['picture'] ?? null,
+            'profile'               => $user['profile'] ?? null,
         ]);
     }
 
@@ -134,9 +134,9 @@ class Provider extends AbstractProvider implements ProviderInterface
         $environment = $this->getConfig('environment', 'production');
 
         return match ($environment) {
-            'staging' => $this->stagingUrl,
+            'staging'    => $this->stagingUrl,
             'production' => $this->productionUrl,
-            default => throw new RuntimeException("Invalid environment '{$environment}' selected for GovBR provider."),
+            default      => throw new RuntimeException("Invalid environment '{$environment}' selected for GovBR provider."),
         };
     }
 }

--- a/src/GovBR/Provider.php
+++ b/src/GovBR/Provider.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace SocialiteProviders\GovBR;
+
+use RuntimeException;
+use SocialiteProviders\Manager\Contracts\OAuth2\ProviderInterface;
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
+use SocialiteProviders\Manager\OAuth2\User;
+
+class Provider extends AbstractProvider implements ProviderInterface
+{
+    /**
+     * Unique Provider Identifier.
+     */
+    const IDENTIFIER = 'GOVBR';
+
+    const SCOPE_OPENID = 'openid';
+
+    const SCOPE_EMAIL = 'email';
+
+    const SCOPE_PROFILE = 'profile';
+
+    const SCOPE_GOVBR_EMPRESA = 'govbr_empresa';
+
+    const SCOPE_GOVBR_CONFIABILIDADES = 'govbr_confiabilidades';
+
+    /**
+     * Staging URL
+     *
+     * @var string
+     */
+    protected $stagingUrl = 'https://sso.staging.acesso.gov.br';
+
+    /**
+     * Production URL
+     *
+     * @var string
+     */
+    protected $productionUrl = 'https://sso.acesso.gov.br';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopeSeparator = ' ';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopes = [
+        self::SCOPE_OPENID,
+        self::SCOPE_EMAIL,
+        self::SCOPE_PROFILE,
+        self::SCOPE_GOVBR_CONFIABILIDADES,
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $usesPKCE = true;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAuthUrl($state)
+    {
+        return $this->buildAuthUrlFromBase($this->getBaseUrlForEnvironment() . '/authorize', $state);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenUrl()
+    {
+        return $this->getBaseUrlForEnvironment() . '/token';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByToken($token)
+    {
+        $response = $this->getHttpClient()->get($this->getBaseUrlForEnvironment() . '/userinfo', [
+            'headers' => [
+                'Authorization' => 'Bearer ' . $token,
+            ],
+        ]);
+
+        return json_decode($response->getBody(), true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return (new User())->setRaw($user)->map([
+            'id' => $user['sub'],
+            'cpf' => $user['sub'],
+            'name' => $user['name'],
+            'email' => $user['email'] ?? null,
+            'email_verified' => $user['email_verified'] ?? null,
+            'phone_number' => $user['phone_number'] ?? null,
+            'phone_number_verified' => $user['phone_number_verified'] ?? null,
+            'avatar_url' => $user['picture'] ?? null,
+            'profile' => $user['profile'] ?? null,
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenFields($code)
+    {
+        return array_merge(parent::getTokenFields($code), [
+            'grant_type' => 'authorization_code',
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function additionalConfigKeys()
+    {
+        return ['environment'];
+    }
+
+    /**
+     * Get the URL for the given environment.
+     *
+     * @throws RuntimeException
+     */
+    protected function getBaseUrlForEnvironment(): string
+    {
+        $environment = $this->getConfig('environment', 'production');
+
+        return match ($environment) {
+            'staging' => $this->stagingUrl,
+            'production' => $this->productionUrl,
+            default => throw new RuntimeException("Invalid environment '{$environment}' selected for GovBR provider."),
+        };
+    }
+}

--- a/src/GovBR/README.md
+++ b/src/GovBR/README.md
@@ -1,0 +1,55 @@
+# GovBR
+
+```bash
+composer require socialiteproviders/govbr
+```
+
+## Installation & Basic Usage
+
+Please see the [Base Installation Guide](https://socialiteproviders.com/usage/), then follow the provider specific instructions below.
+
+### Add configuration to `config/services.php`
+
+```php
+'govbr' => [
+    'client_id' => env('GOVBR_CLIENT_ID'),
+    'client_secret' => env('GOVBR_CLIENT_SECRET'),
+    'redirect' => env('GOVBR_REDIRECT_URI'),
+    'environment' => env('GOVBR_ENVIRONMENT', 'production'),
+],
+```
+
+### Add provider event listener
+
+Configure the package's listener to listen for `SocialiteWasCalled` events.
+
+Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. See the [Base Installation Guide](https://socialiteproviders.com/usage/) for detailed instructions.
+
+```php
+protected $listen = [
+    \SocialiteProviders\Manager\SocialiteWasCalled::class => [
+        // ... other providers
+        \SocialiteProviders\GovBR\GovBRExtendSocialite::class.'@handle',
+    ],
+];
+```
+
+### Usage
+
+You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
+
+```php
+return Socialite::driver('govbr')->redirect();
+```
+
+### Returned User fields
+
+-   `id`
+-   `cpf`
+-   `name`
+-   `email`
+-   `email_verified`
+-   `phone_number`
+-   `phone_number_verified`
+-   `avatar_url`
+-   `profile`

--- a/src/GovBR/composer.json
+++ b/src/GovBR/composer.json
@@ -1,0 +1,33 @@
+{
+    "name": "socialiteproviders/govbr",
+    "description": "GovBR OAuth2 Provider for Laravel Socialite",
+    "keywords": [
+        "laravel",
+        "govbr",
+        "oauth",
+        "provider",
+        "socialite"
+    ],
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Saade",
+            "email": "saade@outlook.com.br"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/socialiteproviders/providers/issues",
+        "source": "https://github.com/socialiteproviders/providers",
+        "docs": "https://socialiteproviders.com/govbr"
+    },
+    "require": {
+        "php": "^8.0",
+        "socialiteproviders/manager": "~4.0",
+        "ext-json": "*"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialiteProviders\\GovBR\\": ""
+        }
+    }
+}


### PR DESCRIPTION
Provider for [GovBR](https://www.gov.br). 

TLDR;
Gov.br is a project to unify the digital channels of  brazil's federal government. 

It all starts with the gov.br portal, which brings together, in one place, services for citizens and information on the activities of all areas of government. By December 2020, the Government websites will be integrated, making the gov.br portal the single entry point to the institutional pages of the federal administration, offering citizens a direct and quick channel for relationship with federal agencies.

Developer docs: http://manual-roteiro-integracao-login-unico.servicos.gov.br/