### PR TITLE
Update in accordance with discord changes

### DIFF
--- a/src/Discord/Provider.php
+++ b/src/Discord/Provider.php
@@ -116,8 +116,9 @@ class Provider extends AbstractProvider
     {
         return (new User())->setRaw($user)->map([
             'id'            => $user['id'],
+            'nickname'      => $user['username'].($user['discriminator'] !== '0' ? '#'.$user['discriminator'] : '')
             'username'      => $user['username'],
-            'discriminator' => $user['discriminator'],
+            'discriminator' => $user['discriminator'] ?? null,
             'global_name'   => $user['global_name'],
             'email'         => $user['email'] ?? null,
             'avatar'        => $this->formatAvatar($user),

--- a/src/Discord/Provider.php
+++ b/src/Discord/Provider.php
@@ -46,7 +46,7 @@ class Provider extends AbstractProvider
     {
         $fields = parent::getCodeFields($state);
 
-        if (! $this->consent) {
+        if (!$this->consent) {
             $fields['prompt'] = 'none';
         }
 
@@ -82,7 +82,7 @@ class Provider extends AbstractProvider
             'https://discord.com/api/users/@me',
             [
                 RequestOptions::HEADERS => [
-                    'Authorization' => 'Bearer '.$token,
+                    'Authorization' => 'Bearer ' . $token,
                 ],
             ]
         );
@@ -115,11 +115,12 @@ class Provider extends AbstractProvider
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([
-            'id'       => $user['id'],
-            'nickname' => $user['username'].($user['discriminator'] !== '0' ? '#'.$user['discriminator'] : ''),
-            'name'     => $user['username'],
-            'email'    => $user['email'] ?? null,
-            'avatar'   => $this->formatAvatar($user),
+            'id'            => $user['id'],
+            'username'      => $user['username'],
+            'discriminator' => $user['discriminator'],
+            'global_name'   => $user['global_name'],
+            'email'         => $user['email'] ?? null,
+            'avatar'        => $this->formatAvatar($user),
         ]);
     }
 

--- a/src/Discord/README.md
+++ b/src/Discord/README.md
@@ -50,8 +50,9 @@ return Socialite::driver('discord')->redirect();
 You'll find all the information about the fields currently being returned on the [Discord Developer Portal - Users Resource](https://discord.com/developers/docs/resources/user).
 
 -   `id` : The user's id (snowflake).
+-   `nickname` : The user's name with discriminator (name#0000).
 -   `username` : The user's username (name).
--   `discriminator` : The user's Discord-tag (#0000).
+-   `discriminator` : The user's Discord-tag (0000).
 -   `global_name` : The user's display name, if it is set (Amazing Name).
 -   `email` : The user's email (name@example.com).
 -   `avatar` : The user's avatar URL.

--- a/src/Discord/README.md
+++ b/src/Discord/README.md
@@ -11,11 +11,11 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
 ### Add configuration to `config/services.php`
 
 ```php
-'discord' => [    
-  'client_id' => env('DISCORD_CLIENT_ID'),  
-  'client_secret' => env('DISCORD_CLIENT_SECRET'),  
+'discord' => [
+  'client_id' => env('DISCORD_CLIENT_ID'),
+  'client_secret' => env('DISCORD_CLIENT_SECRET'),
   'redirect' => env('DISCORD_REDIRECT_URI'),
-  
+
   // optional
   'allow_gif_avatars' => (bool)env('DISCORD_AVATAR_GIF', true),
   'avatar_default_extension' => env('DISCORD_EXTENSION_DEFAULT', 'png'), // only pick from jpg, png, webp
@@ -47,8 +47,11 @@ return Socialite::driver('discord')->redirect();
 
 ### Returned User fields
 
-- ``id``
-- ``nickname``
-- ``name``
-- ``email``
-- ``avatar``
+You'll find all the information about the fields currently being returned on the [Discord Developer Portal - Users Resource](https://discord.com/developers/docs/resources/user).
+
+-   `id` : The user's id (snowflake).
+-   `username` : The user's username (name).
+-   `discriminator` : The user's Discord-tag (#0000).
+-   `global_name` : The user's display name, if it is set (Amazing Name).
+-   `email` : The user's email (name@example.com).
+-   `avatar` : The user's avatar URL.


### PR DESCRIPTION
The **DisplayName**, introduced this year by Discord, can now be found alongside the **Username** and **Discriminator**.

> You'll find all the information about the fields currently being returned on the [Discord Developer Portal - Users Resource](https://discord.com/developers/docs/resources/user).

## New returned fields :
-   `id` : The user's id (snowflake).
-   `nickname` : The user's name with discriminator (name#0000).
-   `username` : The user's username (name).
-   `discriminator` : The user's Discord-tag (0000).
-   `global_name` : The user's display name, if it is set (Amazing Name).
-   `email` : The user's email (name@example.com).
-   `avatar` : The user's avatar URL.
