### PR TITLE
fix: Aikido - add basic auth header for token request

### DIFF
--- a/src/Aikido/Provider.php
+++ b/src/Aikido/Provider.php
@@ -41,6 +41,16 @@ class Provider extends AbstractProvider
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function getTokenHeaders($code): array
+    {
+        return array_merge(parent::getTokenHeaders($code), [
+            'Authorization' => 'Basic ' . base64_encode($this->clientId . ':' . $this->clientSecret),
+        ]);
+    }
+
+    /**
      * Map the raw user array to a Socialite User instance.
      *
      * @param  array{id: string, name: string}  $user


### PR DESCRIPTION
Adding back the Basic auth header for the token request which was removed as part of the reviewing process. 

Without it the following error will happen
```
    Client error: `POST https://app.aikido.dev/api/oauth/token` resulted in a `401 Unauthorized` response:
    {"error":"invalid_client","error_description":"The request is missing an Authorization header"}
```
