### PR TITLE
Update README.md and Provider.php with simplified configuration

### DIFF
--- a/src/GovBR/Provider.php
+++ b/src/GovBR/Provider.php
@@ -131,12 +131,6 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     protected function getBaseUrlForEnvironment(): string
     {
-        $environment = $this->getConfig('environment', 'production');
-
-        return match ($environment) {
-            'staging'    => $this->stagingUrl,
-            'production' => $this->productionUrl,
-            default      => throw new RuntimeException("Invalid environment '{$environment}' selected for GovBR provider."),
-        };
+        return config('app.env') === 'production' ? $this->productionUrl : $this->stagingUrl;
     }
 }

--- a/src/GovBR/README.md
+++ b/src/GovBR/README.md
@@ -15,7 +15,6 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
     'client_id' => env('GOVBR_CLIENT_ID'),
     'client_secret' => env('GOVBR_CLIENT_SECRET'),
     'redirect' => env('GOVBR_REDIRECT_URI'),
-    'environment' => env('GOVBR_ENVIRONMENT', 'production'),
 ],
 ```
 


### PR DESCRIPTION
The following changes have been made to simplified the configuration in the Provider.php file:

README.md:

    Removed the 'environment' key from the 'govbr' configuration array.

Provider.php:

    Simplified the getBaseUrlForEnvironment() method to use the 'app.env' configuration value instead of the 'environment' key.
    Replaced the match statement with a conditional expression to determine the base URL based on the 'app.env' value.