### PR TITLE
Make TikTok username optional based on scopes set

### DIFF
--- a/src/TikTok/Provider.php
+++ b/src/TikTok/Provider.php
@@ -99,16 +99,16 @@ class Provider extends AbstractProvider
     protected function getUserByToken($token)
     {
         $fields = [
-            'open_id', 
+            'open_id',
             'union_id',
             'display_name',
             'avatar_large_url',
         ];
 
-        if (in_array('user.info.profile', $fields)) {
+        if (in_array('user.info.profile', $this->scopes, true)) {
             $fields[] = 'username';
         }
-        
+
         $response = $this->getHttpClient()->get('https://open.tiktokapis.com/v2/user/info/', [
             RequestOptions::HEADERS => [
                 'Authorization' => 'Bearer '.$token,

--- a/src/TikTok/Provider.php
+++ b/src/TikTok/Provider.php
@@ -98,12 +98,23 @@ class Provider extends AbstractProvider
      */
     protected function getUserByToken($token)
     {
+        $fields = [
+            'open_id', 
+            'union_id',
+            'display_name',
+            'avatar_large_url',
+        ];
+
+        if (in_array('user.info.profile', $fields)) {
+            $fields[] = 'username';
+        }
+        
         $response = $this->getHttpClient()->get('https://open.tiktokapis.com/v2/user/info/', [
             RequestOptions::HEADERS => [
                 'Authorization' => 'Bearer '.$token,
             ],
             RequestOptions::QUERY => [
-                'fields' => 'open_id,union_id,display_name,avatar_large_url,username',
+                'fields' => implode(',', $fields),
             ],
         ]);
 


### PR DESCRIPTION
In v2, `username` can be requested only if `user.info.profile` scope is set.
Instead of forcing the scope, since it's not even in the default list of scopes set in the provider, we could just add the username field if the scope is present.

Closes #1198