### PR TITLE
Fix Etsy's x-api-key value

### DIFF
--- a/src/Etsy/Provider.php
+++ b/src/Etsy/Provider.php
@@ -38,7 +38,7 @@ class Provider extends AbstractProvider
         $response = $this->getHttpClient()->get('https://openapi.etsy.com/v3/application/users/'.$tokenData[0], [
             RequestOptions::HEADERS => [
                 'Authorization' => 'Bearer '.$token,
-                'x-api-key'     => $this->clientId,
+                'x-api-key'     => $this->clientId.':'.$this->clientSecret,
             ],
         ]);
 


### PR DESCRIPTION
Etsy made an update to require the x-api-key to include both the client ID and the client Secret. It looks like they started enforcing the new pattern today. This should fix a P1/P0 level issue when users try to authenticate in via Etsy.

https://developers.etsy.com/documentation/essentials/requests