### PR TITLE
Tiktok – Upgrade tiktok API URLs to use v2 (v1 deprecating in Sep 2023)

### DIFF
--- a/src/TikTok/Provider.php
+++ b/src/TikTok/Provider.php
@@ -86,7 +86,7 @@ class Provider extends AbstractProvider
             'client_secret' => $this->clientSecret,
             'code'          => $code,
             'grant_type'    => 'authorization_code',
-            'redirect_uri'  => $this->redirectUrl
+            'redirect_uri'  => $this->redirectUrl,
         ];
     }
 
@@ -129,7 +129,7 @@ class Provider extends AbstractProvider
     {
         return [
             'Accept' => 'application/json',
-            'Content-Type' => 'application/x-www-form-urlencoded'
+            'Content-Type' => 'application/x-www-form-urlencoded',
         ];
     }
 

--- a/src/TikTok/Provider.php
+++ b/src/TikTok/Provider.php
@@ -132,7 +132,7 @@ class Provider extends AbstractProvider
     protected function getTokenHeaders($code)
     {
         return [
-            'Accept' => 'application/json',
+            'Accept'       => 'application/json',
             'Content-Type' => 'application/x-www-form-urlencoded',
         ];
     }

--- a/src/TikTok/Provider.php
+++ b/src/TikTok/Provider.php
@@ -7,6 +7,10 @@ use Laravel\Socialite\Two\InvalidStateException;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
+/**
+ * @see https://developers.tiktok.com/bulletin/migration-guidance-oauth-v1/
+ * @see https://developers.tiktok.com/doc/oauth-user-access-token-management
+ */
 class Provider extends AbstractProvider
 {
     public const IDENTIFIER = 'TIKTOK';

--- a/src/TikTok/Provider.php
+++ b/src/TikTok/Provider.php
@@ -136,5 +136,4 @@ class Provider extends AbstractProvider
             'Content-Type' => 'application/x-www-form-urlencoded',
         ];
     }
-
 }


### PR DESCRIPTION
Tiktok has deprecated their v1 API endpoints and will not longer work after September 2023. This PR updates the TikTok provider accordingly to work with the v2.

Changes: 
- Added `Content-Type` to `application/x-www-form-urlencoded` to the token headers.
- Removed nested `data` property from user response.
- Replaced URLS to the new v2 endpoints.
- Add `redirect_uri` field to the token fields list as it's now required.

### Actions required in the TikTok developer console

As of now, you only had to register "authorised" domains in the TikTok developer console to be able to redirect the user back to your app. In order to use the new endpoints you have to register the full redirect URL in your app settings just like in other providers.

### ⚠️ Major version release

This would require a new major release (V5) as developers have to make some changes in their TikTok app dashboard before upgrading this package.

There are not other breaking changes in this PR apart from that.

### Official Tiktok announcement:

> v1 OAuth will stop working on September 12, 2023 for web apps! We recommend you migrate to v2 OAuth APIs as soon as possible using the instructions below.

Read this blog post for more information about why and what is changing 👇

https://developers.tiktok.com/bulletin/migration-guidance-oauth-v1/