### PR TITLE
fix: Reddit provider

### DIFF
--- a/src/Reddit/Provider.php
+++ b/src/Reddit/Provider.php
@@ -14,12 +14,12 @@ class Provider extends AbstractProvider
 
     protected function getAuthUrl($state): string
     {
-        return $this->buildAuthUrlFromBase('https://ssl.reddit.com/api/v1/authorize', $state);
+        return $this->buildAuthUrlFromBase('https://www.reddit.com/api/v1/authorize', $state);
     }
 
     protected function getTokenUrl(): string
     {
-        return 'https://ssl.reddit.com/api/v1/access_token';
+        return 'https://www.reddit.com/api/v1/access_token';
     }
 
     /**


### PR DESCRIPTION
Three days ago Reddit silently broke authentication using the `ssl.reddit.com` subdomain (https://github.com/ReVanced/revanced-patches/issues/5387#issuecomment-3050530834), and right now, `www.reddit.com` should be used instead.