### PR TITLE
Fix incorrect namespace for Kakao provider in README

### DIFF
--- a/src/Kakao/README.md
+++ b/src/Kakao/README.md
@@ -28,7 +28,7 @@ In Laravel 11, the default `EventServiceProvider` provider was removed. Instead,
 
 ```php
 Event::listen(function (\SocialiteProviders\Manager\SocialiteWasCalled $event) {
-    $event->extendSocialite('kakao', \SocialiteProviders\Kakao\Provider::class);
+    $event->extendSocialite('kakao', \SocialiteProviders\Kakao\KakaoProvider::class);
 });
 ```
 <details>


### PR DESCRIPTION
### Summary  
This PR fixes an incorrect namespace in the README for the Kakao provider.  

### Description  
The current README incorrectly references `\SocialiteProviders\Kakao\Provider::class`,  
but there is no `Provider` class in that namespace.  
The correct class name is `KakaoProvider`.  

#### Before  
```php
$event->extendSocialite('kakao', \SocialiteProviders\Kakao\Provider::class);
```
#### After
```php
$event->extendSocialite('kakao', \SocialiteProviders\Kakao\KakaoProvider::class);
```

#### Impact
This fix ensures that users can correctly register the Kakao provider without encountering class not found errors.

Please review and merge if appropriate.
Thank you!