### PR TITLE
fix(steam): add referer and origin http headers to steam provider because of 403 Forbidden HTTP error

### DIFF
--- a/src/Steam/Provider.php
+++ b/src/Steam/Provider.php
@@ -234,6 +234,7 @@ class Provider extends AbstractProvider
         return [
             RequestOptions::FORM_PARAMS => $this->getParams(),
             RequestOptions::PROXY       => $this->getConfig('proxy'),
+            RequestOptions::HEADERS     => $this->getHeaders(),
         ];
     }
 
@@ -269,6 +270,15 @@ class Provider extends AbstractProvider
         }
 
         return $params;
+    }
+
+    public function getHeaders(): array
+    {
+        // Without it Steam returns 403 Forbidden
+        return [
+            'referer' => 'https://steamcommunity.com/',
+            'origin'  => 'https://steamcommunity.com',
+        ];
     }
 
     /**


### PR DESCRIPTION
This code fixes error shown on image below.

![image](https://github.com/user-attachments/assets/69f85596-ebe4-4792-adb0-4a2a9297e306)

This also was implemented in https://github.com/DoctorMcKay/node-steam-signin/commit/5cc818647f14e33981f3f09e2a405aad1787c684

