### PR TITLE
fix: slack set user scopes

### DIFF
--- a/src/Slack/Provider.php
+++ b/src/Slack/Provider.php
@@ -30,6 +30,13 @@ class Provider extends AbstractProvider
         return $this;
     }
 
+    public function setUserScopes($scopes)
+    {
+        $this->userScopes = (array) $scopes;
+
+        return $this;
+    }
+
     protected function getCodeFields($state = null)
     {
         $fields = parent::getCodeFields($state);


### PR DESCRIPTION
Slack does not allow you to use the legacy scopes for marketplace apps, so requesting the profile info fails marketplace review. This lets you zero out the scopes (getting using info fails, but the info is still abv on the access token response).