### PR TITLE
Dropbox does not return a refresh_token

### DIFF
--- a/src/Dropbox/Provider.php
+++ b/src/Dropbox/Provider.php
@@ -19,6 +19,8 @@ class Provider extends AbstractProvider
 
     protected function getAuthUrl($state): string
     {
+        $this->parameters['token_access_type'] = 'offline';
+        
         return $this->buildAuthUrlFromBase('https://www.dropbox.com/oauth2/authorize', $state);
     }
 


### PR DESCRIPTION
According to the Dropbox Developer docs a refresh_token is only returned, when `token_access_type=offline` is provided during the initial request to `/oauth2/authorize`.

This PR adds the required parameters so that a refresh token is returned.