### PR TITLE
Add Roblox OAuth2 Provider for Laravel Socialite

### DIFF
--- a/monorepo-builder.yml
+++ b/monorepo-builder.yml
@@ -156,6 +156,7 @@ parameters:
     src/Redbooth: 'git@github.com:SocialiteProviders/Redbooth.git'
     src/Reddit: 'git@github.com:SocialiteProviders/Reddit.git'
     src/Rekono: 'git@github.com:SocialiteProviders/Rekono.git'
+    src/Roblox: 'git@gitub.com:SocialiteProviders/Roblox.git'
     src/RunKeeper: 'git@github.com:SocialiteProviders/RunKeeper.git'
     src/SURFconext: 'git@github.com:SocialiteProviders/SURFconext.git'
     src/Sage: 'git@github.com:SocialiteProviders/Sage.git'

--- a/src/Roblox/Provider.php
+++ b/src/Roblox/Provider.php
@@ -79,12 +79,4 @@ class Provider extends AbstractProvider
             'picture'   => $user['picture'] ?? null,  // Roblox may leave this null if the account is new
         ]);
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public static function additionalConfigKeys()
-    {
-        return [];
-    }
 }

--- a/src/Roblox/Provider.php
+++ b/src/Roblox/Provider.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace SocialiteProviders\Roblox;
+
+use GuzzleHttp\RequestOptions;
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
+use SocialiteProviders\Manager\OAuth2\User;
+
+class Provider extends AbstractProvider
+{
+    public const IDENTIFIER = 'ROBLOX';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopes = ['openid', 'profile'];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopeSeparator = ' ';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAuthUrl($state)
+    {
+        return $this->buildAuthUrlFromBase(
+            'https://apis.roblox.com/oauth/v1/authorize',
+            $state
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getCodeFields($state = null)
+    {
+        return array_merge(parent::getCodeFields($state), [
+            'client_id' => $this->clientId,
+            'response_type' => 'code',
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenUrl()
+    {
+        return 'https://apis.roblox.com/oauth/v1/token';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByToken($token)
+    {
+        $response = $this->getHttpClient()->get(
+            'https://apis.roblox.com/oauth/v1/userinfo',
+            [
+                RequestOptions::HEADERS => [
+                    'Authorization' => 'Bearer ' . $token,
+                ],
+            ]
+        );
+
+        return json_decode((string) $response->getBody(), true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return (new User())->setRaw($user)->map([
+            'id'       => $user['sub'],  // Roblox user ID
+            'username' => $user['preferred_username'], // Roblox username (not display name)
+            'nickname' => $user['preferred_username'], // Roblox display name (not guaranteed to be unique)
+            'picture'   => $user['picture'] ?? null,  // Roblox may leave this null if the account is new
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function additionalConfigKeys()
+    {
+        return [];
+    }
+}

--- a/src/Roblox/README.md
+++ b/src/Roblox/README.md
@@ -1,0 +1,66 @@
+# Discord
+
+```bash
+composer require socialiteproviders/roblox
+```
+
+## Installation & Basic Usage
+
+Please see the [Base Installation Guide](https://socialiteproviders.com/usage/), then follow the provider specific instructions below.
+
+### Add configuration to `config/services.php`
+
+```php
+'roblox' => [
+    'client_id' => env('ROBLOX_CLIENT_ID'),
+    'client_secret' => env('ROBLOX_CLIENT_SECRET'),
+    'redirect' => env('ROBLOX_REDIRECT_URI'),
+],
+
+```
+
+### Add provider event listener
+
+#### Laravel 11+
+
+In Laravel 11, the default `EventServiceProvider` provider was removed. Instead, add the listener using the `listen` method on the `Event` facade, in your `AppServiceProvider` `boot` method.
+
+* Note: You do not need to add anything for the built-in socialite providers unless you override them with your own providers.
+
+```php
+Event::listen(function (\SocialiteProviders\Manager\SocialiteWasCalled $event) {
+    $event->extendSocialite('roblox', \SocialiteProviders\roblox\Provider::class);
+});
+```
+<details>
+<summary>
+Laravel 10 or below
+</summary>
+Configure the package's listener to listen for `SocialiteWasCalled` events.
+
+Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. See the [Base Installation Guide](https://socialiteproviders.com/usage/) for detailed instructions.
+
+```php
+protected $listen = [
+    \SocialiteProviders\Manager\SocialiteWasCalled::class => [
+        // ... other providers
+        \SocialiteProviders\roblox\RobloxExtendSocialite::class.'@handle',
+    ],
+];
+```
+</details>
+
+### Usage
+
+You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
+
+```php
+return Socialite::driver('roblox')->redirect();
+```
+
+### Returned User fields
+
+- ``id`` 
+- ``username``
+- ``nickname``
+- ``picture`` 

--- a/src/Roblox/RobloxExtendSocialite.php
+++ b/src/Roblox/RobloxExtendSocialite.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SocialiteProviders\Roblox;
+
+use SocialiteProviders\Manager\SocialiteWasCalled;
+
+class RobloxExtendSocialite
+{
+    public function handle(SocialiteWasCalled $socialiteWasCalled): void
+    {
+        $socialiteWasCalled->extendSocialite('roblox', Provider::class);
+    }
+}

--- a/src/Roblox/composer.json
+++ b/src/Roblox/composer.json
@@ -1,0 +1,32 @@
+{
+    "name": "socialiteproviders/discord",
+    "description": "Roblox OAuth2 Provider for Laravel Socialite",
+    "license": "MIT",
+    "keywords": [
+        "roblox",
+        "laravel",
+        "oauth",
+        "provider",
+        "socialite"
+    ],
+    "authors": [
+        {
+            "name": "Olivier Flentge",
+            "email": "flentgeolivier@gmail.com"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/socialiteproviders/providers/issues",
+        "source": "https://github.com/socialiteproviders/providers",
+    },
+    "require": {
+        "php": "^8.0",
+        "ext-json": "*",
+        "socialiteproviders/manager": "^4.4"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialiteProviders\\Roblox\\": ""
+        }
+    }
+}

--- a/src/Roblox/composer.json
+++ b/src/Roblox/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "socialiteproviders/discord",
+    "name": "socialiteproviders/roblox",
     "description": "Roblox OAuth2 Provider for Laravel Socialite",
     "license": "MIT",
     "keywords": [


### PR DESCRIPTION
This commit introduces the Roblox OAuth2 Provider for Laravel Socialite. It includes the provider's installation and usage instructions in the README file as well as the implementation of the Provider class. It also updates the monorepo-builder.yml file to include a new reference to the Roblox provider repository.

