### PR TITLE
feat: add Aikido OAuth support

### DIFF
--- a/monorepo-builder.yml
+++ b/monorepo-builder.yml
@@ -3,6 +3,7 @@ parameters:
     src/Acclaim: 'git@github.com:SocialiteProviders/Acclaim.git'
     src/Admitad: 'git@github.com:SocialiteProviders/Admitad.git'
     src/Adobe: 'git@github.com:SocialiteProviders/Adobe.git'
+    src/Aikido: 'git@github.com:SocialiteProviders/Aikido.git'
     src/Amazon: 'git@github.com:SocialiteProviders/Amazon.git'
     src/AmoCRM: 'git@github.com:SocialiteProviders/AmoCRM.git'
     src/AngelList: 'git@github.com:SocialiteProviders/AngelList.git'

--- a/src/Aikido/AikidoExtendSocialite.php
+++ b/src/Aikido/AikidoExtendSocialite.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SocialiteProviders\Aikido;
+
+use SocialiteProviders\Manager\SocialiteWasCalled;
+
+class AikidoExtendSocialite
+{
+    public function handle(SocialiteWasCalled $socialiteWasCalled): void
+    {
+        $socialiteWasCalled->extendSocialite('aikido', Provider::class);
+    }
+}

--- a/src/Aikido/Provider.php
+++ b/src/Aikido/Provider.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace SocialiteProviders\Aikido;
+
+use GuzzleHttp\RequestOptions;
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
+use SocialiteProviders\Manager\OAuth2\User;
+
+/**
+ * The Socialite provider for Aikido OAuth.
+ */
+class Provider extends AbstractProvider
+{
+    /**
+     * The base URL for the Aikido OAuth provider.
+     */
+    private const BASE_URL = 'https://app.aikido.dev';
+
+    public const IDENTIFIER = 'AIKIDO';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopes = [''];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAuthUrl($state)
+    {
+        return $this->buildAuthUrlFromBase(
+            self::BASE_URL . '/oauth/authorize',
+            $state
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenUrl()
+    {
+        return self::BASE_URL . '/api/oauth/token';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByToken($token)
+    {
+        $response = $this->getHttpClient()->get(
+            self::BASE_URL . '/api/public/v1/workspace',
+            [
+                RequestOptions::HEADERS => [
+                    'Authorization' => "Bearer {$token}",
+                ],
+            ]
+        );
+
+        return json_decode($response->getBody()->getContents(), true);
+    }
+
+    /**
+     * Create the headers for the token request.
+     *
+     * @return array{Authorization: string, Accept: string}
+     */
+    protected function getTokenHeaders($code): array
+    {
+        return array_merge(parent::getTokenHeaders($code), [
+            'Authorization' => 'Basic ' . base64_encode($this->clientId . ':' . $this->clientSecret),
+        ]);
+    }
+
+    /**
+     * Map the raw user array to a Socialite User instance.
+     *
+     * @param array{id: string, name: string} $user
+     */
+    protected function mapUserToObject(array $user): User
+    {
+        return (new User())->setRaw($user)->map([
+            'id' => $user['id'],
+            'name' => $user['name'],
+        ]);
+    }
+
+    /**
+     * Get the refresh token response for the given refresh token.
+     *
+     * @param string $refreshToken
+     * @return array{access_token: string, expires_in: int, refresh_token: string, scope: string}
+     */
+    protected function getRefreshTokenResponse($refreshToken): array
+    {
+        $response = json_decode($this->getHttpClient()->post($this->getTokenUrl(), [
+            RequestOptions::HEADERS => $this->getTokenHeaders($refreshToken),
+            RequestOptions::FORM_PARAMS => [
+                'grant_type' => 'refresh_token',
+                'refresh_token' => $refreshToken,
+            ],
+        ])->getBody(), true);
+
+        return array_merge($response, ['refresh_token' => $refreshToken]);
+    }
+}

--- a/src/Aikido/README.md
+++ b/src/Aikido/README.md
@@ -1,0 +1,69 @@
+# Aikido
+
+```bash
+composer require socialiteproviders/aikido
+```
+
+## Installation & Basic Usage
+
+Please see the [Base Installation Guide](https://socialiteproviders.com/usage/), then follow the provider specific instructions below.
+
+### Add configuration to `config/services.php`
+
+```php
+'aikido' => [
+    'client_id' => env('AIKIDO_KEY'),
+    'client_secret' => env('AIKIDO_SECRET'),
+    'redirect' => env('AIKIDO_REDIRECT_URI')
+],
+```
+
+### Add provider event listener
+
+#### Laravel 11+
+
+In Laravel 11, the default `EventServiceProvider` provider was removed. Instead, add the listener using the `listen` method on the `Event` facade, in your `AppServiceProvider` `boot` method.
+
+* Note: You do not need to add anything for the built-in socialite providers unless you override them with your own providers.
+
+```php
+Event::listen(function (\SocialiteProviders\Manager\SocialiteWasCalled $event) {
+    $event->extendSocialite('aikido', \SocialiteProviders\Aikido\Provider::class);
+});
+```
+<details>
+<summary>
+Laravel 10 or below
+</summary>
+Configure the package's listener to listen for `SocialiteWasCalled` events.
+
+Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. See the [Base Installation Guide](https://socialiteproviders.com/usage/) for detailed instructions.
+
+```php
+protected $listen = [
+    \SocialiteProviders\Manager\SocialiteWasCalled::class => [
+        // ... other providers
+        \SocialiteProviders\Aikido\AikidoExtendSocialite::class.'@handle',
+    ],
+];
+```
+</details>
+
+### Usage
+
+You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
+
+```php
+return Socialite::driver('aikido')->redirect();
+```
+
+### Returned Workspace fields
+
+- ``id``
+- ``name``
+- ``linked_provider``
+- ``linked_provider_org_name``
+
+### Reference
+
+- [Aikido Developer Hub](https://apidocs.aikido.dev/)

--- a/src/Aikido/README.md
+++ b/src/Aikido/README.md
@@ -61,8 +61,6 @@ return Socialite::driver('aikido')->redirect();
 
 - ``id``
 - ``name``
-- ``linked_provider``
-- ``linked_provider_org_name``
 
 ### Reference
 

--- a/src/Aikido/composer.json
+++ b/src/Aikido/composer.json
@@ -13,7 +13,7 @@
         {
             "name": "Oliver Nybroe",
             "email": "oliver@laravel.com"
-        },
+        }
     ],
     "support": {
         "issues": "https://github.com/socialiteproviders/providers/issues",

--- a/src/Aikido/composer.json
+++ b/src/Aikido/composer.json
@@ -1,0 +1,33 @@
+{
+    "name": "socialiteproviders/aikido",
+    "description": "Aikido OAuth2 Provider for Laravel Socialite",
+    "license": "MIT",
+    "keywords": [
+        "aikido",
+        "laravel",
+        "oauth",
+        "provider",
+        "socialite"
+    ],
+    "authors": [
+        {
+            "name": "Oliver Nybroe",
+            "email": "oliver@laravel.com"
+        },
+    ],
+    "support": {
+        "issues": "https://github.com/socialiteproviders/providers/issues",
+        "source": "https://github.com/socialiteproviders/providers",
+        "docs": "https://socialiteproviders.com/aikido"
+    },
+    "require": {
+        "php": "^8.0",
+        "ext-json": "*",
+        "socialiteproviders/manager": "^4.4"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialiteProviders\\Aikido\\": ""
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for Aikido's OAuth provider
https://apidocs.aikido.dev/ 

Aikido does not have a user endpoint, but have a workspace endpoint instead. An authentication is tied to the workspace, not to the specific user. 

Aikido is also one of the providers which uses `Basic` auth in the headers for client and secret for their token requests.