### PR TITLE
Fix documentation title for Klarna provider

### DIFF
--- a/src/Klarna/README.md
+++ b/src/Klarna/README.md
@@ -1,4 +1,4 @@
-# Intercom
+# Klarna
 
 ```bash
 composer require socialiteproviders/klarna


### PR DESCRIPTION
The Klarna provider documentation title is wrong (Intercom). It seems like a copy/paste error.