### PR TITLE
Fix warning deprecated: str_replace(): Passing null to parameter #2 (…

### DIFF
--- a/src/PayPal/Provider.php
+++ b/src/PayPal/Provider.php
@@ -66,7 +66,7 @@ class Provider extends AbstractProvider
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([
-            'id'       => str_replace('https://www.paypal.com/webapps/auth/identity/user/', null, $user['user_id']),
+            'id'       => str_replace('https://www.paypal.com/webapps/auth/identity/user/', '', $user['user_id']),
             'nickname' => null,
             'name'     => $user['name'] ?? null,
             'email'    => collect($user['emails'] ?? [])->firstWhere('primary')['value'] ?? null,

--- a/src/PayPalSandbox/Provider.php
+++ b/src/PayPalSandbox/Provider.php
@@ -62,7 +62,7 @@ class Provider extends AbstractProvider
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([
-            'id'       => str_replace('https://www.paypal.com/webapps/auth/identity/user/', null, $user['user_id']),
+            'id'       => str_replace('https://www.paypal.com/webapps/auth/identity/user/', '', $user['user_id']),
             'nickname' => null, 'name' => $user['name'],
             'email'    => $user['email'], 'avatar' => null,
         ]);


### PR DESCRIPTION
…$replace) of type array|string is deprecated

```
str_replace(
    array|string $search,
    array|string $replace,
    string|array $subject,
    int &$count = null
): string|array
```
so passing null on param #2 generates warnings

