### PR TITLE
AdmitAd: use space as the scope separator

### DIFF
--- a/src/Admitad/Provider.php
+++ b/src/Admitad/Provider.php
@@ -13,7 +13,12 @@ class Provider extends AbstractProvider
     /**
      * {@inheritdoc}
      */
-    protected $scopes = ['private_data private_data_email'];
+    protected $scopes = ['private_data', 'private_data_email'];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopeSeparator = ' ';
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
According to the [AdmitAd scope documentation](https://developers.admitad.com/hc/en-us/articles/7930273820689-Help-on-access-settings):

> it is required to send `scope` parameter containing names of rights separated by space.

This change should fix this up so it is possible to use the Laravel `->setScopes()` function.