### PR TITLE
Update OneLogin `Provider@getRefreshTokenResponse()`

### DIFF
--- a/src/Onelogin/Provider.php
+++ b/src/Onelogin/Provider.php
@@ -108,9 +108,9 @@ class Provider extends AbstractProvider
 
     /**
      * @param  string  $refreshToken
-     * @return array
+     * @return array|null
      */
-    public function getRefreshTokenResponse(string $refreshToken)
+    public function getRefreshTokenResponse($refreshToken)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             RequestOptions::AUTH        => [$this->clientId, $this->clientSecret],


### PR DESCRIPTION
Similar to https://github.com/SocialiteProviders/Providers/pull/1128, this fixes the signature for OneLogin (created by upstream change method added in https://github.com/laravel/socialite/pull/675)