### PR TITLE
fix(okta): remove duplicate credentials

### DIFF
--- a/src/Okta/Provider.php
+++ b/src/Okta/Provider.php
@@ -114,7 +114,7 @@ class Provider extends AbstractProvider
     {
         $fields = parent::getTokenFields($code);
 
-        // Okta doesn't like credentials being provided in both the Authorization header and body
+        // Okta does not support credentials being provided in both the Authorization header and body.
         unset($fields['client_id']);
         unset($fields['client_secret']);
 

--- a/src/Okta/Provider.php
+++ b/src/Okta/Provider.php
@@ -108,6 +108,20 @@ class Provider extends AbstractProvider
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function getTokenFields($code)
+    {
+        $fields = parent::getTokenFields($code);
+
+        // Okta doesn't like credentials being provided in both the Authorization header and body
+        unset($fields['client_id']);
+        unset($fields['client_secret']);
+
+        return $fields;
+    }
+
+    /**
      * Get the client access token response.
      *
      * @param  array|string  $scopes

--- a/src/Okta/Provider.php
+++ b/src/Okta/Provider.php
@@ -115,8 +115,7 @@ class Provider extends AbstractProvider
         $fields = parent::getTokenFields($code);
 
         // Okta does not support credentials being provided in both the Authorization header and body.
-        unset($fields['client_id']);
-        unset($fields['client_secret']);
+        unset($fields['client_id'], $fields['client_secret']);
 
         return $fields;
     }


### PR DESCRIPTION
https://github.com/laravel/socialite/pull/684 added the client_id and client_secret to the Authorization header in addition to the request body, however Okta throws an error if multiple credentials are provided, so they must be removed from the body before sending the request.