### PR TITLE
Update LifeScienceLogin config URL

### DIFF
--- a/src/LifeScienceLogin/Provider.php
+++ b/src/LifeScienceLogin/Provider.php
@@ -23,7 +23,7 @@ class Provider extends AbstractProvider
     /**
      * LifeScience Login config URL.
      */
-    public const CONFIG_URL = 'https://proxy.aai.lifescience-ri.eu/.well-known/openid-configuration';
+    public const CONFIG_URL = 'https://login.aai.lifescience-ri.eu/oidc/.well-known/openid-configuration';
 
     /**
      * Cache key for the OpenID config.


### PR DESCRIPTION
LSLogin v2 uses a new config URL now. Services can be self-managed via  https://services.aai.lifescience-ri.eu. Once you upgrade to the new provider version, you have to update the `LSLOGIN_CLIENT_ID` and `LSLOGIN_CLIENT_SECRET`, too.

