### PR TITLE
Dropbox does not return a refresh_token

### DIFF
--- a/src/Dropbox/Provider.php
+++ b/src/Dropbox/Provider.php
@@ -19,6 +19,8 @@ class Provider extends AbstractProvider
 
     protected function getAuthUrl($state): string
     {
+        $this->parameters['token_access_type'] = 'offline';
+        
         return $this->buildAuthUrlFromBase('https://www.dropbox.com/oauth2/authorize', $state);
     }
 


### PR DESCRIPTION
According to the Dropbox Developer docs a `refresh_token` is only returned, when `token_access_type=offline` is provided during the initial request to `/oauth2/authorize`.

This PR adds the required parameters so that a refresh token is returned.

# Scenario

I am using Socialite for authenticating multiple third party services to accounts in my application so that my application perform API requests on behalf of my users. In order for my application to not have to request my users to re-authenticate every time the access_token expires, I built a auto-refresh TokenProvider architecture. For this to work I need a `refresh_token` returned, otherwise I can not perform a token refresh.  