### PR TITLE
feat: Add MercadoPago custom provider

### DIFF
--- a/monorepo-builder.yml
+++ b/monorepo-builder.yml
@@ -110,6 +110,7 @@ parameters:
     src/Medium: 'git@github.com:SocialiteProviders/Medium.git'
     src/Meetup: 'git@github.com:SocialiteProviders/Meetup.git'
     src/MercadoLibre: 'git@github.com:SocialiteProviders/MercadoLibre.git'
+    src/MercadoPago: 'git@github.com:SocialiteProviders/MercadoPago.git'
     src/Microsoft: 'git@github.com:SocialiteProviders/Microsoft.git'
     src/Minecraft: 'git@github.com:SocialiteProviders/Minecraft.git'
     src/Mixcloud: 'git@github.com:SocialiteProviders/Mixcloud.git'

--- a/src/MercadoPago/MercadoPagoExtendSocialite.php
+++ b/src/MercadoPago/MercadoPagoExtendSocialite.php
@@ -8,6 +8,6 @@ class MercadoPagoExtendSocialite
 {
     public function handle(SocialiteWasCalled $socialiteWasCalled): void
     {
-        $socialiteWasCalled->extendSocialite('mercadolibre', Provider::class);
+        $socialiteWasCalled->extendSocialite('mercadopago', Provider::class);
     }
 }

--- a/src/MercadoPago/MercadoPagoExtendSocialite.php
+++ b/src/MercadoPago/MercadoPagoExtendSocialite.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SocialiteProviders\MercadoPago;
+
+use SocialiteProviders\Manager\SocialiteWasCalled;
+
+class MercadoPagoExtendSocialite
+{
+    public function handle(SocialiteWasCalled $socialiteWasCalled): void
+    {
+        $socialiteWasCalled->extendSocialite('mercadolibre', Provider::class);
+    }
+}

--- a/src/MercadoPago/Provider.php
+++ b/src/MercadoPago/Provider.php
@@ -14,23 +14,12 @@ class MercadoPagoProvider extends AbstractProvider implements ProviderInterface
 {
     public const DOMAIN = [
         'AR' => 'https://auth.mercadopago.com.ar',
-        'BO' => 'https://auth.mercadopago.com.bo',
         'BR' => 'https://auth.mercadopago.com.br',
         'CL' => 'https://auth.mercadopago.cl',
         'CO' => 'https://auth.mercadopago.com.co',
-        'CR' => 'https://auth.mercadopago.co.cr',
-        'DO' => 'https://auth.mercadopago.com.do',
-        'EC' => 'https://auth.mercadopago.com.ec',
-        'GT' => 'https://auth.mercadopago.com.gt',
-        'HN' => 'https://auth.mercadopago.com.hn',
         'MX' => 'https://auth.mercadopago.com.mx',
-        'NI' => 'https://auth.mercadopago.com.ni',
-        'PA' => 'https://auth.mercadopago.com.pa',
-        'PY' => 'https://auth.mercadopago.com.py',
         'PE' => 'https://auth.mercadopago.com.pe',
-        'SV' => 'https://auth.mercadopago.com.sv',
         'UY' => 'https://auth.mercadopago.com.uy',
-        'VE' => 'https://auth.mercadopago.com.ve',
     ];
 
     /**
@@ -72,7 +61,7 @@ class MercadoPagoProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getAuthUrl($state)
     {
-        $url = self::DOMAIN[config('services.mercadopago.country')] ?? 'https://auth.mercadopago.com.ar';
+        $url = self::DOMAIN[config('services.mercadopago.country')] ?? 'https://auth.mercadopago.com';
         return $this->buildAuthUrlFromBase($url.'/authorization', $state);
     }
 

--- a/src/MercadoPago/Provider.php
+++ b/src/MercadoPago/Provider.php
@@ -72,7 +72,7 @@ class MercadoPagoProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getAuthUrl($state)
     {
-        $url = "https://auth.mercadopago.com.br";
+        $url = self::DOMAIN[config('services.mercadopago.country')] ?? 'https://auth.mercadopago.com.ar';
         return $this->buildAuthUrlFromBase($url.'/authorization', $state);
     }
 

--- a/src/MercadoPago/Provider.php
+++ b/src/MercadoPago/Provider.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Providers;
+
+use GuzzleHttp\RequestOptions;
+use Laravel\Socialite\Two\AbstractProvider;
+use Laravel\Socialite\Two\ProviderInterface;
+use SocialiteProviders\Manager\OAuth2\User;
+
+/**
+ * @see https://www.mercadopago.com.br/developers/pt/reference/oauth/_oauth_token/post
+ */
+class MercadoPagoProvider extends AbstractProvider implements ProviderInterface
+{
+    public const IDENTIFIER = 'MERCADOPAGO';
+
+    public const DOMAIN = [
+        'AR' => 'https://auth.mercadopago.com.ar',
+        'BO' => 'https://auth.mercadopago.com.bo',
+        'BR' => 'https://auth.mercadopago.com.br',
+        'CL' => 'https://auth.mercadopago.cl',
+        'CO' => 'https://auth.mercadopago.com.co',
+        'CR' => 'https://auth.mercadopago.co.cr',
+        'DO' => 'https://auth.mercadopago.com.do',
+        'EC' => 'https://auth.mercadopago.com.ec',
+        'GT' => 'https://auth.mercadopago.com.gt',
+        'HN' => 'https://auth.mercadopago.com.hn',
+        'MX' => 'https://auth.mercadopago.com.mx',
+        'NI' => 'https://auth.mercadopago.com.ni',
+        'PA' => 'https://auth.mercadopago.com.pa',
+        'PY' => 'https://auth.mercadopago.com.py',
+        'PE' => 'https://auth.mercadopago.com.pe',
+        'SV' => 'https://auth.mercadopago.com.sv',
+        'UY' => 'https://auth.mercadopago.com.uy',
+        'VE' => 'https://auth.mercadopago.com.ve',
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopes = ['offline_access', 'read'];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopeSeparator = ' ';
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function additionalConfigKeys()
+    {
+        return ['country'];
+    }
+
+    /**
+     * {@inheritdoc }
+     */
+    protected function getCodeFields($state = null): array
+    {
+        $fields = [
+            'client_id' => $this->clientId,
+            'response_type' => 'code',
+            'platform_id' => 'mp',
+            'state' => $state,
+            'redirect_uri' => $this->redirectUrl,
+        ];
+
+        return array_merge($fields, $this->parameters);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAuthUrl($state)
+    {
+        $url = "https://auth.mercadopago.com.br";
+        return $this->buildAuthUrlFromBase($url.'/authorization', $state);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenUrl()
+    {
+        return 'https://api.mercadopago.com/oauth/token';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByToken($token)
+    {
+        $response = $this->getHttpClient()->get('https://api.mercadopago.com/users/me', [
+            RequestOptions::HEADERS => [
+                'Authorization' => 'Bearer '.$token,
+            ],
+        ]);
+
+        return json_decode((string) $response->getBody(), true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return (new User())->setRaw($user)->map([
+            'id'       => $user['id'],
+            'nickname' => $user['nickname'],
+            'name'     => $user['first_name'].' '.$user['last_name'],
+            'email'    => $user['email'],
+            'avatar'   => $user['thumbnail']['picture_url'] ?? null,
+        ]);
+    }
+}

--- a/src/MercadoPago/Provider.php
+++ b/src/MercadoPago/Provider.php
@@ -12,8 +12,6 @@ use SocialiteProviders\Manager\OAuth2\User;
  */
 class MercadoPagoProvider extends AbstractProvider implements ProviderInterface
 {
-    public const IDENTIFIER = 'MERCADOPAGO';
-
     public const DOMAIN = [
         'AR' => 'https://auth.mercadopago.com.ar',
         'BO' => 'https://auth.mercadopago.com.bo',
@@ -38,7 +36,7 @@ class MercadoPagoProvider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
-    protected $scopes = ['offline_access', 'read'];
+    protected $scopes = ['read'];
 
     /**
      * {@inheritdoc}

--- a/src/MercadoPago/README.md
+++ b/src/MercadoPago/README.md
@@ -1,0 +1,73 @@
+# MercadoPago
+
+```bash
+composer require socialiteproviders/mercadopago
+```
+
+## Installation & Basic Usage
+
+Please see the [Base Installation Guide](https://socialiteproviders.com/usage/), then follow the provider specific instructions below.
+
+### Add configuration to `config/services.php`
+
+```php
+'mercadopago' => [    
+  'client_id' => env('MERCADOPAGO_CLIENT_ID'),  
+  'client_secret' => env('MERCADOPAGO_CLIENT_SECRET'),  
+  'redirect' => env('MERCADOPAGO_REDIRECT_URI'),
+  'country'  => env('MERCADOPAGO_COUNTRY', 'AR'), 
+],
+```
+
+Available countries:
+| Code | Country |
+| ---- | ------- |
+| AR | Argentina |
+| BO | Bolivia |
+| BR | Brasil |
+| CL | Chile |
+| CO | Colombia |
+| CR | Costa Rica |
+| DO | Dominicana |
+| EC | Ecuador |
+| GT | Guatemala |
+| HN | Honduras |
+| MX | México |
+| NI | Nicaragua |
+| PA | Panamá |
+| PY | Paraguay |
+| PE | Perú |
+| SV | Salvador |
+| UY | Uruguay |
+| VE | Venezuela |
+
+### Add provider event listener
+
+Configure the package's listener to listen for `SocialiteWasCalled` events.
+
+Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. See the [Base Installation Guide](https://socialiteproviders.com/usage/) for detailed instructions.
+
+```php
+protected $listen = [
+    \SocialiteProviders\Manager\SocialiteWasCalled::class => [
+        // ... other providers
+        \SocialiteProviders\MercadoPago\MercadoPagoExtendSocialite::class.'@handle',
+    ],
+];
+```
+
+### Usage
+
+You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
+
+```php
+return Socialite::driver('mercadopago')->redirect();
+```
+
+### Returned User fields
+
+- ``id``
+- ``nickname``
+- ``name``
+- ``email``
+- ``avatar``

--- a/src/MercadoPago/README.md
+++ b/src/MercadoPago/README.md
@@ -19,27 +19,16 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
 ],
 ```
 
-Available countries:
+[Available countries](https://www.mercadopago.com.br/developers/en/docs/getting-started#bookmark_availability_of_solutions_in_each_country):
 | Code | Country |
 | ---- | ------- |
 | AR | Argentina |
-| BO | Bolivia |
 | BR | Brasil |
 | CL | Chile |
 | CO | Colombia |
-| CR | Costa Rica |
-| DO | Dominicana |
-| EC | Ecuador |
-| GT | Guatemala |
-| HN | Honduras |
 | MX | México |
-| NI | Nicaragua |
-| PA | Panamá |
-| PY | Paraguay |
 | PE | Perú |
-| SV | Salvador |
 | UY | Uruguay |
-| VE | Venezuela |
 
 ### Add provider event listener
 

--- a/src/MercadoPago/composer.json
+++ b/src/MercadoPago/composer.json
@@ -1,0 +1,33 @@
+{
+    "name": "socialiteproviders/mercadopago",
+    "description": "MercadoPago OAuth2 Provider for Laravel Socialite",
+    "license": "MIT",
+    "keywords": [
+        "laravel",
+        "mercadopago",
+        "oauth",
+        "provider",
+        "socialite"
+    ],
+    "authors": [
+        {
+            "name": "Gabriel Barbosa",
+            "email": "gabrieltads2016@gmail.com"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/socialiteproviders/providers/issues",
+        "source": "https://github.com/socialiteproviders/providers",
+        "docs": "https://socialiteproviders.com/mercadopago"
+    },
+    "require": {
+        "php": "^8.0",
+        "ext-json": "*",
+        "socialiteproviders/manager": "^4.4"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialiteProviders\\MercadoPago\\": ""
+        }
+    }
+}


### PR DESCRIPTION
Very similar to existent MercadoLibre but it changes the auth URLs and it is focused on payments APIs.

Docs: https://www.mercadopago.com.br/developers/pt/reference/oauth/_oauth_token/post
