### PR TITLE
Add User Agent Passing for Discogs

### DIFF
--- a/src/Discogs/Provider.php
+++ b/src/Discogs/Provider.php
@@ -13,6 +13,18 @@ class Provider extends AbstractProvider
     /**
      * {@inheritdoc}
      */
+    protected function getHttpClient()
+    {
+        return new \GuzzleHttp\Client([
+            'headers' => [
+                'User-Agent' => $this->config['user_agent'] ?? 'socialite-discogs',
+            ],
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function user()
     {
         if (! $this->hasNecessaryVerifier()) {

--- a/src/Discogs/README.md
+++ b/src/Discogs/README.md
@@ -28,7 +28,7 @@ In Laravel 11, the default `EventServiceProvider` provider was removed. Instead,
 
 ```php
 Event::listen(function (\SocialiteProviders\Manager\SocialiteWasCalled $event) {
-    $event->extendSocialite('discogs', \SocialiteProviders\Discogs\Provider::class);
+    $event->extendSocialite('discogs', \SocialiteProviders\Discogs\Provider::class ,\SocialiteProvider\Discogs\Server::class);
 });
 ```
 <details>


### PR DESCRIPTION
According to the [https://www.discogs.com/developers#page:authentication,header:authentication-oauth-flow](Discogs Documentation) passing in a user-agent as part of the OAuth flow is required. 

This allows a `user-agent` to be set in the config with a default fallback to `socialite-discogs`