### PR TITLE
Fixes for Apple signature

### DIFF
--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -286,7 +286,7 @@ class Provider extends AbstractProvider
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function refreshToken(string $refreshToken): ResponseInterface
+    public function refreshToken($refreshToken): ResponseInterface
     {
         return $this->getHttpClient()->post($this->getTokenUrl(), [
             RequestOptions::FORM_PARAMS => [


### PR DESCRIPTION
the refreshToken method signature does not match AbstractProvider which will result in a fatal error.

this PR sets the signature to match.