### PR TITLE
fix: using string as array causes error

### DIFF
--- a/src/VKID/Provider.php
+++ b/src/VKID/Provider.php
@@ -56,7 +56,7 @@ class Provider extends AbstractProvider
         $response = $this->getHttpClient()->post('https://id.vk.ru/oauth2/user_info', [
             RequestOptions::HEADERS => ['Accept' => 'application/json'],
             RequestOptions::FORM_PARAMS => [
-                'access_token' => $token['access_token'],
+                'access_token' => $token,
                 'client_id' => $this->clientId,
             ],
         ]);


### PR DESCRIPTION
### Problem
The code was attempting to use string values as arrays, which caused runtime errors.

### Solution
Updated the logic to properly handle strings without treating them as arrays.

### Notes
- Verified that the fix prevents the error from occurring.
- No breaking changes introduced.
