### PR TITLE
Do not use array_add

### DIFF
--- a/src/FranceConnect/Provider.php
+++ b/src/FranceConnect/Provider.php
@@ -94,11 +94,9 @@ class Provider extends AbstractProvider
      */
     protected function getTokenFields($code)
     {
-        return array_add(
-            parent::getTokenFields($code),
-            'grant_type',
-            'authorization_code'
-        );
+        return array_merge(parent::getTokenFields($code), [
+            'grant_type' => 'authorization_code',
+        ]);
     }
 
     /**


### PR DESCRIPTION
Do not use `array_add`. This helper function is not available any more with the Laravel framework.