### PR TITLE
Fix Threads - no avatar default value

### DIFF
--- a/src/Threads/Provider.php
+++ b/src/Threads/Provider.php
@@ -73,7 +73,7 @@ class Provider extends AbstractProvider
             'nickname'     => Arr::get($user, 'username'),
             'name'         => null,
             'email'        => null,
-            'avatar'       => Arr::get($user, 'threads_profile_picture_url'),
+            'avatar'       => Arr::get($user, 'threads_profile_picture_url', ''),
         ]);
     }
 }


### PR DESCRIPTION
Fix for account connection if no avatar is set.

Property avatar cannot be null.