### PR TITLE
fix: fiken and zettle provider classnames

### DIFF
--- a/src/Fiken/FikenExtendSocialite.php
+++ b/src/Fiken/FikenExtendSocialite.php
@@ -8,6 +8,6 @@ class FikenExtendSocialite
 {
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('fiken', FikenProvider::class);
+        $socialiteWasCalled->extendSocialite('fiken', Provider::class);
     }
 }

--- a/src/Fiken/Provider.php
+++ b/src/Fiken/Provider.php
@@ -7,7 +7,7 @@ use Psr\Http\Message\ResponseInterface;
 use SocialiteProviders\Manager\OAuth2\User;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 
-class FikenProvider extends AbstractProvider
+class Provider extends AbstractProvider
 {
     /**
      * Fiken Oauth base url.

--- a/src/Zettle/Provider.php
+++ b/src/Zettle/Provider.php
@@ -6,7 +6,7 @@ use GuzzleHttp\RequestOptions;
 use SocialiteProviders\Manager\OAuth2\User;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 
-class ZettleProvider extends AbstractProvider
+class Provider extends AbstractProvider
 {
     protected $usesPKCE = true;
 

--- a/src/Zettle/ZettleExtendSocialite.php
+++ b/src/Zettle/ZettleExtendSocialite.php
@@ -8,6 +8,6 @@ class ZettleExtendSocialite
 {
     public function handle(SocialiteWasCalled $socialiteWasCalled)
     {
-        $socialiteWasCalled->extendSocialite('zettle', ZettleProvider::class);
+        $socialiteWasCalled->extendSocialite('zettle', Provider::class);
     }
 }


### PR DESCRIPTION
Noticed that I bungled the filename/classname in the Fiken provider I made a few weeks ago. Then copying led to the same error in the Zettle provider that was just merged.