### PR TITLE
Fix for bug when user is not in organization 

### DIFF
--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -101,21 +101,24 @@ class Provider extends AbstractProvider
         }
 
         if ($this->getConfig('tenant', 'common') === 'common' && $this->getConfig('include_tenant_info', false)) {
-            $responseTenant = $this->getHttpClient()->get(
-                'https://graph.microsoft.com/v1.0/organization',
-                [
-                    RequestOptions::HEADERS => [
-                        'Accept'        => 'application/json',
-                        'Authorization' => 'Bearer '.$token,
-                    ],
-                    RequestOptions::QUERY => [
-                        '$select' => implode(',', array_merge(self::DEFAULT_FIELDS_TENANT, $this->getConfig('tenant_fields', []))),
-                    ],
-                ]
-            );
-
-            $formattedResponse['tenant'] = json_decode((string) $responseTenant->getBody(), true)['value'][0] ?? null;
-        }
+            try {
+                $responseTenant = $this->getHttpClient()->get(
+                    'https://graph.microsoft.com/v1.0/organization',
+                    [
+                        RequestOptions::HEADERS => [
+                            'Accept' => 'application/json',
+                            'Authorization' => 'Bearer ' . $token,
+                        ],
+                        RequestOptions::QUERY => [
+                            '$select' => implode(',', array_merge(self::DEFAULT_FIELDS_TENANT, $this->getConfig('tenant_fields', []))),
+                        ],
+                    ]
+                );
+                $formattedResponse['tenant'] = json_decode((string) $responseTenant->getBody(), true)['value'][0] ?? null;
+            } catch (ClientException $e) {
+                //if exception then tenant does not exist.
+                $formattedResponse['tenant'] = null;
+            }
 
         return $formattedResponse;
     }


### PR DESCRIPTION
I've encountered an issue when you put in config` 'include_tenant_info' => true` If the user is not part of an organisation and you try to retrieve it's tenant, then Microsoft API returns a 500 status code error (for some reason), and this breaks execution.

My fix wraps the API call in a try/catch block and if a Client exception occurs, it sets the tenant to null.

