### PR TITLE
fix: sign in with apple docs URL

### DIFF
--- a/src/Apple/README.md
+++ b/src/Apple/README.md
@@ -69,4 +69,4 @@ return Socialite::driver('apple')->redirect();
 
 ### Reference
 
-- [Apple API Reference](https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api)
+- [Apple API Reference](https://developer.apple.com/documentation/signinwithapplerestapi/)


### PR DESCRIPTION
This pull request includes a minor update to the `src/Apple/README.md` file. The change fixes the link to the Apple API Reference by correcting the URL format.