### PR TITLE
handle user name empty values

### DIFF
--- a/src/AzureADB2C/Provider.php
+++ b/src/AzureADB2C/Provider.php
@@ -188,8 +188,8 @@ class Provider extends AbstractProvider
     {
         return (new User)->setRaw($user)->map([
             'id'       => $user['sub'],
-            'nickname' => $user['name'],
-            'name'     => $user['name'],
+            'nickname' => $user['name'] ?? null,
+            'name'     => $user['name'] ?? null,
             'email'    => $user['emails'][0] ?? $user['email'] ?? null,
         ]);
     }


### PR DESCRIPTION
Handle null values for 'nickname' and 'name' in AzureADB2C Provider

Updated the mapUserToObject method to handle empty/null values for 'nickname' and 'name' attributes when mapping user data.  This update ensures compatibility with Azure AD B2C tenants where these user attributes might not be provided or required.