### PR TITLE
Added force HTTPS config option for Steam provider

### DIFF
--- a/src/Steam/Provider.php
+++ b/src/Steam/Provider.php
@@ -113,8 +113,7 @@ class Provider extends AbstractProvider
             throw new RuntimeException('The Steam API key has not been specified.');
         }
 
-        $response = $this->getHttpClient()->request(
-            'GET',
+        $response = $this->getHttpClient()->get(
             sprintf(self::STEAM_INFO_URL, $this->clientSecret, $token)
         );
 
@@ -182,7 +181,7 @@ class Provider extends AbstractProvider
             $requestOptions = array_merge($requestOptions, $customOptions);
         }
 
-        $response = $this->getHttpClient()->request('POST', self::OPENID_URL, $requestOptions);
+        $response = $this->getHttpClient()->post(self::OPENID_URL, $requestOptions);
 
         $results = $this->parseResults((string) $response->getBody());
 

--- a/src/Steam/README.md
+++ b/src/Steam/README.md
@@ -33,14 +33,14 @@ By default this protection is disabled. It will only be active when allowed host
 ### force_https
 Set this property to force HTTPS scheme when redirecting from Steam OAuth.
 
-If you do not set it scheme will be got from your server settings
+If you do not set it, the scheme will be inferred from your server settings.
 
 ```php
 'steam' => [
   'client_id' => null,
   'client_secret' => env('STEAM_CLIENT_SECRET'),
   'redirect' => env('STEAM_REDIRECT_URI'),
-  'force_https' => true,  // This will be force HTTPS scheme
+  'force_https' => true,  // This will force HTTPS scheme
   'allowed_hosts' => [
     'example.com',
   ]

--- a/src/Steam/README.md
+++ b/src/Steam/README.md
@@ -30,6 +30,22 @@ Issue resolved in https://github.com/SocialiteProviders/Providers/pull/817
 
 By default this protection is disabled. It will only be active when allowed hosts is not equal to an empty array.
 
+### force_https
+Set this property to force HTTPS scheme when redirecting from Steam OAuth.
+
+If you do not set it scheme will be got from your server settings
+
+```php
+'steam' => [
+  'client_id' => null,
+  'client_secret' => env('STEAM_CLIENT_SECRET'),
+  'redirect' => env('STEAM_REDIRECT_URI'),
+  'force_https' => true,  // This will be force HTTPS scheme
+  'allowed_hosts' => [
+    'example.com',
+  ]
+],
+```
 
 ## Add provider event listener
 


### PR DESCRIPTION
I added this option because of my problem today - I deployed my application to production using a Docker container (I don't use HTTPS in the container, it's just a reverse proxy from HTTPS to the container) and I can't log in via Steam. I found the problem, solved it and created a pull request