### PR TITLE
Bump to PHP 8.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,14 +11,14 @@ jobs:
       matrix:
         validate: [ false ]
         fail-fast: [ false ]
-        php-versions: ['8.0', '8.1' ]
+        php-versions: [ 8.1, 8.2 ]
         exclude:
-          - php-versions: '8.0'
-          - php-versions: '8.1'
+          - php-versions: 8.1
+          - php-versions: 8.2
         include:
-          - php-versions: '8.0'
+          - php-versions: 8.1
             validate: true
-          - php-versions: '8.1'
+          - php-versions: 8.2
             fail-fast: true
 
     name: PHP ${{ matrix.php-versions }}

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "docs": "https://socialiteproviders.com"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "league/oauth1-client": "^1.9",
         "socialiteproviders/manager": "~4.0"

--- a/src/Acclaim/composer.json
+++ b/src/Acclaim/composer.json
@@ -25,7 +25,7 @@
         "docs": "https://socialiteproviders.com/acclaim"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Admitad/composer.json
+++ b/src/Admitad/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/admitad"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Adobe/composer.json
+++ b/src/Adobe/composer.json
@@ -23,7 +23,7 @@
         "docs": "https://socialiteproviders.com/adobe"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Amazon/composer.json
+++ b/src/Amazon/composer.json
@@ -22,7 +22,7 @@
         "docs": "https://socialiteproviders.com/amazon"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/AmoCRM/composer.json
+++ b/src/AmoCRM/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/amocrm"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/AngelList/composer.json
+++ b/src/AngelList/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/angellist"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/AppNet/composer.json
+++ b/src/AppNet/composer.json
@@ -25,7 +25,7 @@
         "docs": "https://socialiteproviders.com/appnet"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Apple/composer.json
+++ b/src/Apple/composer.json
@@ -36,7 +36,7 @@
         "docs": "https://socialiteproviders.com/apple"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "ext-openssl": "*",
         "firebase/php-jwt": "^6.2",

--- a/src/ArcGIS/composer.json
+++ b/src/ArcGIS/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/arcgis"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Asana/composer.json
+++ b/src/Asana/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/asana"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Atlassian/composer.json
+++ b/src/Atlassian/composer.json
@@ -22,7 +22,7 @@
         "docs": "https://socialiteproviders.com/atlassian"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.0"
     },

--- a/src/Auth0/composer.json
+++ b/src/Auth0/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/auth0"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Authentik/composer.json
+++ b/src/Authentik/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/authentik"
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.0"
     },

--- a/src/AutodeskAPS/composer.json
+++ b/src/AutodeskAPS/composer.json
@@ -24,7 +24,7 @@
     "docs": "https://socialiteproviders.com/aps"
   },
   "require": {
-    "php": "^8.0",
+    "php": "^8.1",
     "ext-json": "*",
     "socialiteproviders/manager": "^4.0"
   },

--- a/src/Aweber/composer.json
+++ b/src/Aweber/composer.json
@@ -25,7 +25,7 @@
         "docs": "https://socialiteproviders.com/aweber"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Azure/composer.json
+++ b/src/Azure/composer.json
@@ -22,7 +22,7 @@
         "docs": "https://socialiteproviders.com/microsoft-azure"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/AzureADB2C/composer.json
+++ b/src/AzureADB2C/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "ext-openssl": "*",
         "firebase/php-jwt": "^6.8",

--- a/src/Battlenet/composer.json
+++ b/src/Battlenet/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/battlenet"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Bexio/composer.json
+++ b/src/Bexio/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.0"
     },

--- a/src/Binance/composer.json
+++ b/src/Binance/composer.json
@@ -15,7 +15,7 @@
         "docs": "https://socialiteproviders.com/binance"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Bitbucket/composer.json
+++ b/src/Bitbucket/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/bitbucket"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Bitly/composer.json
+++ b/src/Bitly/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/bitly"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Bitrix24/composer.json
+++ b/src/Bitrix24/composer.json
@@ -22,7 +22,7 @@
         "docs": "https://socialiteproviders.com/bitrix24"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.0"
     },

--- a/src/Blackboard/composer.json
+++ b/src/Blackboard/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/blackboard"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.0"
     },

--- a/src/Box/composer.json
+++ b/src/Box/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/box"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Buffer/composer.json
+++ b/src/Buffer/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/buffer"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/CampaignMonitor/composer.json
+++ b/src/CampaignMonitor/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/campaignmonitor"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Cheddar/composer.json
+++ b/src/Cheddar/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/cheddar"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/ClaveUnica/composer.json
+++ b/src/ClaveUnica/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/claveunica"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Cognito/composer.json
+++ b/src/Cognito/composer.json
@@ -22,7 +22,7 @@
         "docs": "https://socialiteproviders.com/cognito"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Coinbase/composer.json
+++ b/src/Coinbase/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/coinbase"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/ConstantContact/composer.json
+++ b/src/ConstantContact/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/constantcontact"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Coursera/composer.json
+++ b/src/Coursera/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/coursera"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Dailymotion/composer.json
+++ b/src/Dailymotion/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/dailymotion"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Dataporten/composer.json
+++ b/src/Dataporten/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/dataporten"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Deezer/composer.json
+++ b/src/Deezer/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/deezer"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Deviantart/composer.json
+++ b/src/Deviantart/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/deviantart"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/DigitalOcean/composer.json
+++ b/src/DigitalOcean/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/digitalocean"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Discogs/composer.json
+++ b/src/Discogs/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/discogs"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Discord/composer.json
+++ b/src/Discord/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/discord"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Disqus/composer.json
+++ b/src/Disqus/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/disqus"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Douban/composer.json
+++ b/src/Douban/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/douban"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Dribbble/composer.json
+++ b/src/Dribbble/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/dribbble"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Dropbox/composer.json
+++ b/src/Dropbox/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/dropbox"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Envato/composer.json
+++ b/src/Envato/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/envato"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Etsy/composer.json
+++ b/src/Etsy/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/etsy"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.2"
     },

--- a/src/Eventbrite/composer.json
+++ b/src/Eventbrite/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/eventbrite"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Eveonline/composer.json
+++ b/src/Eveonline/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/eveonline"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "firebase/php-jwt": "^6.0",
         "socialiteproviders/manager": "^4.0"

--- a/src/Exment/composer.json
+++ b/src/Exment/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/exment"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/EyeEm/composer.json
+++ b/src/EyeEm/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/eyeem"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Fablabs/composer.json
+++ b/src/Fablabs/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/fablabs"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Facebook/composer.json
+++ b/src/Facebook/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/facebook"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Faceit/composer.json
+++ b/src/Faceit/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/faceit"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Figma/composer.json
+++ b/src/Figma/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/figma"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Fitbit/composer.json
+++ b/src/Fitbit/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/fitbit"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/FiveHundredPixel/composer.json
+++ b/src/FiveHundredPixel/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/500px"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Flattr/composer.json
+++ b/src/Flattr/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/flattr"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Flexkids/composer.json
+++ b/src/Flexkids/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/flexkids"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Flexmls/composer.json
+++ b/src/Flexmls/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/flexmls"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.0"
     },

--- a/src/Flickr/composer.json
+++ b/src/Flickr/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/flickr"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Foursquare/composer.json
+++ b/src/Foursquare/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/foursquare"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/FranceConnect/composer.json
+++ b/src/FranceConnect/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/franceconnect"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/FusionAuth/composer.json
+++ b/src/FusionAuth/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/fusionauth"
     },
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.0"
     },

--- a/src/GarminConnect/composer.json
+++ b/src/GarminConnect/composer.json
@@ -22,7 +22,7 @@
         "docs": "https://socialiteproviders.com/garmin-connect"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/GettyImages/composer.json
+++ b/src/GettyImages/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/gettyimages"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/GitHub/composer.json
+++ b/src/GitHub/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/github"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/GitLab/composer.json
+++ b/src/GitLab/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/gitlab"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Gitea/composer.json
+++ b/src/Gitea/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/gitea"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Gitee/composer.json
+++ b/src/Gitee/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/gitee"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Goodreads/composer.json
+++ b/src/Goodreads/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/goodreads"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Google/composer.json
+++ b/src/Google/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/google"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/GovBR/composer.json
+++ b/src/GovBR/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/govbr"
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "socialiteproviders/manager": "~4.0",
         "ext-json": "*"
     },

--- a/src/Graph/composer.json
+++ b/src/Graph/composer.json
@@ -22,7 +22,7 @@
         "docs": "https://socialiteproviders.com/microsoft-graph"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Gumroad/composer.json
+++ b/src/Gumroad/composer.json
@@ -23,7 +23,7 @@
         "docs": "https://socialiteproviders.com/gumroad"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.0"
     },

--- a/src/HabrCareer/composer.json
+++ b/src/HabrCareer/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/habrcareer"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/HarID/composer.json
+++ b/src/HarID/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/harid"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Harvest/composer.json
+++ b/src/Harvest/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/harvest"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/HeadHunter/composer.json
+++ b/src/HeadHunter/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/headhunter"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Heroku/composer.json
+++ b/src/Heroku/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/heroku"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/HubSpot/composer.json
+++ b/src/HubSpot/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/hubspot"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/HumanApi/composer.json
+++ b/src/HumanApi/composer.json
@@ -22,7 +22,7 @@
         "docs": "https://socialiteproviders.com/human-api"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/IFSP/composer.json
+++ b/src/IFSP/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/ifsp"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Imgur/composer.json
+++ b/src/Imgur/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/imgur"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Imis/composer.json
+++ b/src/Imis/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/imis"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Instagram/composer.json
+++ b/src/Instagram/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/instagram"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/InstagramBasic/composer.json
+++ b/src/InstagramBasic/composer.json
@@ -22,7 +22,7 @@
         "docs": "https://socialiteproviders.com/instagram-basic"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Instructure/composer.json
+++ b/src/Instructure/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/instructure"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Intercom/composer.json
+++ b/src/Intercom/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/intercom"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Jira/composer.json
+++ b/src/Jira/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/jira"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "ext-openssl": "*",
         "socialiteproviders/manager": "~4.0"

--- a/src/Kakao/composer.json
+++ b/src/Kakao/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/kakao"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Keycloak/composer.json
+++ b/src/Keycloak/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/keycloak"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/LaravelPassport/composer.json
+++ b/src/LaravelPassport/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/laravelpassport"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Lichess/composer.json
+++ b/src/Lichess/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/lichess"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/LifeScienceLogin/composer.json
+++ b/src/LifeScienceLogin/composer.json
@@ -22,7 +22,7 @@
         "docs": "https://socialiteproviders.com/lifesciencelogin"
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Line/composer.json
+++ b/src/Line/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/line"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/LinkedIn/composer.json
+++ b/src/LinkedIn/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/linkedin"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Linode/composer.json
+++ b/src/Linode/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/linode"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Live/composer.json
+++ b/src/Live/composer.json
@@ -22,7 +22,7 @@
         "docs": "https://socialiteproviders.com/microsoft-live"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/MailChimp/composer.json
+++ b/src/MailChimp/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/mailchimp"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Mailru/composer.json
+++ b/src/Mailru/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/mailru"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/MakerLog/composer.json
+++ b/src/MakerLog/composer.json
@@ -25,7 +25,7 @@
         "docs": "https://socialiteproviders.com/makerlog"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Mattermost/composer.json
+++ b/src/Mattermost/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/mattermost"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/MediaCube/composer.json
+++ b/src/MediaCube/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/mediacube"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Mediawiki/composer.json
+++ b/src/Mediawiki/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/mediawiki"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Medium/composer.json
+++ b/src/Medium/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/medium"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Meetup/composer.json
+++ b/src/Meetup/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/meetup"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/MercadoLibre/composer.json
+++ b/src/MercadoLibre/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/mercadolibre"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Microsoft/composer.json
+++ b/src/Microsoft/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/microsoft"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Minecraft/composer.json
+++ b/src/Minecraft/composer.json
@@ -22,7 +22,7 @@
         "source": "https://github.com/socialiteproviders/providers"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Mixcloud/composer.json
+++ b/src/Mixcloud/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/mixcloud"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Mollie/composer.json
+++ b/src/Mollie/composer.json
@@ -15,7 +15,7 @@
         "docs": "https://socialiteproviders.com/mollie"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Monday/composer.json
+++ b/src/Monday/composer.json
@@ -30,7 +30,7 @@
         "docs": "https://socialiteproviders.com/monday"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Monzo/composer.json
+++ b/src/Monzo/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/monzo"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.0"
     },

--- a/src/MusicBrainz/composer.json
+++ b/src/MusicBrainz/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/musicbrainz"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.0"
     },

--- a/src/Naver/composer.json
+++ b/src/Naver/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/naver"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "ext-libxml": "*",
         "ext-simplexml": "*",

--- a/src/Netlify/composer.json
+++ b/src/Netlify/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/netlify"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Neto/composer.json
+++ b/src/Neto/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/neto"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.0"
     },

--- a/src/Nextcloud/composer.json
+++ b/src/Nextcloud/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/nextcloud"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Nocks/composer.json
+++ b/src/Nocks/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/nocks"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Notion/composer.json
+++ b/src/Notion/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/notion"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/OAuthgen/composer.json
+++ b/src/OAuthgen/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/oauthgen"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/OSChina/composer.json
+++ b/src/OSChina/composer.json
@@ -25,7 +25,7 @@
         "docs": "https://socialiteproviders.com/oschina"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Odnoklassniki/composer.json
+++ b/src/Odnoklassniki/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/odnoklassniki"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Okta/composer.json
+++ b/src/Okta/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/okta"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Onelogin/composer.json
+++ b/src/Onelogin/composer.json
@@ -7,7 +7,7 @@
         "email": "ch.amnuay@gmail.com"
     }],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/OpenStreetMap/composer.json
+++ b/src/OpenStreetMap/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/openstreetmap"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Orcid/composer.json
+++ b/src/Orcid/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/orcid"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Ovh/composer.json
+++ b/src/Ovh/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/ovh"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "ovh/ovh": "^2.0",
         "socialiteproviders/manager": "~4.0"

--- a/src/Patreon/composer.json
+++ b/src/Patreon/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/patreon"
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.2"
     },

--- a/src/PayPal/composer.json
+++ b/src/PayPal/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/paypal"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/PayPalSandbox/composer.json
+++ b/src/PayPalSandbox/composer.json
@@ -22,7 +22,7 @@
         "docs": "https://socialiteproviders.com/paypal-sandbox"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Paymill/composer.json
+++ b/src/Paymill/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/paymill"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/PeeringDB/composer.json
+++ b/src/PeeringDB/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/peeringdb"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Pinterest/composer.json
+++ b/src/Pinterest/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/pinterest"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Pipedrive/composer.json
+++ b/src/Pipedrive/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/pipedrive"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Pixnet/composer.json
+++ b/src/Pixnet/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/pixnet"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/PlanningCenter/composer.json
+++ b/src/PlanningCenter/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/planningcenter"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.0"
     },

--- a/src/Podio/composer.json
+++ b/src/Podio/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/podio"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Pr0gramm/composer.json
+++ b/src/Pr0gramm/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/pr0gramm"
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.2"
     },

--- a/src/Procore/composer.json
+++ b/src/Procore/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/procore"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/ProductHunt/composer.json
+++ b/src/ProductHunt/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/producthunt"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/ProjectV/composer.json
+++ b/src/ProjectV/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/projectv"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Pushbullet/composer.json
+++ b/src/Pushbullet/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/pushbullet"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/QQ/composer.json
+++ b/src/QQ/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/qq"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/QuickBooks/composer.json
+++ b/src/QuickBooks/composer.json
@@ -29,7 +29,7 @@
         "docs": "https://socialiteproviders.com/quickbooks"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Readability/composer.json
+++ b/src/Readability/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/readability"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Redbooth/composer.json
+++ b/src/Redbooth/composer.json
@@ -25,7 +25,7 @@
         "docs": "https://socialiteproviders.com/redbooth"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Reddit/composer.json
+++ b/src/Reddit/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/reddit"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Rekono/composer.json
+++ b/src/Rekono/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/rekono"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/RunKeeper/composer.json
+++ b/src/RunKeeper/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/runkeeper"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/SURFconext/composer.json
+++ b/src/SURFconext/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/surfconext"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Sage/composer.json
+++ b/src/Sage/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/sage"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/SalesForce/composer.json
+++ b/src/SalesForce/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/salesforce"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Salesloft/composer.json
+++ b/src/Salesloft/composer.json
@@ -22,7 +22,7 @@
     "docs": "https://socialiteproviders.com/salesloft"
   },
   "require": {
-    "php": "^8.0",
+    "php": "^8.1",
     "ext-json": "*",
     "socialiteproviders/manager": "~4.0"
   },

--- a/src/Saml2/composer.json
+++ b/src/Saml2/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/saml2"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "litesaml/lightsaml": "^4.0",
         "socialiteproviders/manager": "~4.0"

--- a/src/SciStarter/composer.json
+++ b/src/SciStarter/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/scistarter"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/SharePoint/composer.json
+++ b/src/SharePoint/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/sharepoint"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Shopify/composer.json
+++ b/src/Shopify/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/shopify"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Slack/composer.json
+++ b/src/Slack/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/slack"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Smashcast/composer.json
+++ b/src/Smashcast/composer.json
@@ -25,7 +25,7 @@
         "docs": "https://socialiteproviders.com/smashcast"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Snapchat/composer.json
+++ b/src/Snapchat/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/snapchat"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/SoundCloud/composer.json
+++ b/src/SoundCloud/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/soundcloud"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Spotify/composer.json
+++ b/src/Spotify/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/spotify"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/StackExchange/composer.json
+++ b/src/StackExchange/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/stackexchange"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Starling/composer.json
+++ b/src/Starling/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/starling"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Steam/composer.json
+++ b/src/Steam/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/steam"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Steem/composer.json
+++ b/src/Steem/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/steem"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/StockTwits/composer.json
+++ b/src/StockTwits/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/stocktwits"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Strava/composer.json
+++ b/src/Strava/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/strava"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/StreamElements/composer.json
+++ b/src/StreamElements/composer.json
@@ -15,7 +15,7 @@
         "docs": "https://socialiteproviders.com/streamelements"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Streamlabs/composer.json
+++ b/src/Streamlabs/composer.json
@@ -15,7 +15,7 @@
         "docs": "https://socialiteproviders.com/streamlabs"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Stripe/composer.json
+++ b/src/Stripe/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/stripe"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Subscribestar/composer.json
+++ b/src/Subscribestar/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/subscribestar"
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.2"
     },

--- a/src/SuperOffice/composer.json
+++ b/src/SuperOffice/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/superoffice"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "^3.6 || ^4.0"
     },

--- a/src/TVShowTime/composer.json
+++ b/src/TVShowTime/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/tvshowtime"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/TeamService/composer.json
+++ b/src/TeamService/composer.json
@@ -26,7 +26,7 @@
         "docs": "https://socialiteproviders.com/microsoft-teamservice"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Teamleader/composer.json
+++ b/src/Teamleader/composer.json
@@ -25,7 +25,7 @@
         "docs": "https://socialiteproviders.com/teamleader"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Teamweek/composer.json
+++ b/src/Teamweek/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/teamweek"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Telegram/composer.json
+++ b/src/Telegram/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/telegram"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "socialiteproviders/manager": "~4.0"
     },
     "autoload": {

--- a/src/ThirtySevenSignals/composer.json
+++ b/src/ThirtySevenSignals/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/37signals"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/TikTok/composer.json
+++ b/src/TikTok/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/tiktok"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "socialiteproviders/manager": "~4.0"
     },
     "autoload": {

--- a/src/Todoist/composer.json
+++ b/src/Todoist/composer.json
@@ -22,7 +22,7 @@
         "docs": "https://socialiteproviders.com/todoist"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Toyhouse/composer.json
+++ b/src/Toyhouse/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/toyhouse"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Trakt/composer.json
+++ b/src/Trakt/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/trakt"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Trello/composer.json
+++ b/src/Trello/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/trello"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Tumblr/composer.json
+++ b/src/Tumblr/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/tumblr"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/TwentyThreeAndMe/composer.json
+++ b/src/TwentyThreeAndMe/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/23andme"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/TwitCasting/composer.json
+++ b/src/TwitCasting/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/TwitCasting"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Twitch/composer.json
+++ b/src/Twitch/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/twitch"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Twitter/composer.json
+++ b/src/Twitter/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/twitter"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/UCL/composer.json
+++ b/src/UCL/composer.json
@@ -24,7 +24,7 @@
         "docs": "https://socialiteproviders.com/ucl"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/UFS/composer.json
+++ b/src/UFS/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/ufs"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Uber/composer.json
+++ b/src/Uber/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/uber"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Ufutx/composer.json
+++ b/src/Ufutx/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/ufutx-socialite"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Unsplash/composer.json
+++ b/src/Unsplash/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/unsplash"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Untappd/composer.json
+++ b/src/Untappd/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/untappd"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Usos/composer.json
+++ b/src/Usos/composer.json
@@ -22,7 +22,7 @@
         "docs": "https://socialiteproviders.com/usos"
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/VKontakte/composer.json
+++ b/src/VKontakte/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/vkontakte"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Vatsim/composer.json
+++ b/src/Vatsim/composer.json
@@ -23,7 +23,7 @@
         "docs": "https://socialiteproviders.com/vatsim"
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.2"
     },

--- a/src/Venmo/composer.json
+++ b/src/Venmo/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/venmo"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Vercel/composer.json
+++ b/src/Vercel/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/vercel"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/VersionOne/composer.json
+++ b/src/VersionOne/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/versionone"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Vimeo/composer.json
+++ b/src/Vimeo/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/vimeo"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Wave/composer.json
+++ b/src/Wave/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/wave"
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.3"
     },

--- a/src/WeChatServiceAccount/composer.json
+++ b/src/WeChatServiceAccount/composer.json
@@ -23,7 +23,7 @@
         "docs": "https://socialiteproviders.com/wechat-service-account"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/WeChatWeb/composer.json
+++ b/src/WeChatWeb/composer.json
@@ -22,7 +22,7 @@
         "docs": "https://socialiteproviders.com/wechat-web"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Webex/composer.json
+++ b/src/Webex/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/webex"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.0"
     },

--- a/src/Webflow/composer.json
+++ b/src/Webflow/composer.json
@@ -22,7 +22,7 @@
         "docs": "https://socialiteproviders.com/webflow"
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.2"
     },

--- a/src/Weibo/composer.json
+++ b/src/Weibo/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/weibo"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Weixin/composer.json
+++ b/src/Weixin/composer.json
@@ -25,7 +25,7 @@
         "docs": "https://socialiteproviders.com/weixin"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/WeixinWeb/composer.json
+++ b/src/WeixinWeb/composer.json
@@ -22,7 +22,7 @@
         "docs": "https://socialiteproviders.com/weixin-web"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Whmcs/composer.json
+++ b/src/Whmcs/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/whmcs"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Withings/composer.json
+++ b/src/Withings/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/withings"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/WordPress/composer.json
+++ b/src/WordPress/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/wordpress"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Worldcoin/composer.json
+++ b/src/Worldcoin/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.0"
     },

--- a/src/Xero/composer.json
+++ b/src/Xero/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/xero"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "firebase/php-jwt": "^5.2",
         "socialiteproviders/manager": "~4.0"

--- a/src/Xing/composer.json
+++ b/src/Xing/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/xing"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Yahoo/composer.json
+++ b/src/Yahoo/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/yahoo"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Yammer/composer.json
+++ b/src/Yammer/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/yammer"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Yandex/composer.json
+++ b/src/Yandex/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/yandex"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Yiban/composer.json
+++ b/src/Yiban/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/yiban"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/YouTube/composer.json
+++ b/src/YouTube/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/youtube"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Zalo/composer.json
+++ b/src/Zalo/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/zalo"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Zendesk/composer.json
+++ b/src/Zendesk/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/zendesk"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Zoho/composer.json
+++ b/src/Zoho/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/zoho"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },

--- a/src/Zoom/composer.json
+++ b/src/Zoom/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/zoom"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.0"
     },

--- a/src/xREL/composer.json
+++ b/src/xREL/composer.json
@@ -21,7 +21,7 @@
         "docs": "https://socialiteproviders.com/xrel"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "socialiteproviders/manager": "~4.0"
     },


### PR DESCRIPTION
This PR bumps the minimum version requirement to PHP 8.1
As PHP 8.0 will be EOL in a few months.

Cf. https://www.php.net/supported-versions.php

---

The GA PHP versions are updated accordingly.