### PR TITLE
fix: Clerk failing to map nickname when username empty

### DIFF
--- a/src/Clerk/Provider.php
+++ b/src/Clerk/Provider.php
@@ -68,11 +68,11 @@ class Provider extends AbstractProvider
     protected function mapUserToObject(array $user)
     {
         return (new User)->setRaw($user)->map([
-            'id'       => $user['user_id'],
-            'nickname' => $user['username'],
-            'name'     => $user['name'],
-            'email'    => $user['email'],
-            'avatar'   => $user['picture'],
+            'id' => $user['user_id'],
+            'nickname' => $user['username'] ?? ($user['given_name'] ?? explode('@', $user['email'])[0]),
+            'name' => $user['name'],
+            'email' => $user['email'],
+            'avatar' => $user['picture'],
         ]);
     }
 }


### PR DESCRIPTION
Username isn't always returned by Clerk and this is failing. Check for username to map otherwise use given_name or as fallback email address.

Issue: https://github.com/SocialiteProviders/Providers/issues/1308