### PR TITLE
Update Figma provider scopes and token URL

### DIFF
--- a/src/Figma/Provider.php
+++ b/src/Figma/Provider.php
@@ -10,7 +10,7 @@ class Provider extends AbstractProvider
 {
     public const IDENTIFIER = 'FIGMA';
 
-    protected $scopes = ['file_read'];
+    protected $scopes = ['file_content:read'];
 
     protected function getAuthUrl($state): string
     {
@@ -19,7 +19,7 @@ class Provider extends AbstractProvider
 
     protected function getTokenUrl(): string
     {
-        return 'https://www.figma.com/api/oauth/token';
+        return 'https://api.figma.com/v1/oauth/token';
     }
 
     /**


### PR DESCRIPTION
Fixes two recent changes in the Figma API. 

Recently, the token URL changed: 

<img width="779" height="308" alt="image" src="https://github.com/user-attachments/assets/62f9cb82-a6b4-4f94-aae6-df46eb9fdf3c" />

See https://developers.figma.com/docs/rest-api/authentication/

And Figma updated their scope names. 

<img width="754" height="334" alt="image" src="https://github.com/user-attachments/assets/f62b0848-468b-4bb2-8f4c-bdd4509b2a31" />


See https://developers.figma.com/docs/rest-api/scopes/
