### PR TITLE
Add Threads provider

### DIFF
--- a/monorepo-builder.yml
+++ b/monorepo-builder.yml
@@ -191,6 +191,7 @@ parameters:
     src/Teamweek: 'git@github.com:SocialiteProviders/Teamweek.git'
     src/Telegram: 'git@github.com:SocialiteProviders/Telegram.git'
     src/ThirtySevenSignals: 'git@github.com:SocialiteProviders/37Signals.git'
+    src/Threads: 'git@github.com:SocialiteProviders/Threads.git'
     src/TikTok: 'git@github.com:SocialiteProviders/TikTok.git'
     src/Todoist: 'git@github.com:SocialiteProviders/Todoist.git'
     src/Toyhouse: 'git@github.com:SocialiteProviders/Toyhouse.git'

--- a/src/Threads/Provider.php
+++ b/src/Threads/Provider.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace SocialiteProviders\Threads;
+
+use GuzzleHttp\RequestOptions;
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
+use SocialiteProviders\Manager\OAuth2\User;
+
+/**
+ * @see https://developers.facebook.com/docs/threads
+ */
+class Provider extends AbstractProvider
+{
+    public const IDENTIFIER = 'THREADS';
+
+    /**
+     * The user fields being requested.
+     *
+     * @var array<string>
+     */
+    protected $fields = [
+        'id',
+        'threads_profile_picture_url',
+        'username',
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopes = [
+        'threads_basic',
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getAuthUrl($state)
+    {
+        return $this->buildAuthUrlFromBase('https://threads.net/oauth/authorize', $state);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getTokenUrl()
+    {
+        return 'https://graph.threads.net/oauth/access_token';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getUserByToken($token)
+    {
+        $queryParameters = [
+            'access_token' => $token,
+            'fields'       => implode(',', $this->fields),
+        ];
+
+        if (! empty($this->clientSecret)) {
+            $queryParameters['appsecret_proof'] = hash_hmac('sha256', $token, $this->clientSecret);
+        }
+
+        $response = $this->getHttpClient()->get('https://graph.threads.net/me', [
+            RequestOptions::HEADERS => [
+                'Accept' => 'application/json',
+            ],
+            RequestOptions::QUERY => $queryParameters,
+        ]);
+
+        return json_decode((string) $response->getBody(), true);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return (new User())->setRaw($user)->map([
+            'id'           => $user['id'],
+            'nickname'     => $user['username'],
+            'name'         => null,
+            'email'        => null,
+            'avatar'       => $user['threads_profile_picture_url'],
+        ]);
+    }
+}

--- a/src/Threads/README.md
+++ b/src/Threads/README.md
@@ -1,0 +1,115 @@
+# Threads
+
+```bash
+composer require socialiteproviders/threads
+```
+
+## Installation & Basic Usage
+
+Please see the [Base Installation Guide](https://socialiteproviders.com/usage/), then follow the provider specific instructions below.
+
+### Add configuration to `config/services.php`
+
+```php
+'threads' => [    
+  'client_id' => env('THREADS_CLIENT_ID'),  
+  'client_secret' => env('THREADS_CLIENT_SECRET'),  
+  'redirect' => env('THREADS_REDIRECT_URI') 
+],
+```
+
+### Add provider event listener
+
+#### Laravel 11+
+
+In Laravel 11, the default `EventServiceProvider` provider was removed. Instead, add the listener using the `listen` method on the `Event` facade, in your `AppServiceProvider` `boot` method.
+
+* Note: You do not need to add anything for the built-in socialite providers unless you override them with your own providers.
+
+```php
+Event::listen(function (\SocialiteProviders\Manager\SocialiteWasCalled $event) {
+    $event->extendSocialite('threads', \SocialiteProviders\Threads\Provider::class);
+});
+```
+<details>
+<summary>
+Laravel 10 or below
+</summary>
+Configure the package's listener to listen for `SocialiteWasCalled` events.
+
+Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. See the [Base Installation Guide](https://socialiteproviders.com/usage/) for detailed instructions.
+
+```php
+protected $listen = [
+    \SocialiteProviders\Manager\SocialiteWasCalled::class => [
+        // ... other providers
+        \SocialiteProviders\StartGg\ThreadsExtendSocialite::class.'@handle',
+    ],
+];
+```
+</details>
+
+### Usage
+
+You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
+
+```php
+return Socialite::driver('threads')->redirect();
+```
+
+### Returned User fields
+
+- ``id``
+- ``nickname``
+- ``avatar``
+
+### Refreshing access tokens
+
+Threads does not support refresh tokens. It is however possible to exchange the default short-lived access tokens for long-lived refreshable access tokens. Socialite only supports the conventional way of refreshing access token with refresh tokens, so you need to implement this in your own code if you need to refresh access tokens.
+
+First, exchange a short-lived access token for a long-lived access token.
+
+```php
+public function exchangeAccessToken(string $accessToken): string
+{
+    $response = Http::post('https://graph.threads.net/access_token', [
+            RequestOptions::HEADERS => [
+                'Content-Type' => 'application/json'
+            ],
+            RequestOptions::FORM_PARAMS => [
+                'access_token'  => $accessToken,
+                'client_secret' => config('threads.client_secret'),
+                'grant_type'    => 'th_exchange_token',
+            ],
+        ]);
+
+    $response = json_decode((string) $response->getBody(), true);
+    
+    return $response['access_token'];
+}
+```
+
+After obtaining a long-lived access token, this token can be refreshed as long as it's still valid.
+
+```php
+public function refreshAccessToken(string $accessToken): string
+{
+    $response = Http::post('https://graph.threads.net/refresh_access_token', [
+            RequestOptions::HEADERS => [
+                'Content-Type' => 'application/json'
+            ],
+            RequestOptions::FORM_PARAMS => [
+                'access_token'  => $accessToken,
+                'grant_type'    => 'th_refresh_token',
+            ],
+        ]);
+
+    $response = json_decode((string) $response->getBody(), true);
+    
+    return $response['access_token'];
+}
+```
+
+### Reference
+
+- [Threads API](https://developers.facebook.com/docs/threads)

--- a/src/Threads/ThreadsExtendSocialite.php
+++ b/src/Threads/ThreadsExtendSocialite.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SocialiteProviders\Threads;
+
+use SocialiteProviders\Manager\SocialiteWasCalled;
+
+class ThreadsExtendSocialite
+{
+    public function handle(SocialiteWasCalled $socialiteWasCalled): void
+    {
+        $socialiteWasCalled->extendSocialite('threads', Provider::class);
+    }
+}

--- a/src/Threads/composer.json
+++ b/src/Threads/composer.json
@@ -1,0 +1,34 @@
+{
+    "name": "socialiteproviders/threads",
+    "description": "Threads OAuth2 Provider for Laravel Socialite",
+    "license": "MIT",
+    "keywords": [
+        "threads",
+        "laravel",
+        "oauth",
+        "provider",
+        "socialite"
+    ],
+    "authors": [
+        {
+            "name": "Nick Been",
+            "email": "nick@nickbeen.nl",
+            "homepage": "https://nickbeen.nl"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/socialiteproviders/providers/issues",
+        "source": "https://github.com/socialiteproviders/providers",
+        "docs": "https://socialiteproviders.com/threads"
+    },
+    "require": {
+        "php": "^8.0",
+        "ext-json": "*",
+        "socialiteproviders/manager": "^4.4"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialiteProviders\\Threads\\": ""
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a provider for Threads (www.threads.net), the Twitter-like social network of Meta.

Note: Threads does not support refresh tokens, but allows the default short-lived access tokens to be exchanged for long-lived refreshable access tokens. I've added example code in the README.md instead of incorrectly implementing it in the `getRefreshTokenResponse` method.

Docs: https://developers.facebook.com/docs/threads