### PR TITLE
fix: bump todoist api version

### DIFF
--- a/src/Todoist/Provider.php
+++ b/src/Todoist/Provider.php
@@ -12,7 +12,7 @@ class Provider extends AbstractProvider
 
     public const AUTH_URL = 'https://todoist.com/oauth/authorize';
     public const TOKEN_URL = 'https://todoist.com/oauth/access_token';
-    public const SYNC_URL = 'https://api.todoist.com/sync/v8/sync';
+    public const SYNC_URL = 'https://api.todoist.com/sync/v9/sync';
 
     /**
      * {@inheritdoc}
@@ -46,10 +46,12 @@ class Provider extends AbstractProvider
     protected function getUserByToken($token)
     {
         $response = $this->getHttpClient()->get(self::SYNC_URL, [
+            RequestOptions::HEADERS => [
+                'Authorization' => sprintf('Bearer %s', $token)
+            ],
             RequestOptions::QUERY => [
-                'token'          => $token,
                 'sync_token'     => '*',
-                'resource_types' => json_encode(['user']),
+                'resource_types' => json_encode(['user'], JSON_THROW_ON_ERROR),
             ],
         ]);
 


### PR DESCRIPTION
```
Client error: `GET https://api.todoist.com/sync/v8/sync?token=?&sync_token=%2A&resource_types=%5B%22user%22%5D` resulted in a `410 Gone` response:
This endpoint is deprecated.
```

