### PR TITLE
Fix: set access token properly when fetching user with apple

### DIFF
--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -97,7 +97,11 @@ class Provider extends AbstractProvider
     }
 
     /**
-     * {@inheritdoc}
+     * Get the raw user for the given identity token.
+     *
+     * @param string $token
+     *
+     * @return array
      */
     protected function getUserByToken($token)
     {

--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -182,12 +182,12 @@ class Provider extends AbstractProvider
         //Temporary fix to enable stateless
         $response = $this->getAccessTokenResponse($this->getCode());
 
-        $appleUserToken = $this->getUserByToken(
-            $token = Arr::get($response, 'id_token')
+        $userFromIdToken = $this->getUserByToken(
+            Arr::get($response, 'id_token')
         );
 
         if ($this->usesState()) {
-            $state = explode('.', $appleUserToken['nonce'])[1];
+            $state = explode('.', $userFromIdToken['nonce'])[1];
             if ($state === $this->request->input('state')) {
                 $this->request->session()->put([
                     'state'        => $state,
@@ -200,15 +200,15 @@ class Provider extends AbstractProvider
             }
         }
 
-        $user = $this->mapUserToObject($appleUserToken);
+        $user = $this->mapUserToObject($userFromIdToken);
 
         if ($user instanceof User) {
             $user->setAccessTokenResponseBody($response);
         }
 
-        return $user->setToken($token)
-            ->setRefreshToken(Arr::get($response, 'refresh_token'))
-            ->setExpiresIn(Arr::get($response, 'expires_in'));
+        return $user->setToken($this->parseAccessToken($response))
+            ->setRefreshToken($this->parseRefreshToken($response))
+            ->setExpiresIn($this->parseExpiresIn($response));
     }
 
     /**


### PR DESCRIPTION
The `token` of the `\Laravel\Socialite\Two\User` class is meant to hold the access token.

The `id_token` acquired from Apple authorization requests is not a valid access token.

Also, I've clarified the intent of `getUserByToken` which unlike its parent it expects an identity token instead of an access token.

---

I would go and deprecate `userByIdentityToken` in favor of `getUserByToken`, but unsure what are the other opinions about this.