### PR TITLE
Update Azure ADB2C user email field

### DIFF
--- a/src/AzureADB2C/Provider.php
+++ b/src/AzureADB2C/Provider.php
@@ -202,7 +202,7 @@ class Provider extends AbstractProvider
             'id'       => $user['sub'],
             'nickname' => $user['name'],
             'name'     => $user['name'],
-            'email'    => $user['emails'][0],
+            'email'    => $user['emails'][0] ?? $user['email'],
         ]);
     }
 

--- a/src/AzureADB2C/Provider.php
+++ b/src/AzureADB2C/Provider.php
@@ -202,7 +202,7 @@ class Provider extends AbstractProvider
             'id'       => $user['sub'],
             'nickname' => $user['name'],
             'name'     => $user['name'],
-            'email'    => $user['emails'][0] ?? $user['email'],
+            'email'    => $user['emails'][0] ?? $user['email'] ?? null,
         ]);
     }
 


### PR DESCRIPTION
Azure ADB2C can return a `email` key. This PR checks if there is a `emails` array or a singel `email` key. 