### PR TITLE
Update scopes For SSO Login

### DIFF
--- a/src/Instagram/Provider.php
+++ b/src/Instagram/Provider.php
@@ -19,7 +19,7 @@ class Provider extends AbstractProvider
      */
     protected $fields = ['account_type', 'id', 'username', 'media_count'];
 
-    protected $scopes = ['instagram_business_basic', 'instagram_business_content_publish', 'instagram_business_manage_messages', 'instagram_business_manage_comments'];
+    protected $scopes = ['instagram_business_basic'];
 
     protected function getAuthUrl($state): string
     {

--- a/src/Instagram/Provider.php
+++ b/src/Instagram/Provider.php
@@ -19,7 +19,7 @@ class Provider extends AbstractProvider
      */
     protected $fields = ['account_type', 'id', 'username', 'media_count'];
 
-    protected $scopes = ['user_profile'];
+    protected $scopes = ['instagram_business_basic', 'instagram_business_content_publish', 'instagram_business_manage_messages', 'instagram_business_manage_comments'];
 
     protected function getAuthUrl($state): string
     {


### PR DESCRIPTION
Meta changed the scope for Instagram from `user_profile` to `'instagram_business_basic'`, `'instagram_business_content_publish'`, `'instagram_business_manage_messages'`, and `'instagram_business_manage_comments'`. I tested it on my local machine, and it works fine with the new scope. Can you merge my proposed changes?

meta developer doc link for your reference
[Scope Update](https://developers.facebook.com/docs/instagram-platform/instagram-api-with-instagram-login)
