### PR TITLE
Updated SuperOffice provider

### DIFF
--- a/src/SuperOffice/Provider.php
+++ b/src/SuperOffice/Provider.php
@@ -119,7 +119,7 @@ class Provider extends AbstractProvider
             $api_url = json_decode((string) $response->getBody(), true)['Api'];
 
             if (!$api_url) {
-                throw new \Exception('No API URL received from '. $url);
+                throw new \Exception('No API URL received from '.$url);
             }
 
             return $api_url.'/v1/';

--- a/src/SuperOffice/Provider.php
+++ b/src/SuperOffice/Provider.php
@@ -104,11 +104,10 @@ class Provider extends AbstractProvider
 
     private function getBaseApiUrl(): string
     {
-        $cache_time = 60 * 60 * 8; // 8 hours
         $environment = $this->getConfig('environment', 'sod');
         $customer_id = $this->getConfig('customer_id');
 
-        return cache()->remember('superoffice-base-url', $cache_time, function () use ($environment, $customer_id) {
+        return cache()->remember('superoffice-base-url', now()->addHours(8), function () use ($environment, $customer_id) {
             $url = sprintf(
                 'https://%s.superoffice.com/api/state/%s',
                 $environment,

--- a/src/SuperOffice/Provider.php
+++ b/src/SuperOffice/Provider.php
@@ -108,7 +108,7 @@ class Provider extends AbstractProvider
         $environment = $this->getConfig('environment', 'sod');
         $customer_id = $this->getConfig('customer_id');
 
-        return cache()->remember('superoffice-base-url', $cache_time, function () use($environment, $customer_id) {
+        return cache()->remember('superoffice-base-url', $cache_time, function () use ($environment, $customer_id) {
             $url = sprintf(
                 'https://%s.superoffice.com/api/state/%s',
                 $environment,
@@ -118,8 +118,7 @@ class Provider extends AbstractProvider
             $response = $this->getHttpClient()->get($url);
             $api_url = json_decode((string) $response->getBody(), true)['Api'];
 
-            if(!$api_url)
-            {
+            if (!$api_url) {
                 throw new \Exception('No API URL received from '. $url);
             }
 

--- a/src/SuperOffice/Provider.php
+++ b/src/SuperOffice/Provider.php
@@ -105,23 +105,23 @@ class Provider extends AbstractProvider
     private function getBaseApiUrl(): string
     {
         $environment = $this->getConfig('environment', 'sod');
-        $customer_id = $this->getConfig('customer_id');
+        $customerId = $this->getConfig('customer_id');
 
-        return cache()->remember('superoffice-base-url', now()->addHours(8), function () use ($environment, $customer_id) {
+        return cache()->remember('superoffice-base-url', now()->addHours(8), function () use ($environment, $customerId) {
             $url = sprintf(
                 'https://%s.superoffice.com/api/state/%s',
                 $environment,
-                $customer_id
+                $customerId
             );
 
             $response = $this->getHttpClient()->get($url);
-            $api_url = json_decode((string) $response->getBody(), true)['Api'];
+            $apiUrl = json_decode((string) $response->getBody(), true)['Api'];
 
-            if (!$api_url) {
+            if (!$apiUrl) {
                 throw new \Exception('No API URL received from '.$url);
             }
 
-            return $api_url.'/v1/';
+            return $apiUrl.'/v1/';
         });
     }
 }


### PR DESCRIPTION
Due to some upcoming updates in SuperOffice they require that the API endpoint URL is dynamic.
- https://community.superoffice.com/no/technical/forums/general-forums/announcements/currently-testing-in-sod-api-calls-must-now-use-the-tenants-correct-public-endpoint/
- https://community.superoffice.com/no/technical/forums/general-forums/announcements/breaking-changes-api-urls-for-online-tenants/

This will give some idea of what this additional request returns https://sod.superoffice.com/api/state/Cust12345.

Since this requires additional requests, cache has been added on an 8 hour interval. The cache name chosen matches that of another package I use https://gitlab.com/cadix/web/superoffice-api/-/blob/dev/src/Model.php#L329.