### PR TITLE
No need to use getConfig() for client_id and client_secret

### DIFF
--- a/src/AutodeskAPS/Provider.php
+++ b/src/AutodeskAPS/Provider.php
@@ -41,7 +41,7 @@ class Provider extends AbstractProvider
     protected function getCodeFields($state = null)
     {
         $fields = [
-            'client_id'     => $this->getConfig('client_id') ?? $this->clientId,
+            'client_id'     => $this->clientId,
             'redirect_uri'  => $this->getConfig('redirect') ?? $this->redirectUrl,
             'scope'         => $this->formatScopes($this->getScopes(), $this->scopeSeparator),
             'response_type' => 'code',
@@ -82,7 +82,7 @@ class Provider extends AbstractProvider
      */
     protected function getTokenHeaders($code): array
     {
-        $base64 = base64_encode(($this->getConfig('client_id') ?? $this->clientId).':'.($this->getConfig('client_secret') ?? $this->clientSecret));
+        $base64 = base64_encode("{$this->clientId}:{$this->clientSecret}");
 
         return [
             'Content-Type'  => 'application/x-www-form-urlencoded',

--- a/src/AutodeskAPS/Provider.php
+++ b/src/AutodeskAPS/Provider.php
@@ -42,7 +42,7 @@ class Provider extends AbstractProvider
     {
         $fields = [
             'client_id'     => $this->clientId,
-            'redirect_uri'  => $this->getConfig('redirect') ?? $this->redirectUrl,
+            'redirect_uri'  => $this->redirectUrl,
             'scope'         => $this->formatScopes($this->getScopes(), $this->scopeSeparator),
             'response_type' => 'code',
         ];
@@ -67,7 +67,7 @@ class Provider extends AbstractProvider
         $fields = [
             'grant_type'   => 'authorization_code',
             'code'         => $code,
-            'redirect_uri' => $this->getConfig('redirect') ?? $this->redirectUrl,
+            'redirect_uri' => $this->redirectUrl,
         ];
 
         if ($this->usesPKCE()) {

--- a/src/Cognito/Provider.php
+++ b/src/Cognito/Provider.php
@@ -104,7 +104,7 @@ class Provider extends AbstractProvider
     public function logoutCognitoUser(): string
     {
         $authHost = $this->getConfig('host');
-        $clientId = $this->getConfig('client_id');
+        $clientId = $this->clientId;
         $logoutUri = $this->getConfig('logout_uri');
 
         return sprintf('%s/logout?client_id=%s&logout_uri=%s', $authHost, $clientId, $logoutUri);
@@ -120,7 +120,7 @@ class Provider extends AbstractProvider
         $authHost = $this->getConfig('host');
 
         return sprintf('%s/logout?', $authHost).http_build_query([
-            'client_id'     => $this->getConfig('client_id'),
+            'client_id'     => $this->clientId,
             'redirect_uri'  => $this->getConfig('redirect'),
             'response_type' => 'code',
             'scope'         => $this->formatScopes($this->getScopes(), $this->scopeSeparator),

--- a/src/Cognito/Provider.php
+++ b/src/Cognito/Provider.php
@@ -121,7 +121,7 @@ class Provider extends AbstractProvider
 
         return sprintf('%s/logout?', $authHost).http_build_query([
             'client_id'     => $this->clientId,
-            'redirect_uri'  => $this->getConfig('redirect'),
+            'redirect_uri'  => $this->redirectUrl,
             'response_type' => 'code',
             'scope'         => $this->formatScopes($this->getScopes(), $this->scopeSeparator),
         ]);


### PR DESCRIPTION
No need to use `getConfig()` for `client_id`, `client_secret` and `redirect`