### PR TITLE
TikTok – fix: support mapping users without union_id

### DIFF
--- a/src/TikTok/Provider.php
+++ b/src/TikTok/Provider.php
@@ -120,7 +120,7 @@ class Provider extends AbstractProvider
 
         return (new User())->setRaw($user)->map([
             'id'       => $user['open_id'],
-            'union_id' => $user['union_id'],
+            'union_id' => $user['union_id'] ?? null,
             'name'     => $user['display_name'],
             'avatar'   => $user['avatar_large_url'],
         ]);


### PR DESCRIPTION
The `union_id` field is supposed to act as a common user key shared across the apps of the same developer. Even if it's included in [TikTok's v2 docs](https://developers.tiktok.com/doc/tiktok-api-v2-get-user-info) and being requested to be included in the response when fetching the user [here](https://github.com/SocialiteProviders/TikTok/blob/master/Provider.php#L103), it is not always being provided in the response as the other fields. Still unclear why this is happening but happens. Since this parameter is required to construct the User instance, it fails.

This PR just fixes the cases where this field is not being included by setting it to `null`.

<img width="1211" alt="image" src="https://github.com/SocialiteProviders/TikTok/assets/1769417/409eec81-4ae0-434e-86e6-45357b5ff2ef">