### PR TITLE
[KEYCLOAK] Added post logout redirect for Keycloak v18+

### DIFF
--- a/src/Keycloak/Provider.php
+++ b/src/Keycloak/Provider.php
@@ -89,9 +89,10 @@ class Provider extends AbstractProvider
      * @param string|null $redirectUri
      * @param string|null $clientId
      * @param string|null $idTokenHint
-     * @param array $additionalParameters
+     * @param array       $additionalParameters
      *
      * @throws InvalidArgumentException
+     *
      * @return string
      */
     public function getLogoutUrl(?string $redirectUri = null, ?string $clientId = null, ?string $idTokenHint = null, ...$additionalParameters): string

--- a/src/Keycloak/Provider.php
+++ b/src/Keycloak/Provider.php
@@ -4,6 +4,7 @@ namespace SocialiteProviders\Keycloak;
 
 use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
+use SocialiteProviders\Manager\Exception\InvalidArgumentException;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -82,20 +83,57 @@ class Provider extends AbstractProvider
     }
 
     /**
-     * Return logout endpoint with redirect_uri query parameter.
+     * Return logout endpoint with redirect_uri, clientId, idTokenHint
+     * and optional parameters by a key value array.
      *
      * @param string|null $redirectUri
+     * @param string|null $clientId
+     * @param string|null $idTokenHint
+     * @param array $additionalParameters
      *
+     * @throws InvalidArgumentException
      * @return string
      */
-    public function getLogoutUrl(?string $redirectUri = null): string
+    public function getLogoutUrl(?string $redirectUri = null, ?string $clientId = null, ?string $idTokenHint = null, ...$additionalParameters): string
     {
         $logoutUrl = $this->getBaseUrl().'/protocol/openid-connect/logout';
 
+        // Keycloak v18+ or before
         if ($redirectUri === null) {
             return $logoutUrl;
         }
 
-        return $logoutUrl.'?redirect_uri='.urlencode($redirectUri);
+        // Before Keycloak v18
+        if ($clientId === null && $idTokenHint === null) {
+            return $logoutUrl.'?redirect_uri='.urlencode($redirectUri);
+        }
+
+        // Keycloak v18+
+        // https://www.keycloak.org/docs/18.0/securing_apps/index.html#logout
+        // https://openid.net/specs/openid-connect-rpinitiated-1_0.html
+        $logoutUrl .= '?post_logout_redirect_uri='.urlencode($redirectUri);
+
+        // Either clientId or idTokenHint
+        // is required for the post redirect to work.
+        if ($clientId !== null) {
+            $logoutUrl .= '&client_id='.urlencode($clientId);
+        }
+
+        if ($idTokenHint !== null) {
+            $logoutUrl .= '&id_token_hint='.urlencode($idTokenHint);
+        }
+
+        foreach ($additionalParameters as $parameter) {
+            if (!is_array($parameter) || sizeof($parameter) > 1) {
+                throw new InvalidArgumentException('Invalid argument. Expected an array with a key and a value.');
+            }
+
+            $parameterKey = array_keys($parameter)[0];
+            $parameterValue = array_values($parameter)[0];
+
+            $logoutUrl .= "&{$parameterKey}=".urlencode($parameterValue);
+        }
+
+        return $logoutUrl;
     }
 }

--- a/src/Keycloak/README.md
+++ b/src/Keycloak/README.md
@@ -46,14 +46,29 @@ return Socialite::driver('keycloak')->redirect();
 To logout of your app and Keycloak:
 ```php
 public function logout() {
-    Auth::logout(); // Logout of your app
+    // Logout of your app.
+    Auth::logout();
     
-    // Keycloak v18+ does not support a redirect URL
+    // The user will not be redirected back.
     return redirect(Socialite::driver('keycloak')->getLogoutUrl());
     
+    // The URL the user is redirected to after logout.
+    $redirectUri = Config::get('app.url');
+    
+    // Keycloak v18+ does support a post_logout_redirect_uri in combination with a
+    // client_id or an id_token_hint parameter or both of them.
+    // NOTE: You will need to set valid post logout redirect URI in Keycloak.
+    return redirect(Socialite::driver('keycloak')->getLogoutUrl($redirectUri, env('KEYCLOAK_CLIENT_ID')));
+    return redirect(Socialite::driver('keycloak')->getLogoutUrl($redirectUri, null, 'YOUR_ID_TOKEN_HINT'));
+    return redirect(Socialite::driver('keycloak')->getLogoutUrl($redirectUri, env('KEYCLOAK_CLIENT_ID'), 'YOUR_ID_TOKEN_HINT'));
+    
+    // You may add additional allowed parameters as listed in
+    // https://openid.net/specs/openid-connect-rpinitiated-1_0.html
+    return redirect(Socialite::driver('keycloak')->getLogoutUrl($redirectUri, null, null, ['state' => '...'], ['ui_locales' => 'de-DE']));
+    
     // Keycloak before v18 does support a redirect URL
-    $redirectUri = Config::get('app.url'); // The URL the user is redirected to
-    return redirect(Socialite::driver('keycloak')->getLogoutUrl($redirectUri)); // Redirect to Keycloak
+    // to redirect back to Keycloak.
+    return redirect(Socialite::driver('keycloak')->getLogoutUrl($redirectUri));
 }
 ```
 

--- a/src/Keycloak/README.md
+++ b/src/Keycloak/README.md
@@ -64,7 +64,7 @@ public function logout() {
     
     // You may add additional allowed parameters as listed in
     // https://openid.net/specs/openid-connect-rpinitiated-1_0.html
-    return redirect(Socialite::driver('keycloak')->getLogoutUrl($redirectUri, null, null, ['state' => '...'], ['ui_locales' => 'de-DE']));
+    return redirect(Socialite::driver('keycloak')->getLogoutUrl($redirectUri, CLIENT_ID, null, ['state' => '...'], ['ui_locales' => 'de-DE']));
     
     // Keycloak before v18 does support a redirect URL
     // to redirect back to Keycloak.


### PR DESCRIPTION
Added post logout redirect for Keycloak v18+ using either clientId or idTokenHint or both of them as one of them is required for post logout redirect to work.

Added the possibility to add additional parameters using a key value array.

Updated README.

@atymic 

