### PR TITLE
docs: update linkdin provider documentation

### DIFF
--- a/src/LinkedIn/README.md
+++ b/src/LinkedIn/README.md
@@ -11,7 +11,7 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
 ### Add configuration to `config/services.php`
 
 ```php
-'linkedin' => [    
+'linkedin-openid' => [   
   'client_id' => env('LINKEDIN_CLIENT_ID'),  
   'client_secret' => env('LINKEDIN_CLIENT_SECRET'),  
   'redirect' => env('LINKEDIN_REDIRECT_URI') 
@@ -54,7 +54,7 @@ protected $listen = [
 You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::driver('linkedin')->redirect();
+return Socialite::driver('linkedin-openid')->redirect();
 ```
 
 ### Returned User fields


### PR DESCRIPTION
Recently I had an error when trying to do Sig In, the reason is that Linkdin changed the way it authenticates, and the package is already that way.

The old way to connect with provider givem error, because now LinkedIn is using Sign In with LinkedIn using OpenID Connect instead of Sign In with LinkedIn.

So you just need to use linkedin-openid instead of linkedin in the `service.php` and `Socialite::driver('linkedin-openid')->redirect();`