### PR TITLE
Make LaravelPassport userinfo_uri configurable.

### DIFF
--- a/src/LaravelPassport/Provider.php
+++ b/src/LaravelPassport/Provider.php
@@ -104,7 +104,7 @@ class Provider extends AbstractProvider
         return rtrim($this->getConfig('host'), '/').'/'.ltrim($this->getConfig($type, Arr::get([
             'authorize_uri' => 'oauth/authorize',
             'token_uri'     => 'oauth/token',
-            'userinfo_uri'  => 'api/user',
+            'userinfo_uri'  => $this->getConfig('userinfo_uri', 'api/user')',
         ], $type)), '/');
     }
 


### PR DESCRIPTION
fixed https://github.com/SocialiteProviders/Providers/issues/1219

