### PR TITLE
Added scopeSeparator property to Atlassian provider

### DIFF
--- a/src/Atlassian/Provider.php
+++ b/src/Atlassian/Provider.php
@@ -26,6 +26,11 @@ class Provider extends AbstractProvider
     /**
      * {@inheritdoc}
      */
+    protected $scopeSeparator = ' ';
+
+    /**
+     * {@inheritdoc}
+     */
     protected function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase('https://auth.atlassian.com/authorize', $state);


### PR DESCRIPTION
As stated in [Atlassian's documentation](https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/#1--direct-the-user-to-the-authorization-url-to-get-an-authorization-code), scopes should be separated with a space.

Currently, the `scopeSeparator` property in `AbstractProvider` is set to a comma so this provider does not work.