### PR TITLE
update wiki link (mc provider)

### DIFF
--- a/src/Minecraft/README.md
+++ b/src/Minecraft/README.md
@@ -7,7 +7,7 @@ composer require socialiteproviders/minecraft
 ## Installation & Basic Usage
 
 Please see the [Base Installation Guide](https://socialiteproviders.com/usage/), then follow the provider specific instructions below.
-This provider is based on the [Microsoft Authentication Scheme](https://wiki.vg/Microsoft_Authentication_Scheme) described in [this document](https://mojang-api-docs.netlify.app/authentication/msa.html#oauth-2).
+This provider is based on the [Microsoft Authentication Scheme](https://minecraft.wiki/w/Microsoft_authentication) described in [this document](https://mojang-api-docs.netlify.app/authentication/msa.html#oauth-2).
 
 ### Add configuration to `config/services.php`
 


### PR DESCRIPTION
wiki.vg moved to the [official mc wiki](https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge) since it is [closed](https://tkte.ch/articles/2024/11/11/sunsetting.html) 