### PR TITLE
Autodesk APS fix naming and updated URLs

### DIFF
--- a/src/AutodeskAPS/AutodeskAPSExtendSocialite.php
+++ b/src/AutodeskAPS/AutodeskAPSExtendSocialite.php
@@ -13,6 +13,6 @@ class AutodeskAPSExtendSocialite
      */
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('aps', Provider::class);
+        $socialiteWasCalled->extendSocialite('autodeskaps', Provider::class);
     }
 }

--- a/src/AutodeskAPS/Provider.php
+++ b/src/AutodeskAPS/Provider.php
@@ -22,7 +22,7 @@ class Provider extends AbstractProvider
     {
         return
             $this->buildAuthUrlFromBase(
-                'https://developer.api.autodesk.com/authentication/v1/authorize',
+                'https://developer.api.autodesk.com/authentication/v2/authorize',
                 $state
             );
     }
@@ -32,7 +32,7 @@ class Provider extends AbstractProvider
      */
     protected function getTokenUrl(): string
     {
-        return 'https://developer.api.autodesk.com/authentication/v1/gettoken';
+        return 'https://developer.api.autodesk.com/authentication/v2/token';
     }
 
     /**
@@ -44,7 +44,7 @@ class Provider extends AbstractProvider
     protected function getUserByToken($token): array
     {
         $response = $this->getHttpClient()->get(
-            'https://developer.api.autodesk.com/userprofile/v1/users/@me',
+            'https://api.userprofile.autodesk.com/userinfo',
             [
                 RequestOptions::HEADERS => [
                     'Accept'        => 'application/json',
@@ -57,22 +57,23 @@ class Provider extends AbstractProvider
     }
 
     /**
-     * https://forge.autodesk.com/en/docs/oauth/v2/reference/http/users-@me-GET/.
+     * https://aps.autodesk.com/en/docs/oauth/v2/reference/http/userinfo-GET/.
      *
      * {@inheritdoc}
      */
     protected function mapUserToObject(array $user): User
     {
         return (new User())->setRaw($user)->map([
-            'id'             => $user['userId'],
-            'email'          => $user['emailId'],
-            'username'       => $user['userName'],
-            'first_name'     => $user['firstName'],
-            'last_name'      => $user['lastName'],
-            'country_code'   => $user['countryCode'],
-            'language'       => $user['language'],
-            'profile_images' => $user['profileImages'],
-            'website'        => $user['websiteUrl'] ?? null,
+            'id'             => $user['sub'],
+            'email'          => $user['email'],
+            'email_verified' => $user['email_verified'],
+            'username'       => $user['preferred_username'],
+            'full_name'      => $user['name'],
+            'first_name'     => $user['given_name'],
+            'last_name'      => $user['family_name'],
+            'language'       => $user['locale'],
+            'image'          => $user['picture'],
+            'website'        => $user['profile'] ?? null,
         ]);
     }
 }

--- a/src/AutodeskAPS/Provider.php
+++ b/src/AutodeskAPS/Provider.php
@@ -57,7 +57,7 @@ class Provider extends AbstractProvider
     }
 
     /**
-     * https://aps.autodesk.com/en/docs/oauth/v2/reference/http/userinfo-GET/.
+     * @see https://aps.autodesk.com/en/docs/oauth/v2/reference/http/userinfo-GET/.
      *
      * {@inheritdoc}
      */

--- a/src/AutodeskAPS/README.md
+++ b/src/AutodeskAPS/README.md
@@ -47,11 +47,18 @@ return Socialite::driver('autodeskaps')->redirect();
 
 ### Returned user fields
 
+Make sure to ask for the proper [scopes](https://aps.autodesk.com/en/docs/oauth/v2/developers_guide/scopes/).
 - `id`
-- `name`
 - `email`
+- `email_verified`
 - `username`
+- `full_name`
+- `first_name`
+- `last_name`
+- `language`
+- `image`
+- `website`
 
 ### Reference
 
-- [Autodesk documentation](https://aps.autodesk.com/en/docs/oauth/v1/tutorials/get-3-legged-token/);
+- [Autodesk documentation](https://aps.autodesk.com/en/docs/oauth/v2/developers_guide/overview/);

--- a/src/AutodeskAPS/README.md
+++ b/src/AutodeskAPS/README.md
@@ -18,7 +18,6 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
   'client_id' => env('AUTODESK_APS_CLIENT_ID'),  
   'client_secret' => env('AUTODESK_APS_CLIENT_SECRET'),  
   'redirect' => env('AUTODESK_APS_REDIRECT_URI'),
-  'region' => env('AUTODESK_APS_REGION'), // Could add a default of EU or US
 ],
 ```
 

--- a/src/AutodeskAPS/README.md
+++ b/src/AutodeskAPS/README.md
@@ -3,7 +3,7 @@
 This is a socialite provider for Autodesk APS (formerly Forge). 
 
 ```bash
-composer require socialiteproviders/autodesk-aps
+composer require socialiteproviders/aps
 ```
 
 ## Installation & Basic Usage
@@ -18,6 +18,7 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
   'client_id' => env('AUTODESK_APS_CLIENT_ID'),  
   'client_secret' => env('AUTODESK_APS_CLIENT_SECRET'),  
   'redirect' => env('AUTODESK_APS_REDIRECT_URI'),
+  'region' => env('AUTODESK_APS_REGION'), // Could add a default of EU or US
 ],
 ```
 
@@ -31,7 +32,7 @@ Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. 
 protected $listen = [
     \SocialiteProviders\Manager\SocialiteWasCalled::class => [
         // ... other providers
-        \SocialiteProviders\APS\AutodeskAPSExtendSocialite::class.'@handle',
+        \SocialiteProviders\AutodeskAPS\AutodeskAPSExtendSocialite::class.'@handle',
     ],
 ];
 ```

--- a/src/AutodeskAPS/composer.json
+++ b/src/AutodeskAPS/composer.json
@@ -21,7 +21,7 @@
     "support": {
         "issues": "https://github.com/socialiteproviders/providers/issues",
         "source": "https://github.com/socialiteproviders/providers",
-        "docs": "https://socialiteproviders.com/aps"
+        "docs": "https://socialiteproviders.com/AutodeskAPS"
     },
     "require": {
         "php": "^8.0",
@@ -30,7 +30,7 @@
     },
     "autoload": {
         "psr-4": {
-            "SocialiteProviders\\APS\\": ""
+            "SocialiteProviders\\AutodeskAPS\\": ""
         }
     }
 }


### PR DESCRIPTION
- Fixed naming;
- Added `region` as a config parameter;
- Fixed docs URL to match https://github.com/SocialiteProviders/website/pull/39;

Since the repository name is https://github.com/SocialiteProviders/AutodeskAPS, we might want to change the composer package name as well to something like `socialiteproviders/autodesk-aps`. The only 2 installs of the [package](https://packagist.org/packages/socialiteproviders/aps) at the moment are from me.