### PR TITLE
ClaveUnica provider: set scopes acording to Implemetation guide

### DIFF
--- a/src/ClaveUnica/Provider.php
+++ b/src/ClaveUnica/Provider.php
@@ -17,7 +17,6 @@ class Provider extends AbstractProvider
         'openid',
         'run',
         'name',
-        'email',
     ];
 
     protected $scopeSeparator = ' ';


### PR DESCRIPTION
Acroding to official implementation guide of ClaveUnica, there is no email scope

Official guide:
https://claveunica.gob.cl/instituciones link "Ir a guía técnica"

Direct link:

https://docs.google.com/document/d/16c0D2jVhuYOYGI9z4kC2aoNH8oWNA9v1cc3tXQ76TO0/edit

