### PR TITLE
feat: add Crowdin provider

### DIFF
--- a/monorepo-builder.yml
+++ b/monorepo-builder.yml
@@ -39,6 +39,7 @@ parameters:
     src/Coinbase: 'git@github.com:SocialiteProviders/Coinbase.git'
     src/ConstantContact: 'git@github.com:SocialiteProviders/ConstantContact.git'
     src/Coursera: 'git@github.com:SocialiteProviders/Coursera.git'
+    src/Crowdin: 'git@github.com:SocialiteProviders/Crowdin.git'
     src/Dailymotion: 'git@github.com:SocialiteProviders/Dailymotion.git'
     src/Dataporten: 'git@github.com:SocialiteProviders/Dataporten.git'
     src/Deezer: 'git@github.com:SocialiteProviders/Deezer.git'

--- a/src/Crowdin/CrowdinExtendSocialite.php
+++ b/src/Crowdin/CrowdinExtendSocialite.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SocialiteProviders\Crowdin;
+
+use SocialiteProviders\Manager\SocialiteWasCalled;
+
+class CrowdinExtendSocialite
+{
+    public function handle(SocialiteWasCalled $socialiteWasCalled): void
+    {
+        $socialiteWasCalled->extendSocialite('crowdin', Provider::class);
+    }
+}

--- a/src/Crowdin/Provider.php
+++ b/src/Crowdin/Provider.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace SocialiteProviders\Crowdin;
+
+use GuzzleHttp\RequestOptions;
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
+use SocialiteProviders\Manager\OAuth2\User;
+
+class Provider extends AbstractProvider
+{
+    public const IDENTIFIER = 'CROWDIN';
+
+    protected $scopes = ['project.status'];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $consent = false;
+
+    protected $scopeSeparator = ' ';
+
+    protected function getAuthUrl($state): string
+    {
+        return $this->buildAuthUrlFromBase('https://accounts.crowdin.com/oauth/authorize', $state);
+    }
+
+    protected function getTokenUrl(): string
+    {
+        return 'https://accounts.crowdin.com/oauth/token';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByToken($token)
+    {
+        $response = $this->getHttpClient()->get(
+            'https://crowdin.com/api/v2/user',
+            [
+                RequestOptions::HEADERS => [
+                    'Authorization' => 'Bearer '.$token,
+                ],
+            ]
+        );
+
+        return json_decode((string) $response->getBody(), true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return (new User)->setRaw($user)->map([
+            'id'       => $user['data']['id'],
+            'nickname' => $user['data']['fullName'],
+            'name'     => $user['data']['username'],
+            'email'    => $user['data']['email'] ?? null,
+            'avatar'   => $user['data']['avatarUrl'],
+        ]);
+    }
+}

--- a/src/Crowdin/README.md
+++ b/src/Crowdin/README.md
@@ -1,0 +1,66 @@
+# Crowdin
+
+```bash
+composer require socialiteproviders/crowdin
+```
+
+## Installation & Basic Usage
+
+Please see the [Base Installation Guide](https://socialiteproviders.com/usage/), then follow the provider specific instructions below.
+
+### Add configuration to `config/services.php`
+
+```php
+'crowdin' => [    
+  'client_id' => env('CROWDIN_CLIENT_ID'),  
+  'client_secret' => env('CROWDIN_CLIENT_SECRET'),  
+  'redirect' => env('CROWDIN_REDIRECT_URI'),
+],
+```
+
+### Add provider event listener
+
+#### Laravel 11+
+
+In Laravel 11, the default `EventServiceProvider` provider was removed. Instead, add the listener using the `listen` method on the `Event` facade, in your `AppServiceProvider` `boot` method.
+
+* Note: You do not need to add anything for the built-in socialite providers unless you override them with your own providers.
+
+```php
+Event::listen(function (\SocialiteProviders\Manager\SocialiteWasCalled $event) {
+    $event->extendSocialite('crowdin', \SocialiteProviders\Crowdin\Provider::class);
+});
+```
+<details>
+<summary>
+Laravel 10 or below
+</summary>
+Configure the package's listener to listen for `SocialiteWasCalled` events.
+
+Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. See the [Base Installation Guide](https://socialiteproviders.com/usage/) for detailed instructions.
+
+```php
+protected $listen = [
+    \SocialiteProviders\Manager\SocialiteWasCalled::class => [
+        // ... other providers
+        \SocialiteProviders\Crowdin\CrowdinExtendSocialite::class.'@handle',
+    ],
+];
+```
+</details>
+
+### Usage
+
+You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
+
+```php
+return Socialite::driver('crowdin')->redirect();
+```
+
+### Returned User fields
+
+- ``id``
+- ``nickname``
+- ``name``
+- ``email``
+- ``avatar``

--- a/src/Crowdin/composer.json
+++ b/src/Crowdin/composer.json
@@ -1,0 +1,35 @@
+{
+    "name": "socialiteproviders/crowdin",
+    "description": "Crowdin OAuth2 Provider for Laravel Socialite",
+    "license": "MIT",
+    "keywords": [
+        "crowdin",
+        "laravel",
+        "oauth",
+        "provider",
+        "socialite"
+    ],
+    "authors": [
+        {
+            "name": "WentTheFox",
+            "email": "mail@went.tf",
+            "homepage": "https://went.tf",
+            "role": "developer"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/socialiteproviders/providers/issues",
+        "source": "https://github.com/socialiteproviders/providers",
+        "docs": "https://socialiteproviders.com/crowdin"
+    },
+    "require": {
+        "php": "^8.0",
+        "ext-json": "*",
+        "socialiteproviders/manager": "^4.4"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialiteProviders\\Crowdin\\": ""
+        }
+    }
+}


### PR DESCRIPTION
Implemented by duplicating the Discord provider and following this service-specific guide: https://support.crowdin.com/developer/authorizing-oauth-apps/

The Crowdin OAuth API requires a scope to be specified, otherwise the authorization flow breaks. The list of available scopes is at https://support.crowdin.com/developer/understanding-scopes/ but there does not appear to be a generic "just the basic user info please" scope. "Translation status" (`project.status`) is one of, if not the least invasive from that list which also does not require an Enterprise license, that's why I opted to make it the default.

Side note: when using the default Laravel `php artisan serve` command, which uses `127.0.0.1:8000` as the host, authorization requests get mysteriously rejected with a 403 error by the service when this is used in a `redirect_uri`. For my testing I had to change things around to use `localhost:8000` in the `APP_URL` env var and had to run `php artisan serve --host=localhost` to get this to work. This would not affect a real deployment behind an actual URL, but I'm not sure it's worth noting this anywhere.