### PR TITLE
Add IVAO Provider

### DIFF
--- a/monorepo-builder.yml
+++ b/monorepo-builder.yml
@@ -93,6 +93,7 @@ parameters:
     src/InstagramBasic: 'git@github.com:SocialiteProviders/InstagramBasic.git'
     src/Instructure: 'git@github.com:SocialiteProviders/Instructure.git'
     src/Intercom: 'git@github.com:SocialiteProviders/Intercom.git'
+    src/Ivao: 'git@github.com:SocialiteProviders/Ivao.git'
     src/Jira: 'git@github.com:SocialiteProviders/Jira.git'
     src/JumpCloud: 'git@github.com:SocialiteProviders/JumpCloud.git'
     src/Kakao: 'git@github.com:SocialiteProviders/Kakao.git'

--- a/src/Ivao/IvaoExtendSocialite.php
+++ b/src/Ivao/IvaoExtendSocialite.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SocialiteProviders\Ivao;
+
+use SocialiteProviders\Manager\SocialiteWasCalled;
+
+class IvaoExtendSocialite
+{
+    public function handle(SocialiteWasCalled $socialiteWasCalled): void
+    {
+        $socialiteWasCalled->extendSocialite('ivao', Provider::class);
+    }
+}

--- a/src/Ivao/Provider.php
+++ b/src/Ivao/Provider.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace SocialiteProviders\Ivao;
+
+use GuzzleHttp\RequestOptions;
+use Illuminate\Support\Arr;
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
+use SocialiteProviders\Manager\OAuth2\User;
+
+class Provider extends AbstractProvider
+{
+    public const IDENTIFIER = 'IVAO';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopeSeparator = ' ';
+
+    /**
+     * The scopes being requested that are mandatory.
+     *
+     * @var array
+     */
+    protected $requiredScopes = ['email'];
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getAuthUrl($state)
+    {
+        return $this->buildAuthUrlFromBase('https://sso.ivao.aero/authorize', $state);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getTokenUrl()
+    {
+        return 'https://api.ivao.aero/v2/oauth/token';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getUserByToken($token)
+    {
+        $response = $this->getHttpClient()->get(
+            'https://api.ivao.aero/v2/users/me',
+            [
+                RequestOptions::HEADERS => [
+                    'Authorization' => 'Bearer '.$token,
+                ],
+            ]
+        );
+
+        return json_decode((string) $response->getBody(), true);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return (new User())->setRaw($user)->map([
+            'id'           => Arr::get($user, 'id'),
+            'name'         => Arr::get($user, 'firstName').' '.Arr::get($user, 'lastName'),
+            'email'        => Arr::get($user, 'email'),
+            'nickname'     => Arr::get($user, 'publicNickname'),
+            'division'     => Arr::get($user, 'divisionId'),
+            'atc_rating'   => Arr::get($user, 'rating.atcRating.id'),
+            'pilot_rating' => Arr::get($user, 'rating.pilotRating.id'),
+        ]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getScopes()
+    {
+        return array_unique(array_merge(parent::getScopes(), $this->getRequiredScopes()));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getCodeFields($state = null)
+    {
+        $fields = parent::getCodeFields($state);
+
+        if ($requiredScopes = $this->getRequiredScopes()) {
+            $fields['required_scopes'] = $this->formatScopes($requiredScopes, $this->scopeSeparator);
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Merge the required scopes of the requested access.
+     *
+     * @param  array|string  $scopes
+     * @return $this
+     */
+    public function requiredScopes($scopes)
+    {
+        $this->requiredScopes = array_unique(array_merge($this->requiredScopes, (array) $scopes));
+
+        return $this;
+    }
+
+    /**
+     * Set the required scopes of the requested access.
+     *
+     * @param  array|string  $scopes
+     * @return $this
+     */
+    public function setRequiredScopes($scopes)
+    {
+        $this->requiredScopes = array_unique((array) $scopes);
+
+        return $this;
+    }
+
+    /**
+     * Get the current required scopes.
+     *
+     * @return array
+     */
+    public function getRequiredScopes()
+    {
+        return $this->requiredScopes;
+    }
+}

--- a/src/Ivao/README.md
+++ b/src/Ivao/README.md
@@ -1,0 +1,58 @@
+# Ivao
+
+```bash
+composer require socialiteproviders/ivao
+```
+
+## Installation & Basic Usage
+
+Please see the [Base Installation Guide](https://socialiteproviders.com/usage/), then follow the provider specific instructions below.
+
+### Add configuration to `config/services.php`
+
+```php
+'ivao' => [
+  'client_id' => env('IVAO_CLIENT_ID'),
+  'client_secret' => env('IVAO_CLIENT_SECRET'),
+  'redirect' => env('IVAO_REDIRECT_URI')
+],
+```
+
+### Add provider event listener
+
+#### Laravel 11+
+
+In Laravel 11, the default `EventServiceProvider` provider was removed. Instead, add the listener using the `listen` method on the `Event` facade, in your `AppServiceProvider` `boot` method.
+
+* Note: You do not need to add anything for the built-in socialite providers unless you override them with your own providers.
+
+```php
+Event::listen(function (\SocialiteProviders\Manager\SocialiteWasCalled $event) {
+    $event->extendSocialite('ivao', \SocialiteProviders\Ivao\Provider::class);
+});
+```
+<details>
+<summary>
+Laravel 10 or below
+</summary>
+Configure the package's listener to listen for `SocialiteWasCalled` events.
+
+Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. See the [Base Installation Guide](https://socialiteproviders.com/usage/) for detailed instructions.
+
+```php
+protected $listen = [
+    \SocialiteProviders\Manager\SocialiteWasCalled::class => [
+        // ... other providers
+        \SocialiteProviders\Ivao\IvaoExtendSocialite::class.'@handle',
+    ],
+];
+```
+</details>
+
+### Usage
+
+You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
+
+```php
+return Socialite::driver('ivao')->redirect();
+```

--- a/src/Ivao/composer.json
+++ b/src/Ivao/composer.json
@@ -1,0 +1,35 @@
+{
+    "name": "socialiteproviders/ivao",
+    "description": "IVAO OAuth2 Provider for Laravel Socialite",
+    "license": "MIT",
+    "keywords": [
+        "laravel",
+        "socialite",
+        "oauth",
+        "oauth2",
+        "provider",
+        "ivao"
+    ],
+    "authors": [
+        {
+            "name": "Arthur Parienté",
+            "email": "arthur.pariente06@gmail.com",
+            "role": "Developer"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/socialiteproviders/providers/issues",
+        "source": "https://github.com/socialiteproviders/providers",
+        "docs": "https://socialiteproviders.com/ivao"
+    },
+    "require": {
+        "php": "^8.0",
+        "ext-json": "*",
+        "socialiteproviders/manager": "^4.4"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialiteProviders\\Ivao\\": ""
+        }
+    }
+}


### PR DESCRIPTION
The OAuth endpoints for the IVAO API can be found [here](https://api.ivao.aero/.well-known/openid-configuration). This URL provides all the necessary information, including the authorization, token, and userinfo endpoints.

Since the endpoints for other providers are hard-coded in this repository, I have also hard-coded the IVAO endpoints. There is no reason to expect these endpoints to change, so this approach ensures stability.

For more details, you can refer to the [IVAO API documentation](https://api.ivao.aero/docs).