### PR TITLE
Add safe check for email claim

### DIFF
--- a/src/Auth0/Provider.php
+++ b/src/Auth0/Provider.php
@@ -74,7 +74,7 @@ class Provider extends AbstractProvider
             'id'       => $user['sub'],
             'nickname' => $user['nickname'],
             'name'     => Arr::get($user, 'given_name', '').' '.Arr::get($user, 'family_name', ''),
-            'email'    => $user['email'],
+            'email'    => Arr::get($user, 'email'),
             'avatar'   => null,
         ]);
     }


### PR DESCRIPTION
Use Laravel's helper function `Arr::get` when accessing the 'email' key in the `$user` array. 

This prevents PHP from throwing an "Undefined index" error when trying to access the 'email' key that doesn't exist in the array. Valid in the case where the email is not a claim used to identify the user.