### PR TITLE
Add `broadcaster_type` to Twitch user mapping

### DIFF
--- a/src/Twitch/Provider.php
+++ b/src/Twitch/Provider.php
@@ -53,11 +53,12 @@ class Provider extends AbstractProvider
         $user = $user['data']['0'];
 
         return (new User)->setRaw($user)->map([
-            'id'       => $user['id'],
-            'nickname' => $user['display_name'],
-            'name'     => $user['display_name'],
-            'email'    => Arr::get($user, 'email'),
-            'avatar'   => $user['profile_image_url'],
+            'id'                => $user['id'],
+            'nickname'          => $user['display_name'],
+            'name'              => $user['display_name'],
+            'email'             => Arr::get($user, 'email'),
+            'avatar'            => $user['profile_image_url'],
+            'broadcaster_type'  => Arr::get($user, 'broadcaster_type'),
         ]);
     }
 

--- a/src/Twitch/README.md
+++ b/src/Twitch/README.md
@@ -64,3 +64,4 @@ return Socialite::driver('twitch')->redirect();
 - ``name``
 - ``email``
 - ``avatar``
+- ``broadcaster_type``


### PR DESCRIPTION
Allows you to determine whether a connected user is an affiliate or partner, thereby avoiding the need to make an additional request on the same access point.