### PR TITLE
[streamelements] Fix Authorization type and mapUserToObject

### DIFF
--- a/src/StreamElements/Provider.php
+++ b/src/StreamElements/Provider.php
@@ -40,7 +40,7 @@ class Provider extends AbstractProvider
             'https://api.streamelements.com/kappa/v2/channels/me',
             [
                 RequestOptions::HEADERS => [
-                    'Authorization' => 'Bearer '.$token,
+                    'Authorization' => 'oAuth '.$token,
                 ],
             ]
         );
@@ -61,7 +61,6 @@ class Provider extends AbstractProvider
             'email'         => $user['email'],
             'avatar'        => $user['avatar'],
             'type'          => $user['broadcasterType'],
-            'verified'      => $user['verified'],
             'partner'       => $user['isPartner'],
             'suspended'     => $user['suspended'],
         ]);


### PR DESCRIPTION
The payload response from the API has changed a bit and it appears StreamElements has changed their token type to "oAuth" on these types of requests. 

I used their javascript example to find the solution https://github.com/StreamElements/authentication-samples/blob/master/nodejs/index.js

This will resolve https://github.com/SocialiteProviders/Providers/issues/1003