### PR TITLE
Added support to read sp_sign_assertions key to remove hardcoded value

### DIFF
--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -370,7 +370,7 @@ class Provider extends AbstractProvider implements SocialiteProvider
     {
         $spSsoDescriptor = new SpSsoDescriptor();
         $spSsoDescriptor
-            ->setWantAssertionsSigned($this->getConfig('sp_sign_assertions', true))
+            ->setWantAssertionsSigned((bool) $this->getConfig('sp_sign_assertions', true))
             ->addNameIDFormat($this->getNameIDFormat());
 
         foreach ([SamlConstants::BINDING_SAML2_HTTP_REDIRECT, SamlConstants::BINDING_SAML2_HTTP_POST] as $binding) {

--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -169,6 +169,7 @@ class Provider extends AbstractProvider implements SocialiteProvider
             'sp_org_url',
             'sp_default_binding_method',
             'sp_name_id_format',
+            'sp_sign_assertions',
             'idp_binding_method',
             'attribute_map',
         ];
@@ -368,7 +369,9 @@ class Provider extends AbstractProvider implements SocialiteProvider
     public function getServiceProviderEntityDescriptor(): EntityDescriptor
     {
         $spSsoDescriptor = new SpSsoDescriptor();
-        $spSsoDescriptor->setWantAssertionsSigned(true)->addNameIDFormat($this->getNameIDFormat());
+        $spSsoDescriptor
+            ->setWantAssertionsSigned($this->getConfig('sp_sign_assertions', true))
+            ->addNameIDFormat($this->getNameIDFormat());
 
         foreach ([SamlConstants::BINDING_SAML2_HTTP_REDIRECT, SamlConstants::BINDING_SAML2_HTTP_POST] as $binding) {
             $acsRoute = $this->getAssertionConsumerServiceRoute();

--- a/src/Saml2/README.md
+++ b/src/Saml2/README.md
@@ -160,6 +160,7 @@ SAML2 supports the signing and encryption of messages and assertions. Many Ident
   'sp_certificate' => file_get_contents('path/to/sp_saml.crt'),
   'sp_private_key' => file_get_contents('path/to/sp_saml.pem'),
   'sp_private_key_passphrase' => 'passphrase to your private key, provide it only if you have one',
+  'sp_sign_assertions' => true, // or false to disable assertion signing
 ],
 ```
 


### PR DESCRIPTION
Replaced hard-coded value, now it's reading the sp_sign_assertions from the config key and setting the given value, default to true to avoid breaking changes.