### PR TITLE
new oauth provider for linux.do forum

### DIFF
--- a/src/LinuxDo/LinuxDoExtendSocialite.php
+++ b/src/LinuxDo/LinuxDoExtendSocialite.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SocialiteProviders\LinuxDo;
+
+use SocialiteProviders\Manager\SocialiteWasCalled;
+
+class LinuxDoExtendSocialite
+{
+    /**
+     * Register the provider.
+     *
+     * @param  \SocialiteProviders\Manager\SocialiteWasCalled  $socialiteWasCalled
+     * @return void
+     */
+    public function handle(SocialiteWasCalled $socialiteWasCalled)
+    {
+        $socialiteWasCalled->extendSocialite('linux_do', Provider::class);
+    }
+}

--- a/src/LinuxDo/Provider.php
+++ b/src/LinuxDo/Provider.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace SocialiteProviders\LinuxDo;
+
+use GuzzleHttp\RequestOptions;
+use Illuminate\Support\Facades\Log;
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
+use SocialiteProviders\Manager\OAuth2\User;
+
+class Provider extends AbstractProvider
+{
+    const IDENTIFIER = 'LINUX_DO';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopes = ['profile', 'email'];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAuthUrl($state)
+    {
+        return $this->buildAuthUrlFromBase('https://connect.linux.do/oauth2/authorize', $state);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenUrl()
+    {
+        return 'https://connect.linux.do/oauth2/token';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByToken($token)
+    {
+        $response = $this->getHttpClient()->get('https://connect.linux.do/api/user', [
+            RequestOptions::HEADERS => [
+                'Authorization' => 'Bearer '.$token,
+            ],
+        ]);
+
+//        Log::warning("LinuxDO Hint getUserResponse:", ["response"=>$response->getBody()]);
+
+        return json_decode((string) $response->getBody(), true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+//        Log::warning("LinuxDO Hint UserMap:", $user);
+        return (new User)->setRaw($user)->map([
+            'id'       => $user['id'],
+            'nickname' => $user['username'],
+            'name'     => $user['name'],
+            'email'    => $user['email'],
+            'avatar'  => $user['avatar_url'],
+        ]);
+    }
+}

--- a/src/LinuxDo/README.md
+++ b/src/LinuxDo/README.md
@@ -1,0 +1,70 @@
+# LinuxDo
+
+```bash
+composer require socialiteproviders/linuxdo
+```
+
+## Installation & Basic Usage
+
+Please see the [Base Installation Guide](https://socialiteproviders.com/usage/), then follow the provider specific instructions below.
+
+### Add configuration to `config/services.php`
+
+```php
+'linux_do' => [
+    'client_id' => env('LINUXDO_CLIENT_ID'),
+    'client_secret' => env('LINUXDO_CLIENT_SECRET'),
+    'redirect' => env('LINUXDO_REDIRECT_URI'),
+],
+```
+
+### Add provider event listener
+
+#### Laravel 11+
+
+In Laravel 11, the default `EventServiceProvider` provider was removed. Instead, add the listener using the `listen` method on the `Event` facade, in your `AppServiceProvider` `boot` method.
+
+* Note: You do not need to add anything for the built-in socialite providers unless you override them with your own providers.
+
+```php
+Event::listen(function (\SocialiteProviders\Manager\SocialiteWasCalled $event) {
+    $event->extendSocialite('linux_do', \SocialiteProviders\LinuxDo\Provider::class);
+});
+```
+<details>
+<summary>
+Laravel 10 or below
+</summary>
+Configure the package's listener to listen for `SocialiteWasCalled` events.
+
+Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. See the [Base Installation Guide](https://socialiteproviders.com/usage/) for detailed instructions.
+
+```php
+protected $listen = [
+    \SocialiteProviders\Manager\SocialiteWasCalled::class => [
+        // ... other providers
+        \SocialiteProviders\LinuxDo\LinuxDoExtendSocialite::class.'@handle',
+    ],
+];
+```
+</details>
+
+### Usage
+
+You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
+
+```php
+return Socialite::driver('linux_do')->redirect();
+```
+
+### Returned User fields
+
+- ``id``
+- ``nickname``
+- ``name``
+- ``email``
+- ``avatar``
+
+### Reference
+
+- [Create Linux.do OAuth2 Application](https://connect.linux.do/)

--- a/src/LinuxDo/composer.json
+++ b/src/LinuxDo/composer.json
@@ -1,0 +1,33 @@
+{
+    "name": "socialiteproviders/linuxdo",
+    "description": "LinuxDo OAuth2 Provider for Laravel Socialite",
+    "license": "MIT",
+    "keywords": [
+        "linuxdo",
+        "linux.do",
+        "oauth",
+        "socialite",
+        "provider"
+    ],
+    "authors": [
+        {
+            "name": "Travis Tang",
+            "email": "me@investravis.com"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/Travisun/oauthProviders/issues",
+        "source": "https://github.com/Travisun/oauthProviders",
+        "docs": "https://github.com/Travisun/oauthProviders"
+    },
+    "require": {
+        "php": "^8.0",
+        "ext-json": "*",
+        "socialiteproviders/manager": "^4.4"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialiteProviders\\LinuxDo\\": ""
+        }
+    }
+}


### PR DESCRIPTION
Linux.do is a Chinese online communication community with a high-value forum of more than 200,000 online users, who discuss topics about life, technology, entrepreneurship, emerging businesses, cutting-edge technology, finance, etc. This move aims to provide an Oauth2 login standard provider to enrich the Socialite provider list, so that the Socialite concept can benefit more than 200,000 global citizens.