### PR TITLE
fix: Prevent null array offset errors in Provider.php for ORCID

### DIFF
--- a/src/Orcid/Provider.php
+++ b/src/Orcid/Provider.php
@@ -180,10 +180,12 @@ class Provider extends AbstractProvider
      */
     protected function mapUserToObject(array $user)
     {
+        $given_name = $user['person']['name']['given-names']['value'] ?? "";
+        $family_name = $user['person']['name']['family-name']['value'] ?? "";
         return (new User())->setRaw($user)->map([
             $this->getConfig('uid_fieldname', 'id') => $user['orcid-identifier']['path'],
-            'nickname'                              => $user['person']['name']['given-names']['value'],
-            'name'                                  => sprintf('%s %s', $user['person']['name']['given-names']['value'], $user['person']['name']['family-name']['value']),
+            'nickname'                              => $given_name,
+            'name'                                  => sprintf('%s %s', $given_name, $family_name),
             'email'                                 => Arr::get($user, 'email'),
         ]);
     }


### PR DESCRIPTION
In the event user data in the response from ORCID does not have a supplied name, an "array offset" error will be encountered because the `value` key won't exist as it's currently specified. 

"Family names" (or last names) are considered optional by ORCID, which means `$user['person']['name']['family-name']` won't always have a `['value']` key available.

For the moment, "given names" (or first names) are required by ORCID so there's no problem assuming this `['value']` information will exist in the response, but if ORCID ever does the right thing and makes "given names" optional, this will cause errors. It would be a good idea to future proof this with a null coalesce as well. My solution also reduces code duplication. 
