### PR TITLE
Microsoft - Update email field to return mail

### DIFF
--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -179,7 +179,7 @@ class Provider extends AbstractProvider
             'id'       => $user['id'],
             'nickname' => null,
             'name'     => $user['displayName'],
-            'email'    => $user['userPrincipalName'],
+            'email'    => $user['mail'],
             'avatar'   => Arr::get($user, 'avatar'),
 
             'businessPhones'    => Arr::get($user, 'businessPhones'),


### PR DESCRIPTION
The base package `laravel/socialite` has the method `getEmail` within the class [AbstractUser](https://github.com/laravel/socialite/blob/5.x/src/AbstractUser.php#L94). Within `mapUserToObject` it is returning `userPrincipalName` in the email field, therefor `getEmail` is returning an empty string.

This PR is to return the correct field. 

Side note the `userPrincipalName` is return on #195 of the provider.