### PR TITLE
On nickname discriminator is now displayed only if the user has assigned one

### DIFF
--- a/src/Discord/Provider.php
+++ b/src/Discord/Provider.php
@@ -117,7 +117,7 @@ class Provider extends AbstractProvider
     {
         return (new User())->setRaw($user)->map([
             'id'       => $user['id'],
-            'nickname' => sprintf('%s#%s', $user['username'], $user['discriminator']),
+            'nickname' => $user['username'] . ($user['discriminator'] !== '0' ? '#' . $user['discriminator'] : ''),
             'name'     => $user['username'],
             'email'    => $user['email'] ?? null,
             'avatar'   => $this->formatAvatar($user),

--- a/src/Discord/Provider.php
+++ b/src/Discord/Provider.php
@@ -117,7 +117,7 @@ class Provider extends AbstractProvider
     {
         return (new User())->setRaw($user)->map([
             'id'       => $user['id'],
-            'nickname' => $user['username'] . ($user['discriminator'] !== '0' ? '#' . $user['discriminator'] : ''),
+            'nickname' => $user['username'].($user['discriminator'] !== '0' ? '#'.$user['discriminator'] : ''),
             'name'     => $user['username'],
             'email'    => $user['email'] ?? null,
             'avatar'   => $this->formatAvatar($user),


### PR DESCRIPTION
With discord's new naming system, only displays the discriminator if the user has one.

