### PR TITLE
Fix bad-looking transparent Discord avatars

### DIFF
--- a/src/Discord/Provider.php
+++ b/src/Discord/Provider.php
@@ -104,7 +104,7 @@ class Provider extends AbstractProvider
 
         $isGif = preg_match('/a_.+/m', $user['avatar']) === 1;
         $extension = $this->getConfig('allow_gif_avatars', true) && $isGif ? 'gif' :
-            $this->getConfig('avatar_default_extension', 'jpg');
+            $this->getConfig('avatar_default_extension', 'png');
 
         return sprintf('https://cdn.discordapp.com/avatars/%s/%s.%s', $user['id'], $user['avatar'], $extension);
     }

--- a/src/Discord/README.md
+++ b/src/Discord/README.md
@@ -18,7 +18,7 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
   
   // optional
   'allow_gif_avatars' => (bool)env('DISCORD_AVATAR_GIF', true),
-  'avatar_default_extension' => env('DISCORD_EXTENSION_DEFAULT', 'jpg'), // only pick from jpg, png, webp
+  'avatar_default_extension' => env('DISCORD_EXTENSION_DEFAULT', 'png'), // only pick from jpg, png, webp
 ],
 ```
 


### PR DESCRIPTION
Discord supports transparency in avatars and using the JPEG format for them looks very ugly, so switch to PNG.