### PR TITLE
Fixing APS OAuth

### DIFF
--- a/src/AutodeskAPS/Provider.php
+++ b/src/AutodeskAPS/Provider.php
@@ -35,6 +35,61 @@ class Provider extends AbstractProvider
         return 'https://developer.api.autodesk.com/authentication/v2/token';
     }
 
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function getCodeFields($state = null)
+	{
+		$fields = [
+			'client_id' => $this->getConfig('client_id') ?? $this->clientId,
+			'redirect_uri' => $this->getConfig('redirect') ?? $this->redirectUrl,
+			'scope' => $this->formatScopes($this->getScopes(), $this->scopeSeparator),
+			'response_type' => 'code',
+		];
+
+		if ($this->usesState()) {
+			$fields['state'] = $state;
+		}
+
+		if ($this->usesPKCE()) {
+			$fields['code_challenge'] = $this->getCodeChallenge();
+			$fields['code_challenge_method'] = $this->getCodeChallengeMethod();
+		}
+
+		return array_merge($fields, $this->parameters);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function getTokenFields($code)
+	{
+		$fields = [
+			'grant_type' => 'authorization_code',
+			'code' => $code,
+			'redirect_uri' => $this->getConfig('redirect') ?? $this->redirectUrl,
+		];
+
+		if ($this->usesPKCE()) {
+			$fields['code_verifier'] = $this->request->session()->pull('code_verifier');
+		}
+
+		return array_merge($fields, $this->parameters);
+	}
+
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function getTokenHeaders($code): array
+	{
+		$base64 = base64_encode(($this->getConfig('client_id') ?? $this->clientId).':'.($this->getConfig('client_secret') ?? $this->clientSecret));
+		return [
+			'Content-Type' => 'application/x-www-form-urlencoded',
+			'Authorization' => 'Basic '.$base64,
+		];
+	}
+
     /**
      * @param  string  $token
      * @return array


### PR DESCRIPTION
Fixing APS OAuth.

Also added possibility to use `setConfig`. This makes it possible to use the package in a multi-tenancy app. 

According to the [docs](https://aps.autodesk.com/en/docs/oauth/v2/tutorials/get-3-legged-token/#step-3-exchange-the-authorization-code-for-an-access-token) a base64 encrypted header of the client ID and secret is required. But not all "standard" headers are required or matched the docs. For example the content-type. 