### PR TITLE
Garmin Connect - Update README.md

### DIFF
--- a/src/GarminConnect/README.md
+++ b/src/GarminConnect/README.md
@@ -28,7 +28,7 @@ In Laravel 11, the default `EventServiceProvider` provider was removed. Instead,
 
 ```php
 Event::listen(function (\SocialiteProviders\Manager\SocialiteWasCalled $event) {
-    $event->extendSocialite('garmin-connect', \SocialiteProviders\GarminConnect\Provider::class);
+    $event->extendSocialite('garmin-connect', \SocialiteProviders\GarminConnect\Provider::class, \SocialiteProviders\GarminConnect\Server::class);
 });
 ```
 <details>


### PR DESCRIPTION
Fixes does not `extend Laravel\Socialite\Two\AbstractProvider` error by adding missing oauth1 Server class

