### PR TITLE
ArcGIS Provider: Add Host, port and directory as additionnal config

### DIFF
--- a/src/ArcGIS/Provider.php
+++ b/src/ArcGIS/Provider.php
@@ -10,6 +10,15 @@ class Provider extends AbstractProvider
 {
     public const IDENTIFIER = 'ARCGIS';
 
+    public static function additionalConfigKeys(): array
+    {
+        return [
+            'arcgis_host',
+            'arcgis_port',
+            'arcgis_directory',
+        ];
+    }
+
     protected function getBaseUrl()
     {
         $port = null === $this->getServerPort() ? '' : ':'.$this->getServerPort();


### PR DESCRIPTION
Currently, the provider only supports ArcGIS Online. This change is intended to make it compatible with ArcGIS Enterprise installations.
Tested and working under ArcGIS Enterprise & Online.