### PR TITLE
Fixes #1231; Null tenant info being returned. 

### DIFF
--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -3,6 +3,7 @@
 namespace SocialiteProviders\Microsoft;
 
 use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
@@ -149,7 +150,7 @@ class Provider extends AbstractProvider
                     ]
                 );
                 $formattedResponse['tenant'] = json_decode((string) $responseTenant->getBody(), true)['value'][0] ?? null;
-            } catch (ClientException) {
+            } catch (ServerException) {
                 //if exception then tenant does not exist.
                 $formattedResponse['tenant'] = null;
             }

--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -3,7 +3,7 @@
 namespace SocialiteProviders\Microsoft;
 
 use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Exception\ServerException;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
@@ -150,7 +150,7 @@ class Provider extends AbstractProvider
                     ]
                 );
                 $formattedResponse['tenant'] = json_decode((string) $responseTenant->getBody(), true)['value'][0] ?? null;
-            } catch (ServerException) {
+            } catch (RequestException) {
                 //if exception then tenant does not exist.
                 $formattedResponse['tenant'] = null;
             }

--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -134,7 +134,7 @@ class Provider extends AbstractProvider
             }
         }
 
-        if ($this->getConfig('tenant', 'common') === 'common' && $this->getConfig('include_tenant_info', false)) {
+        if ($this->getConfig('include_tenant_info', false)) {
             try {
                 $responseTenant = $this->getHttpClient()->get(
                     'https://graph.microsoft.com/v1.0/organization',


### PR DESCRIPTION
I encountered an issue when using `include_tenant_info` where the tenant info being returned was null every time. The issue was caused by a forced use of the common tenant when fetching tenant info.
```php
$this->getConfig('tenant', 'common') === 'common'
```
I can't find a reason for why this was here, as it prevents users who are using a custom tenant ID or the `organizations` tenant from fetching tenant info. I can confirm tenant info began being returned again after removing the check. It still works with the `common` tenant, `organizations`  tenant, `consumers` tenant, and a custom `tenant identifier`.

In addition, when a user logs in with an account where the tenant does not exists (ex a personal account), Microsoft returns a 500 error. Currently, the exception being caught is a `ClientException` when it should be a `ServerException`. This fixes the 500 error when users login with a consumer account.

This will close #1231 