### PR TITLE
fix: instagram provider merge code fields

### DIFF
--- a/src/InstagramBasic/Provider.php
+++ b/src/InstagramBasic/Provider.php
@@ -86,15 +86,11 @@ class Provider extends AbstractProvider
      */
     protected function getCodeFields($state = null)
     {
-        $fields = [
-            'state'         => $state,
-            'response_type' => 'code',
-            'app_id'        => $this->clientId,
-            'redirect_uri'  => $this->redirectUrl,
-            'scope'         => $this->formatScopes($this->scopes, $this->scopeSeparator),
-        ];
-
-        return array_merge($fields, $this->parameters);
+        $fields = parent::getCodeFields($state);
+        $fields['app_id'] = $fields['client_id'];
+        unset($fields['client_id']);
+    
+        return $fields;
     }
 
     public function getAccessToken($code)

--- a/src/InstagramBasic/Provider.php
+++ b/src/InstagramBasic/Provider.php
@@ -86,13 +86,15 @@ class Provider extends AbstractProvider
      */
     protected function getCodeFields($state = null)
     {
-        return [
+        $fields = [
             'state'         => $state,
             'response_type' => 'code',
             'app_id'        => $this->clientId,
             'redirect_uri'  => $this->redirectUrl,
             'scope'         => $this->formatScopes($this->scopes, $this->scopeSeparator),
         ];
+
+        return array_merge($fields, $this->parameters);
     }
 
     public function getAccessToken($code)


### PR DESCRIPTION
Align the getCodeFields method with the AbstractProvider.php where the CodeFields are merged with the external parameters.
