### PR TITLE
Fix Twitch TypeError when refreshing tokens

### DIFF
--- a/src/Twitch/Provider.php
+++ b/src/Twitch/Provider.php
@@ -4,6 +4,7 @@ namespace SocialiteProviders\Twitch;
 
 use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
+use Laravel\Socialite\Two\Token;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -73,5 +74,20 @@ class Provider extends AbstractProvider
             'email'    => Arr::get($user, 'email'),
             'avatar'   => $user['profile_image_url'],
         ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function refreshToken($refreshToken)
+    {
+        $response = $this->getRefreshTokenResponse($refreshToken);
+
+        return new Token(
+            Arr::get($response, 'access_token'),
+            Arr::get($response, 'refresh_token'),
+            Arr::get($response, 'expires_in'),
+            Arr::get($response, 'scope', [])
+        );
     }
 }


### PR DESCRIPTION
Refreshing tokens with Twitch will result in a TypeError. Socialite expects the scope to be returned as a `string`, but Twitch will return the scope in an `array`.

## Fix error

Use the scope array directly instead of using `explode()`.

## Reproduce error

```php
Socialite::driver('twitch')->refreshToken($refreshToken);
```

Example [response](https://dev.twitch.tv/docs/authentication/refresh-tokens/#how-to-use-a-refresh-token):
```json
{
  "access_token": "1ssjqsqfy6bads1ws7m03gras79zfr",
  "refresh_token": "eyJfMzUtNDU0OC4MWYwLTQ5MDY5ODY4NGNlMSJ9%asdfasdf=",
  "scope": [
    "channel:read:subscriptions",
    "channel:manage:polls"
  ],
  "token_type": "bearer"
}
```
Result:

```php
   TypeError

  explode(): Argument #2 ($string) must be of type string, array given

  at vendor/laravel/socialite/src/Two/AbstractProvider.php:357
    353▕         return new Token(
    354▕             Arr::get($response, 'access_token'),
    355▕             Arr::get($response, 'refresh_token'),
    356▕             Arr::get($response, 'expires_in'),
  ➜ 357▕             explode($this->scopeSeparator, Arr::get($response, 'scope', ''))
    358▕         );
    359▕     }
    360▕
    361▕     /**
```