### PR TITLE
get Tiktok user from the official user details endpoint

### DIFF
--- a/src/TikTok/Provider.php
+++ b/src/TikTok/Provider.php
@@ -55,10 +55,7 @@ class Provider extends AbstractProvider
         $token = Arr::get($response, 'data.access_token');
 
         $this->user = $this->mapUserToObject(
-            $this->getUserByToken([
-                'access_token' => $token,
-                'open_id'      => Arr::get($response, 'data.open_id'),
-            ])
+            $this->getUserByToken($token)
         );
 
         return $this->user->setToken($token)
@@ -89,20 +86,17 @@ class Provider extends AbstractProvider
     }
 
     /**
-     * Get TikTok user by token.
-     *
-     * @param array $data
-     *
-     * @return mixed
+     * @inheritdoc
      */
-    protected function getUserByToken($data)
+    protected function getUserByToken($token)
     {
-        // Note: The TikTok api does not have an endpoint to get a user by the access
-        // token only. Open id is also required therefore:
-        // $data['access_token'] = $token, $data['open_id'] = $open_id
-
         $response = $this->getHttpClient()->get(
-            'https://open-api.tiktok.com/oauth/userinfo?'.http_build_query($data)
+            'https://open.tiktokapis.com/v2/user/info/?fields=open_id,union_id,display_name,avatar_large_url',
+            [
+                'headers' => [
+                    'Authorization' => 'Bearer ' . $token,
+                ]
+            ]
         );
 
         return json_decode((string) $response->getBody(), true);
@@ -119,7 +113,7 @@ class Provider extends AbstractProvider
             'id'       => $user['open_id'],
             'union_id' => $user['union_id'],
             'name'     => $user['display_name'],
-            'avatar'   => $user['avatar_larger'],
+            'avatar'   => $user['avatar_large_url'],
         ]);
     }
 }

--- a/src/TikTok/Provider.php
+++ b/src/TikTok/Provider.php
@@ -94,8 +94,8 @@ class Provider extends AbstractProvider
             'https://open.tiktokapis.com/v2/user/info/?fields=open_id,union_id,display_name,avatar_large_url',
             [
                 'headers' => [
-                    'Authorization' => 'Bearer ' . $token,
-                ]
+                    'Authorization' => 'Bearer '.$token,
+                ],
             ]
         );
 


### PR DESCRIPTION
The code in master branch gets user details through `open-api.tiktok.com/oauth/userinfo` endpoint which now seems outdated as it is not even mentioned in the current version of official Tiktok API [documentation](https://developers.tiktok.com/doc). Also with this endpoint I've faced issues like 'Undefined array key "avatar_larger"'. 
Furthermore using of this endpoint leads to code inconsistency because with the API access token it requires also to send `open_id` field in `getUserByToken` method.

At the same time there is an official [user details endpoint](https://developers.tiktok.com/doc/tiktok-api-v2-get-user-info) which requires only access token. 
The fix switches getUserByToken method to this endpoint.