### PR TITLE
Microsoft provider - replace tenant api catch all when user is identified as a consumer type

### DIFF
--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -2,16 +2,25 @@
 
 namespace SocialiteProviders\Microsoft;
 
+use Exception;
+use Firebase\JWT\JWK;
+use Firebase\JWT\JWT;
 use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
+use Laravel\Socialite\Two\InvalidStateException;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Microsoft\MicrosoftUser as User;
 
 class Provider extends AbstractProvider
 {
     public const IDENTIFIER = 'MICROSOFT';
+
+    /**
+     * The tenant id associated with personal Microsoft accounts (services like Xbox, Teams for Life, or Outlook).
+     * Note: only reported in JWT ID_TOKENs and not in call's to Graph Organization endpoint.
+     */
+    public const MS_ENTRA_CONSUMER_TENANT_ID = '9188040d-6c67-4c5b-b112-36a304b66dad';
 
     /**
      * Default field list to request from Microsoft.
@@ -126,26 +135,25 @@ class Provider extends AbstractProvider
             }
         }
 
-        if ($this->getConfig('include_tenant_info', false)) {
-            try {
-                $responseTenant = $this->getHttpClient()->get(
-                    'https://graph.microsoft.com/v1.0/organization',
-                    [
-                        RequestOptions::HEADERS => [
-                            'Accept'        => 'application/json',
-                            'Authorization' => 'Bearer '.$token,
-                        ],
-                        RequestOptions::QUERY => [
-                            '$select' => implode(',', array_merge(self::DEFAULT_FIELDS_TENANT, $this->getConfig('tenant_fields', []))),
-                        ],
-                        RequestOptions::PROXY => $this->getConfig('proxy'),
-                    ]
-                );
-                $formattedResponse['tenant'] = json_decode((string) $responseTenant->getBody(), true)['value'][0] ?? null;
-            } catch (RequestException) {
-                //if exception then tenant does not exist.
-                $formattedResponse['tenant'] = null;
-            }
+        $formattedResponse['tenant'] = null;
+
+        if ($this->getConfig('include_tenant_info', false) && ! $this->isConsumerTenant()) {
+
+            $responseTenant = $this->getHttpClient()->get(
+                'https://graph.microsoft.com/v1.0/organization',
+                [
+                    RequestOptions::HEADERS => [
+                        'Accept'        => 'application/json',
+                        'Authorization' => 'Bearer '.$token,
+                    ],
+                    RequestOptions::QUERY => [
+                        '$select' => implode(',', array_merge(self::DEFAULT_FIELDS_TENANT, $this->getConfig('tenant_fields', []))),
+                    ],
+                    RequestOptions::PROXY => $this->getConfig('proxy'),
+                ]
+            );
+
+            $formattedResponse['tenant'] = json_decode((string) $responseTenant->getBody(), true)['value'][0] ?? null;
         }
 
         return $formattedResponse;
@@ -189,6 +197,7 @@ class Provider extends AbstractProvider
 
             'tenant' => Arr::get($user, 'tenant'),
         ]);
+
     }
 
     /**
@@ -212,5 +221,143 @@ class Provider extends AbstractProvider
             'tenant_fields',
             'proxy',
         ];
+    }
+
+    /**
+     * Check the ID_TOKEN for tenant details via JWT decode.
+     * https://learn.microsoft.com/en-us/entra/identity-platform/optional-claims
+     *
+     * @return bool
+     */
+    public function isConsumerTenant(): bool
+    {
+        if ($idToken = $this->parseIdToken($this->credentialsResponseBody)) {
+
+            $claims = $this->validate($idToken);
+
+            return ($claims?->tid ?? '') === self::MS_ENTRA_CONSUMER_TENANT_ID;
+        }
+
+        return false;
+    }
+
+    /**
+     * When Scope includes 'openid' or 'profile' the ID_TOKEN is made available to us.
+     * https://learn.microsoft.com/en-us/entra/identity-platform/id-tokens
+     *
+     * @param  $body
+     * @return array|\ArrayAccess|mixed
+     */
+    protected function parseIdToken($body)
+    {
+        return Arr::get($body, 'id_token');
+    }
+
+    /**
+     * Get public keys to verify id_token from jwks_uri.
+     * Retrieves the list of public keys in the JWKS format (JSON Web Key Set)
+     *
+     * @return array
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    private function getJWTKeys(): array
+    {
+        $response = $this->getHttpClient()->get($this->getOpenIdConfiguration()->jwks_uri);
+
+        return json_decode((string) $response->getBody(), true);
+    }
+
+    /**
+     * Get OpenID Configuration.
+     *
+     * @return mixed
+     *
+     * @throws \Laravel\Socialite\Two\InvalidStateException
+     */
+    private function getOpenIdConfiguration(): mixed
+    {
+        try {
+            // URI Discovery Mechanism for the Provider Configuration URI
+            //
+            // https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc#fetch-the-openid-configuration-document
+            //
+            $discovery = sprintf('https://login.microsoftonline.com/%s/v2.0/.well-known/openid-configuration', $this->getConfig('tenant', 'common'));
+
+            $response = $this->getHttpClient()->get($discovery);
+        } catch (Exception $ex) {
+            throw new InvalidStateException("Error on getting OpenID Configuration. {$ex}");
+        }
+
+        return json_decode((string) $response->getBody());
+    }
+
+    /**
+     * Extract algorithm from header, failing that defer to OIDC speced supported algorithms then service's default.
+     *
+     * @param  $jwtHeader
+     * @return string
+     */
+    private function getTokenSigningAlgorithm($jwtHeader): string
+    {
+        return $jwtHeader?->alg ?? (string) collect(
+            array_merge($this->getOpenIdConfiguration()->id_token_signing_alg_values_supported,
+                [$this->getConfig('default_algorithm', 'RS256')])
+        )->first();
+    }
+
+    /**
+     * validate id_token
+     * - signature validation using firebase/jwt library.
+     * - claims validation
+     * iss: MUST match iss = issuer value on metadata.
+     * aud: MUST include client_id for this client.
+     * exp: MUST time() < exp.
+     *
+     * @param  string  $idToken
+     * @return mixed|\stdClass
+     *
+     * @throws \Laravel\Socialite\Two\InvalidStateException
+     */
+    private function validate(string $idToken)
+    {
+        // https://learn.microsoft.com/en-us/entra/identity-platform/access-token-claims-reference
+        try {
+            [$headersB64, $payloadB64, $sig] = explode('.', $idToken);
+            $jwtHeaders = JWT::jsonDecode(JWT::urlsafeB64Decode($headersB64));
+
+            // decode body without signature check
+            // $jwtPayload = JWT::jsonDecode(JWT::urlsafeB64Decode($payloadB64));
+
+            // decode body with signature check
+            $alg = $this->getTokenSigningAlgorithm($jwtHeaders);
+            $headers = new \stdClass;
+            $jwtPayload = JWT::decode($idToken, JWK::parseKeySet($this->getJWTKeys(), $alg), $headers);
+
+            // iss validation -  a security token service (STS) URI
+            // Identifies the STS that constructs and returns the token, and the Microsoft Entra tenant of the authenticated user.
+            // https://learn.microsoft.com/en-au/entra/identity-platform/access-tokens#multitenant-applications
+            $issuer = str_replace('{tenantid}', $jwtPayload->tid, $this->getOpenIdConfiguration()->issuer);
+            if (strcmp($iss = $jwtPayload->iss, $issuer)) {
+                throw new InvalidStateException('iss on id_token does not match issuer value on the OpenID configuration');
+            }
+
+            // aud validation - an Application ID URI or GUID
+            // Identifies the intended audience of the token.
+            if (! str_contains($jwtPayload->aud, $this->config['client_id'])) {
+                throw new InvalidStateException('aud on id_token does not match the client_id for this application');
+            }
+
+            // exp validation - int, a Unix timestamp
+            // Specifies the expiration time before which the JWT can be accepted for processing.
+            if ((int) $jwtPayload->exp < time()) {
+                throw new InvalidStateException('id_token is expired');
+            }
+
+            return $jwtPayload;
+
+        } catch (Exception $e) {
+            throw new InvalidStateException("Error on validating id_token. {$e}");
+        }
     }
 }

--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -41,7 +41,13 @@ class Provider extends AbstractProvider
      */
     protected const DEFAULT_FIELDS_TENANT = ['id', 'displayName', 'city', 'country', 'countryLetterCode', 'state', 'street', 'verifiedDomains'];
 
-    protected $scopes = ['User.Read'];
+    /**
+     * {@inheritdoc}
+     * https://learn.microsoft.com/en-us/graph/permissions-overview
+     * https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#openid-connect-scopes
+     * https://learn.microsoft.com/en-us/entra/identity-platform/id-tokens
+     */
+    protected $scopes = ['openid', 'profile', 'User.Read'];
 
     protected $scopeSeparator = ' ';
 

--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -71,7 +71,7 @@ class Provider extends AbstractProvider
      */
     public function getLogoutUrl(?string $redirectUri = null)
     {
-        $logoutUrl = sprintf('https://login.microsoftonline.com/%s/oauth2/logout', $this->getConfig('tenant', 'common'));
+        $logoutUrl = sprintf('https://login.microsoftonline.com/%s/oauth2/v2.0/logout', $this->getConfig('tenant', 'common'));
 
         return $redirectUri === null ?
             $logoutUrl :

--- a/src/Microsoft/composer.json
+++ b/src/Microsoft/composer.json
@@ -23,6 +23,7 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
+        "firebase/php-jwt": "^6.8",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {


### PR DESCRIPTION
As per request for PR  in https://github.com/SocialiteProviders/Providers/issues/1029#issuecomment-1932034542

In the Microsoft provider we can skip any MS Graph API calls for Org/Tenant info  'https://graph.microsoft.com/v1.0/organization' when the user is identified as a consumer.

A new method `isConsumerTenant()` is used to verify and check the ID_TOKEN for tenant details via JWT decode.
> This essentially replaces the _catch_all_ try catch block (for failed API calls) used to determine tenant existence or not.

Inspired by AzureADB2C, XERO ( see  https://github.com/SocialiteProviders/Providers/blob/master/src/AzureADB2C/Provider.php#L168 )

----

1. Including 'openid' and 'profile' is the scope request allows the ID_TOKEN to be inspected and claims to be decoded.

  * https://learn.microsoft.com/en-us/azure/active-directory/ develop/id-tokens
  * https://learn.microsoft.com/en-us/answers/questions/1289403/determine-organisationid-tenant-upon-oauth2-login


2. Utilise Openid-configuration is a URI defined within OpenID Connect (OIDC)  which provides configuration information about the Identity Provider (IDP).
> Inspired by AzureADB2C, XERO, SURFContext, LifeScienceLogin use of OIDC

* Remove need to check the `getConfig('tenant', 'common') === 'common'` as no longer required, we check API rather than catch server failure 500.
* allow other config('tenant') values to be used and retrieve the tenant (organisation) data, where the options supported are defined at

https://learn.microsoft.com/en-au/entra/identity-platform/v2-protocols#endpoints

> The {issuer} value in the path of the request can be used to control who can sign into the application.
> `common` - for both Microsoft accounts and work or school accounts,
> `organizations` - for work or school accounts only,
> `consumers` - for Microsoft accounts only,
> `tenant identifiers` - such as the tenant ID or domain name.

