### PR TITLE
feat: VK ID OAuth2 Provider

### DIFF
--- a/monorepo-builder.yml
+++ b/monorepo-builder.yml
@@ -222,6 +222,7 @@ parameters:
     src/Unsplash: 'git@github.com:SocialiteProviders/Unsplash.git'
     src/Untappd: 'git@github.com:SocialiteProviders/Untappd.git'
     src/Usos: 'git@github.com:SocialiteProviders/Usos.git'
+    src/VKID: 'git@github.com:SocialiteProviders/VKID.git'
     src/VKontakte: 'git@github.com:SocialiteProviders/VKontakte.git'
     src/Vatsim: 'git@github.com:SocialiteProviders/Vatsim.git'
     src/Venmo: 'git@github.com:SocialiteProviders/Venmo.git'

--- a/src/VKID/Provider.php
+++ b/src/VKID/Provider.php
@@ -78,29 +78,6 @@ class Provider extends AbstractProvider
     /**
      * {@inheritdoc}
      */
-    public function user()
-    {
-        if ($this->hasInvalidState()) {
-            throw new InvalidStateException();
-        }
-
-        $response = $this->getAccessTokenResponse($this->getCode());
-
-        $user = $this->mapUserToObject($this->getUserByToken($response));
-
-        $this->credentialsResponseBody = $response;
-
-        if ($user instanceof User) {
-            $user->setAccessTokenResponseBody($this->credentialsResponseBody);
-        }
-
-        return $user->setToken($this->parseAccessToken($response))
-            ->setExpiresIn($this->parseExpiresIn($response));
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([

--- a/src/VKID/Provider.php
+++ b/src/VKID/Provider.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace SocialiteProviders\VKID;
+
+use RuntimeException;
+use Illuminate\Support\Arr;
+use GuzzleHttp\RequestOptions;
+use SocialiteProviders\Manager\OAuth2\User;
+use Laravel\Socialite\Two\InvalidStateException;
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
+
+class Provider extends AbstractProvider
+{
+    /**
+     * Unique Provider Identifier.
+     */
+    public const IDENTIFIER = 'VKID';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $stateless = false;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $usesPKCE = true;
+
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopes = ['email'];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAuthUrl($state)
+    {
+        return $this->buildAuthUrlFromBase('https://id.vk.com/authorize', $state);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenUrl()
+    {
+        return 'https://id.vk.com/oauth2/auth';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByToken($token)
+    {
+        $response = $this->getHttpClient()->post('https://id.vk.com/oauth2/user_info', [
+            RequestOptions::HEADERS => ['Accept' => 'application/json'],
+            RequestOptions::FORM_PARAMS => [
+                'access_token' => $token['access_token'],
+                'client_id' => $this->clientId,
+            ],
+        ]);
+
+        $contents = (string) $response->getBody();
+
+        $response = json_decode($contents, true);
+
+        if (!is_array($response) || !isset($response['user'])) {
+            throw new RuntimeException(sprintf(
+                'Invalid JSON response from VK: %s',
+                $contents
+            ));
+        }
+
+        return $response['user'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function user()
+    {
+        if ($this->hasInvalidState()) {
+            throw new InvalidStateException();
+        }
+
+        $response = $this->getAccessTokenResponse($this->getCode());
+
+        $user = $this->mapUserToObject($this->getUserByToken($response));
+
+        $this->credentialsResponseBody = $response;
+
+        if ($user instanceof User) {
+            $user->setAccessTokenResponseBody($this->credentialsResponseBody);
+        }
+
+        return $user->setToken($this->parseAccessToken($response))
+            ->setExpiresIn($this->parseExpiresIn($response));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return (new User())->setRaw($user)->map([
+            'id'       => Arr::get($user, 'user_id'),
+            'name'     => trim(Arr::get($user, 'first_name') . ' ' . Arr::get($user, 'last_name')),
+            'email'    => Arr::get($user, 'email'),
+            'avatar'   => Arr::get($user, 'avatar'),
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenFields($code)
+    {
+        return array_merge(parent::getTokenFields($code), [
+            'grant_type' => 'authorization_code',
+            'device_id'  => $this->getDeviceId(),
+        ]);
+    }
+
+    /**
+     * Get the device_id from the request.
+     *
+     * @return string
+     */
+    protected function getDeviceId()
+    {
+        return $this->request->input('device_id');
+    }
+}

--- a/src/VKID/README.md
+++ b/src/VKID/README.md
@@ -1,0 +1,72 @@
+# VK ID
+
+```bash
+composer require socialiteproviders/vkid
+```
+
+## Register an application 
+
+Add new application at [vk.com](https://id.vk.com/about/business/go).
+
+## Installation & Basic Usage
+
+Please see the [Base Installation Guide](https://socialiteproviders.com/usage/), then follow the provider specific instructions below.
+
+### Add configuration to `config/services.php`
+
+```php
+'vkid' => [
+  'client_id' => env('VKID_CLIENT_ID'),
+  'client_secret' => env('VKID_CLIENT_SECRET'),
+  'redirect' => env('VKID_REDIRECT_URI')
+],
+```
+
+### Add provider event listener
+
+#### Laravel 11+
+
+In Laravel 11, the default `EventServiceProvider` provider was removed. Instead, add the listener using the `listen` method on the `Event` facade, in your `AppServiceProvider` `boot` method.
+
+* Note: You do not need to add anything for the built-in socialite providers unless you override them with your own providers.
+
+```php
+Event::listen(function (\SocialiteProviders\Manager\SocialiteWasCalled $event) {
+    $event->extendSocialite('vkid', \SocialiteProviders\VKID\Provider::class);
+});
+```
+<details>
+<summary>
+Laravel 10 or below
+</summary>
+Configure the package's listener to listen for `SocialiteWasCalled` events.
+
+Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. See the [Base Installation Guide](https://socialiteproviders.com/usage/) for detailed instructions.
+
+```php
+protected $listen = [
+    \SocialiteProviders\Manager\SocialiteWasCalled::class => [
+        // ... other providers
+        \SocialiteProviders\VKID\VKIDExtendSocialite::class.'@handle',
+    ],
+];
+```
+</details>
+
+### Usage
+
+You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
+
+```php
+return Socialite::driver('vkid')->redirect();
+```
+
+### Returned User fields
+- ``id``
+- ``name``
+- ``email``
+- ``avatar``
+
+### Reference
+
+- [VK ID Reference](https://id.vk.com/about/business/go/docs/ru/vkid/latest/methods)

--- a/src/VKID/VKIDExtendSocialite.php
+++ b/src/VKID/VKIDExtendSocialite.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SocialiteProviders\VKID;
+
+use SocialiteProviders\Manager\SocialiteWasCalled;
+
+class VKIDExtendSocialite
+{
+    /**
+     * Register the provider.
+     *
+     * @param \SocialiteProviders\Manager\SocialiteWasCalled $socialiteWasCalled
+     */
+    public function handle(SocialiteWasCalled $socialiteWasCalled)
+    {
+        $socialiteWasCalled->extendSocialite('vkid', Provider::class);
+    }
+}

--- a/src/VKID/composer.json
+++ b/src/VKID/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.4",
         "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },

--- a/src/VKID/composer.json
+++ b/src/VKID/composer.json
@@ -1,0 +1,34 @@
+{
+    "name": "socialiteproviders/vkid",
+    "description": "VK ID OAuth2 Provider for Laravel Socialite",
+    "keywords": [
+        "laravel",
+        "oauth",
+        "provider",
+        "socialite",
+        "vkontakte",
+        "vkid"
+    ],
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Vladimir Kharinenkov",
+            "email": "vhar@mail.ru"
+        }
+    ],
+    "require": {
+        "php": "^7.4 || ^8.0",
+        "ext-json": "*",
+        "socialiteproviders/manager": "^4.4"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialiteProviders\\VKID\\": ""
+        }
+    },
+    "support": {
+        "issues": "https://github.com/socialiteproviders/providers/issues",
+        "source": "https://github.com/socialiteproviders/providers",
+        "docs": "https://socialiteproviders.com/vkid"
+    }
+}


### PR DESCRIPTION
New VK ID OAuth2 Provider

[OAuth VKontakte](https://github.com/SocialiteProviders/Providers/tree/master/src/VKontakte) now is deprecated.  
Obtaining a user access key (access token) is now possible only through OAuth VK ID.   

[VK ID Reference](https://id.vk.com/about/business/go/docs/ru/vkid/latest/oauth-vk#OAuth-VKontakte)
