### PR TITLE
Add note about Passport server route configuration

### DIFF
--- a/src/LaravelPassport/README.md
+++ b/src/LaravelPassport/README.md
@@ -34,6 +34,24 @@ protected $listen = [
 ];
 ```
 
+### Passport server configuration note
+
+If you are experiencing successful authentication, but the returned user contains null attributes, you may need to change your `routes/api.php` file.  The default routes file uses the `auth:sanctum` middleware:
+
+```php
+Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
+    return $request->user();
+});
+```
+
+It may need to be changed to `auth:api` in order to return the correct attributes:
+
+```php
+Route::middleware('auth:api')->get('/user', function (Request $request) {
+    return $request->user();
+});
+```
+
 ### Usage
 
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):


### PR DESCRIPTION
I spent quite a long time trying to troubleshoot an issue where the user object returned from the Laravel-Passport provider was coming through with all null attributes. After finally finding https://github.com/SocialiteProviders/Providers/issues/922, my problem was resolved.

This is technically mentioned in the [Passport docs](https://laravel.com/docs/10.x/passport#protecting-routes), but I never made the connection to how it would operate with Socialite. It makes sense now, but I feel it wasn't very clear.

I was hoping to contribute this small note in the docs here to hopefully save others from this.

Thanks!