### PR TITLE
Fix: diffrent request resposne from diffrent hosts

### DIFF
--- a/src/Steam/Provider.php
+++ b/src/Steam/Provider.php
@@ -219,15 +219,9 @@ class Provider extends AbstractProvider
      */
     private function normalizeOpenidKeys()
     {
-        $normalized = [];
-        foreach ($this->request->all() as $key => $value) {
-            if (str_starts_with($key, 'openid_')) {
-                $normalizedKey = 'openid.'.substr($key, 7);
-            } else {
-                $normalizedKey = $key;
-            }
-            $normalized[$normalizedKey] = $value;
-        }
+        $normalized = $this->request->collect()->mapWithKeys(function ($value, $key) {
+            return [preg_replace('/^openid_/', 'openid.', $key) => $value];
+        })->all();
 
         $this->request->replace($normalized);
     }

--- a/src/Steam/Provider.php
+++ b/src/Steam/Provider.php
@@ -40,17 +40,17 @@ class Provider extends AbstractProvider
     /**
      * @var string
      */
-    public const OPENID_SIG = 'openid_sig';
+    public const OPENID_SIG = 'openid.sig';
 
     /**
      * @var string
      */
-    public const OPENID_SIGNED = 'openid_signed';
+    public const OPENID_SIGNED = 'openid.signed';
 
     /**
      * @var string
      */
-    public const OPENID_ASSOC_HANDLE = 'openid_assoc_handle';
+    public const OPENID_ASSOC_HANDLE = 'openid.assoc_handle';
 
     /**
      * @var string

--- a/src/Steam/Provider.php
+++ b/src/Steam/Provider.php
@@ -60,7 +60,17 @@ class Provider extends AbstractProvider
     /**
      * @var string
      */
-    public const OPENID_ERROR = 'openid_error';
+    public const OPENID_ERROR = 'openid.error';
+
+    /**
+     * @var string
+     */
+    public const OPENID_RETURN_TO = 'openid.return_to';
+
+    /**
+     * @var string
+     */
+    public const OPENID_CLAIMED_ID = 'openid.claimed_id';
 
     /**
      * {@inheritdoc}
@@ -160,11 +170,13 @@ class Provider extends AbstractProvider
      */
     public function validate()
     {
+        $this->normalizeOpenidKeys();
+
         if (! $this->requestIsValid()) {
             throw new OpenIDValidationException('A critical openid parameter is missing from the request');
         }
 
-        if (! $this->validateHost($this->request->get('openid_return_to'))) {
+        if (! $this->validateHost($this->request->get(self::OPENID_RETURN_TO))) {
             throw new OpenIDValidationException('Invalid return_to host');
         }
 
@@ -198,6 +210,26 @@ class Provider extends AbstractProvider
         return $this->request->has(self::OPENID_ASSOC_HANDLE)
             && $this->request->has(self::OPENID_SIGNED)
             && $this->request->has(self::OPENID_SIG);
+    }
+
+    /**
+     * Normlize openid keys from diffrent requests
+     *
+     * @return void
+     */
+    private function normalizeOpenidKeys()
+    {
+        $normalized = [];
+        foreach ($this->request->all() as $key => $value) {
+            if (str_starts_with($key, 'openid_')) {
+                $normalizedKey = 'openid.'.substr($key, 7);
+            } else {
+                $normalizedKey = $key;
+            }
+            $normalized[$normalizedKey] = $value;
+        }
+
+        $this->request->replace($normalized);
     }
 
     /**
@@ -238,7 +270,7 @@ class Provider extends AbstractProvider
         $signedParams = explode(',', $this->request->get(self::OPENID_SIGNED));
 
         foreach ($signedParams as $item) {
-            $value = $this->request->get('openid_'.str_replace('.', '_', $item));
+            $value = $this->request->get('openid.'.str_replace('.', '_', $item));
             $params['openid.'.$item] = $value;
         }
 
@@ -277,7 +309,7 @@ class Provider extends AbstractProvider
     {
         preg_match(
             '#^https?://steamcommunity.com/openid/id/([0-9]{17,25})#',
-            $this->request->get('openid_claimed_id'),
+            $this->request->get(self::OPENID_CLAIMED_ID),
             $matches
         );
 

--- a/src/Steam/Provider.php
+++ b/src/Steam/Provider.php
@@ -161,7 +161,7 @@ class Provider extends AbstractProvider
     public function validate()
     {
         if (! $this->requestIsValid()) {
-            return false;
+            throw new OpenIDValidationException('A critical openid parameter is missing from the request');
         }
 
         if (! $this->validateHost($this->request->get('openid_return_to'))) {


### PR DESCRIPTION
This pull request addresses an inconsistency in OpenID request responses observed between local development and AWS Lambda deployments. 

- **Normalization:** The code now normalizes OpenID request keys by consistently using the `openid.` previously it was sometimes `openid_` and other times`openid.` depending on where the code was executed. This ensures consistent handling across different environments.
- **Constant Definitions:** Introduced constants for common OpenID keys (`self::OPENID_RETURN_TO`, `self::OPENID_CLAIMED_ID`) to improve code readability, maintainability, and reduce the risk of typos.
- **Improved Error Handling:** Replaced the generic "unknown error" return with a more specific `OpenIDValidationException` when critical OpenID parameters are missing from the request, enhancing debugging and error handling.

This change ensures more robust and predictable behavior of the OpenID integration across different environments.