### PR TITLE
Update firebase/php-jwt to latest version (6.8) 

### DIFF
--- a/src/AzureADB2C/Provider.php
+++ b/src/AzureADB2C/Provider.php
@@ -186,7 +186,7 @@ class Provider extends AbstractProvider
             }
 
             // signature validation and return claims
-            return (array) JWT::decode($idToken, JWK::parseKeySet($this->getJWTKeys(), $this->getConfig('default_algorithm')), $this->getOpenIdConfiguration()->id_token_signing_alg_values_supported);
+            return (array) JWT::decode($idToken, JWK::parseKeySet($this->getJWTKeys(), $this->getConfig('default_algorithm')));
         } catch (Exception $ex) {
             throw new InvalidStateException("Error on validationg id_token. {$ex}");
         }

--- a/src/AzureADB2C/composer.json
+++ b/src/AzureADB2C/composer.json
@@ -24,7 +24,7 @@
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "ext-openssl": "*",
-        "firebase/php-jwt": "^5.2",
+        "firebase/php-jwt": "^6.8",
         "socialiteproviders/manager": "~4.0"
     },
     "autoload": {


### PR DESCRIPTION
The current version set in the composer file for AzureADB2C is incompatible with the current version of Laravel passport (requires 6.4 or higher).