### PR TITLE
Use LinkedIn sign in with Open ID 

### DIFF
--- a/src/LinkedIn/Provider.php
+++ b/src/LinkedIn/Provider.php
@@ -2,11 +2,11 @@
 
 namespace SocialiteProviders\LinkedIn;
 
-use Laravel\Socialite\Two\LinkedInProvider;
+use Laravel\Socialite\Two\LinkedInOpenIdProvider;
 use SocialiteProviders\Manager\ConfigTrait;
 use SocialiteProviders\Manager\Contracts\OAuth2\ProviderInterface;
 
-class Provider extends LinkedInProvider implements ProviderInterface
+class Provider extends LinkedInOpenIdProvider implements ProviderInterface
 {
     use ConfigTrait;
 


### PR DESCRIPTION
Since August 2023 LinkedIn [deprecated](https://learn.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin) their older sign-in which is still used here. The new provider was added to Socialite so it should be used here.
#1115