### PR TITLE
Handle null avatar in user data

### DIFF
--- a/src/Clerk/Provider.php
+++ b/src/Clerk/Provider.php
@@ -72,7 +72,7 @@ class Provider extends AbstractProvider
             'nickname' => $user['username'] ?? ($user['given_name'] ?? null),
             'name' => $user['name'],
             'email' => $user['email'],
-            'avatar' => $user['picture'],
+            'avatar' => $user['picture'] ?? null,
         ]);
     }
 }


### PR DESCRIPTION
Clerk does not provide avatars by default.

