### PR TITLE
Upgrade Apple dependencies to be compatible with PHP 8.3

### DIFF
--- a/src/Apple/composer.json
+++ b/src/Apple/composer.json
@@ -40,8 +40,8 @@
         "ext-json": "*",
         "ext-openssl": "*",
         "firebase/php-jwt": "^6.8",
-        "lcobucci/clock": "^2.0 || ^3.0",
-        "lcobucci/jwt": "^4.1.5 || ^5.0.0",
+        "lcobucci/clock": "^2.0 || ^3.2",
+        "lcobucci/jwt": "^4.1.5 || ^5.2.0",
         "socialiteproviders/manager": "^4.4"
     },
     "suggest": {


### PR DESCRIPTION
Pakcages lcobucci/clock and lcobucci/jwt required PHP up to 8.2 in the previous versions.