### PR TITLE
Use ID returned by pr0gramm.com

### DIFF
--- a/src/Pr0gramm/Provider.php
+++ b/src/Pr0gramm/Provider.php
@@ -71,6 +71,7 @@ class Provider extends AbstractProvider
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([
+            'id'   => $user['identifier'],
             'name' => $user['name'],
         ]);
     }


### PR DESCRIPTION
The pr0gramm.com API returns the User ID in a field called `identifier`. This PR adds a mapping, so the ID can be accessed easily.