### PR TITLE
fix: extracting Tiktok user from nested property

### DIFF
--- a/src/TikTok/Provider.php
+++ b/src/TikTok/Provider.php
@@ -107,7 +107,7 @@ class Provider extends AbstractProvider
      */
     protected function mapUserToObject($user)
     {
-        $user = $user['data'];
+        $user = $user['data']['user'];
 
         return (new User())->setRaw($user)->map([
             'id'       => $user['open_id'],


### PR DESCRIPTION
Seems like https://github.com/SocialiteProviders/Providers/pull/994 introduced a bug:

After updating I started getting this error:

```Undefined array key "open_id"```

Before using this new endpoint, the tiktok response was like:

```json
{
    "data": {
        "access_token": "act.c39724355c65afcd2d7026dcdbd76d40LJQ7fHsqvfUVmZl5nxWKEJ1FU1wc!6393",
        "captcha": "",
        "desc_url": "",
        "description": "",
        "error_code": 0,
        "expires_in": 86400,
        "log_id": "20220714041044010002007735002037040BAF34",
        "open_id": "cdbbfaea-34f6-4a45-ab45-b12f78b1813d",
        "refresh_expires_in": 31536000,
        "refresh_token": "rft.dc8946222f5c87a21f681dc7995e3hEuMiySL8qLspsKgovFb6D0NyMly!6418",
        "scope": "user.info.basic"
    },
    "message": "success"
}
```

But using the new endpoint, the user is nested under a `user` property:

```json
{
   "data":{
      "user":{
         "avatar_url":"https://p19-sign.tiktokcdn-us.com/tos-useast5-avt-0068-tx/b17f0e4b3a4f4a50993cf72cda8b88b8~c5_168x168.jpeg",
         "open_id":"723f24d7-e717-40f8-a2b6-cb8464cd23b4",
         "union_id":"c9c60f44-a68e-4f5d-84dd-ce22faeb0ba1",
         "display_name": "Tik Toker"
      }
   },
   "error":{
      "code":"ok",
      "message":"",
      "log_id":"20220829194722CBE87ED59D524E727021"
   }
}
```

Note that now the user is nested under `data.user` instead of `data`.

So when calling `mapUserToObject`, it's accessing `data` but not `data.user` and it fails while extracting any parameter: https://github.com/SocialiteProviders/Providers/blob/master/src/TikTok/Provider.php#L108-L118 

This PR fixes that by extracting the user information from the `user` property.