### PR TITLE
Fix for Mailru Provider

### DIFF
--- a/src/Mailru/Provider.php
+++ b/src/Mailru/Provider.php
@@ -43,7 +43,7 @@ class Provider extends AbstractProvider
     {
         return (new User)->setRaw($user)->map([
             'id'       => $user['id'],
-            'nickname' => $user['nickname'],
+            'nickname' => \Arr::get($user, 'nickname'),
             'name'     => $user['name'],
             'email'    => $user['email'],
             'avatar'   => $user['image'],

--- a/src/Mailru/Provider.php
+++ b/src/Mailru/Provider.php
@@ -3,6 +3,7 @@
 namespace SocialiteProviders\Mailru;
 
 use GuzzleHttp\RequestOptions;
+use Illuminate\Support\Arr;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -43,7 +44,7 @@ class Provider extends AbstractProvider
     {
         return (new User)->setRaw($user)->map([
             'id'       => $user['id'],
-            'nickname' => \Arr::get($user, 'nickname'),
+            'nickname' => Arr::get($user, 'nickname'),
             'name'     => $user['name'],
             'email'    => $user['email'],
             'avatar'   => $user['image'],


### PR DESCRIPTION
The "nickname" field, in a user object, is not always returned since it's a relatively new field. Therefore, old mail.ru accounts do not have that field and mail.ru OAuth does not return that field in their response.

This bug breaks mail.ru OAuth for older accounts and some users cannot register or login via Mailru Provider.