### PR TITLE
Fix Start.gg `getRefreshTokenResponse()`

### DIFF
--- a/src/StartGg/Provider.php
+++ b/src/StartGg/Provider.php
@@ -96,4 +96,24 @@ class Provider extends AbstractProvider
             'discriminator' => $user['discriminator'],
         ]);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRefreshTokenResponse($refreshToken)
+    {
+        $response = $this->getHttpClient()->post('https://api.start.gg/oauth/refresh', [
+            RequestOptions::HEADERS => ['Content-Type' => 'application/json'],
+            RequestOptions::FORM_PARAMS => [
+                'grant_type'    => 'refresh_token',
+                'refresh_token' => $refreshToken,
+                'scope'         => $this->formatScopes($this->getScopes(), $this->scopeSeparator),
+                'client_id'     => $this->clientId,
+                'client_secret' => $this->clientSecret,
+                'redirect_uri'  => $this->redirectUrl,
+            ],
+        ]);
+
+        return json_decode((string) $response->getBody(), true);
+    }
 }


### PR DESCRIPTION
The recently added `getRefreshTokenResponse()` method (https://github.com/laravel/socialite/pull/675) does not work with [start.gg](https://dev.start.gg/docs/oauth/oauth-overview#refresh-token) as they use an unconventional setup for updating refresh tokens.

This PR overrides `getRefreshTokenResponse()` with the necessary changes.