### PR TITLE
Change the function visibility of Zendesk's getSubdomain

### DIFF
--- a/src/Zendesk/Provider.php
+++ b/src/Zendesk/Provider.php
@@ -60,7 +60,7 @@ class Provider extends AbstractProvider
      *
      * @return string
      */
-    private function getSubdomain()
+    protected function getSubdomain()
     {
         return $this->getConfig('subdomain');
     }


### PR DESCRIPTION
Hi, I'm writing an integration for Zendesk that works globally, so I need to be able to change the subdomain dynamically. I extended the Provider but need to override this method 😄 