### PR TITLE
chore: remove `ext-json` dependency from all provider `composer.json` files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "league/oauth1-client": "^1.9",
         "socialiteproviders/manager": "^4.4"
     },

--- a/src/Acclaim/composer.json
+++ b/src/Acclaim/composer.json
@@ -26,7 +26,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Admitad/composer.json
+++ b/src/Admitad/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Adobe/composer.json
+++ b/src/Adobe/composer.json
@@ -24,7 +24,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Aikido/composer.json
+++ b/src/Aikido/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Amazon/composer.json
+++ b/src/Amazon/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/AmoCRM/composer.json
+++ b/src/AmoCRM/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/AngelList/composer.json
+++ b/src/AngelList/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/AppNet/composer.json
+++ b/src/AppNet/composer.json
@@ -26,7 +26,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Apple/composer.json
+++ b/src/Apple/composer.json
@@ -37,7 +37,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "ext-openssl": "*",
         "firebase/php-jwt": "^7.0",
         "lcobucci/clock": "^2.0 || ^3.0",

--- a/src/ArcGIS/composer.json
+++ b/src/ArcGIS/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Asana/composer.json
+++ b/src/Asana/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Atlassian/composer.json
+++ b/src/Atlassian/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Auth0/composer.json
+++ b/src/Auth0/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Authelia/composer.json
+++ b/src/Authelia/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.2",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.8"
     },
     "autoload": {

--- a/src/Authentik/composer.json
+++ b/src/Authentik/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/AutodeskAPS/composer.json
+++ b/src/AutodeskAPS/composer.json
@@ -25,7 +25,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Aweber/composer.json
+++ b/src/Aweber/composer.json
@@ -26,7 +26,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Azure/composer.json
+++ b/src/Azure/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/AzureADB2C/composer.json
+++ b/src/AzureADB2C/composer.json
@@ -24,7 +24,6 @@
     ],
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "ext-openssl": "*",
         "firebase/php-jwt": "^7.0",
         "socialiteproviders/manager": "^4.4"

--- a/src/Battlenet/composer.json
+++ b/src/Battlenet/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Bexio/composer.json
+++ b/src/Bexio/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Binance/composer.json
+++ b/src/Binance/composer.json
@@ -16,7 +16,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Bitbucket/composer.json
+++ b/src/Bitbucket/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Bitly/composer.json
+++ b/src/Bitly/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Bitrix24/composer.json
+++ b/src/Bitrix24/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Blackboard/composer.json
+++ b/src/Blackboard/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Box/composer.json
+++ b/src/Box/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Buffer/composer.json
+++ b/src/Buffer/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Calendly/composer.json
+++ b/src/Calendly/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.1",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/CampaignMonitor/composer.json
+++ b/src/CampaignMonitor/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Cheddar/composer.json
+++ b/src/Cheddar/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/ClaveUnica/composer.json
+++ b/src/ClaveUnica/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Clerk/composer.json
+++ b/src/Clerk/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/ClickUp/composer.json
+++ b/src/ClickUp/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Clover/composer.json
+++ b/src/Clover/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.1",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Cognito/composer.json
+++ b/src/Cognito/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Coinbase/composer.json
+++ b/src/Coinbase/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/ConstantContact/composer.json
+++ b/src/ConstantContact/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Coursera/composer.json
+++ b/src/Coursera/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Crowdin/composer.json
+++ b/src/Crowdin/composer.json
@@ -24,7 +24,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Dailymotion/composer.json
+++ b/src/Dailymotion/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Dataporten/composer.json
+++ b/src/Dataporten/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Deezer/composer.json
+++ b/src/Deezer/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Deviantart/composer.json
+++ b/src/Deviantart/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Didit/composer.json
+++ b/src/Didit/composer.json
@@ -25,7 +25,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/DigitalOcean/composer.json
+++ b/src/DigitalOcean/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Discogs/composer.json
+++ b/src/Discogs/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Discord/composer.json
+++ b/src/Discord/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Disqus/composer.json
+++ b/src/Disqus/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/DocuSign/composer.json
+++ b/src/DocuSign/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Douban/composer.json
+++ b/src/Douban/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Dribbble/composer.json
+++ b/src/Dribbble/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Dropbox/composer.json
+++ b/src/Dropbox/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/EduID/composer.json
+++ b/src/EduID/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Envato/composer.json
+++ b/src/Envato/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Etsy/composer.json
+++ b/src/Etsy/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Eventbrite/composer.json
+++ b/src/Eventbrite/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Eveonline/composer.json
+++ b/src/Eveonline/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "firebase/php-jwt": "^7.0",
         "socialiteproviders/manager": "^4.4"
     },

--- a/src/Exment/composer.json
+++ b/src/Exment/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/EyeEm/composer.json
+++ b/src/EyeEm/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Fablabs/composer.json
+++ b/src/Fablabs/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Facebook/composer.json
+++ b/src/Facebook/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Faceit/composer.json
+++ b/src/Faceit/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Figma/composer.json
+++ b/src/Figma/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Fiken/composer.json
+++ b/src/Fiken/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Fitbit/composer.json
+++ b/src/Fitbit/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/FiveHundredPixel/composer.json
+++ b/src/FiveHundredPixel/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Flattr/composer.json
+++ b/src/Flattr/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Flexkids/composer.json
+++ b/src/Flexkids/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Flexmls/composer.json
+++ b/src/Flexmls/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Flickr/composer.json
+++ b/src/Flickr/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Foursquare/composer.json
+++ b/src/Foursquare/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/FranceConnect/composer.json
+++ b/src/FranceConnect/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/FusionAuth/composer.json
+++ b/src/FusionAuth/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/GarminConnect/composer.json
+++ b/src/GarminConnect/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/GettyImages/composer.json
+++ b/src/GettyImages/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/GitHub/composer.json
+++ b/src/GitHub/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/GitLab/composer.json
+++ b/src/GitLab/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Gitea/composer.json
+++ b/src/Gitea/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Gitee/composer.json
+++ b/src/Gitee/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/GoHighLevel/composer.json
+++ b/src/GoHighLevel/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.1",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.8"
     },
     "autoload": {

--- a/src/Goodreads/composer.json
+++ b/src/Goodreads/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Google/composer.json
+++ b/src/Google/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/GovBR/composer.json
+++ b/src/GovBR/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Graph/composer.json
+++ b/src/Graph/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Gumroad/composer.json
+++ b/src/Gumroad/composer.json
@@ -24,7 +24,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/HabrCareer/composer.json
+++ b/src/HabrCareer/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/HarID/composer.json
+++ b/src/HarID/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Harvest/composer.json
+++ b/src/Harvest/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/HeadHunter/composer.json
+++ b/src/HeadHunter/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Heroku/composer.json
+++ b/src/Heroku/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/HubSpot/composer.json
+++ b/src/HubSpot/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/HumanApi/composer.json
+++ b/src/HumanApi/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/IFSP/composer.json
+++ b/src/IFSP/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Imgur/composer.json
+++ b/src/Imgur/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Imis/composer.json
+++ b/src/Imis/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Indeed/composer.json
+++ b/src/Indeed/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Infomaniak/composer.json
+++ b/src/Infomaniak/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Instagram/composer.json
+++ b/src/Instagram/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/InstagramBasic/composer.json
+++ b/src/InstagramBasic/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Instructure/composer.json
+++ b/src/Instructure/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Intercom/composer.json
+++ b/src/Intercom/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Ivao/composer.json
+++ b/src/Ivao/composer.json
@@ -24,7 +24,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Jira/composer.json
+++ b/src/Jira/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "ext-openssl": "*",
         "socialiteproviders/manager": "^4.4"
     },

--- a/src/JumpCloud/composer.json
+++ b/src/JumpCloud/composer.json
@@ -24,7 +24,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Kakao/composer.json
+++ b/src/Kakao/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Kanidm/composer.json
+++ b/src/Kanidm/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Keycloak/composer.json
+++ b/src/Keycloak/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Kick/composer.json
+++ b/src/Kick/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4|^4.8|^4.8.1"
     },
     "autoload": {

--- a/src/Kinde/composer.json
+++ b/src/Kinde/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Klarna/composer.json
+++ b/src/Klarna/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Kommo/composer.json
+++ b/src/Kommo/composer.json
@@ -10,7 +10,6 @@
     ],
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/LaravelPassport/composer.json
+++ b/src/LaravelPassport/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Lichess/composer.json
+++ b/src/Lichess/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/LifeScienceLogin/composer.json
+++ b/src/LifeScienceLogin/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Line/composer.json
+++ b/src/Line/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/LinkedIn/composer.json
+++ b/src/LinkedIn/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Linode/composer.json
+++ b/src/Linode/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Live/composer.json
+++ b/src/Live/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/MailChimp/composer.json
+++ b/src/MailChimp/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Mailru/composer.json
+++ b/src/Mailru/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/MakerLog/composer.json
+++ b/src/MakerLog/composer.json
@@ -26,7 +26,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Mattermost/composer.json
+++ b/src/Mattermost/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/MediaCube/composer.json
+++ b/src/MediaCube/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Mediawiki/composer.json
+++ b/src/Mediawiki/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Medium/composer.json
+++ b/src/Medium/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Meetup/composer.json
+++ b/src/Meetup/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/MercadoLibre/composer.json
+++ b/src/MercadoLibre/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/MercadoPago/composer.json
+++ b/src/MercadoPago/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Microsoft/composer.json
+++ b/src/Microsoft/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "firebase/php-jwt": "^7.0",
         "socialiteproviders/manager": "^4.4"
     },

--- a/src/Minecraft/composer.json
+++ b/src/Minecraft/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Mixcloud/composer.json
+++ b/src/Mixcloud/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Mollie/composer.json
+++ b/src/Mollie/composer.json
@@ -16,7 +16,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Monday/composer.json
+++ b/src/Monday/composer.json
@@ -31,7 +31,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Monzo/composer.json
+++ b/src/Monzo/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/MusicBrainz/composer.json
+++ b/src/MusicBrainz/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/NFDILogin/composer.json
+++ b/src/NFDILogin/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Naver/composer.json
+++ b/src/Naver/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "ext-libxml": "*",
         "ext-simplexml": "*",
         "socialiteproviders/manager": "^4.4"

--- a/src/Netlify/composer.json
+++ b/src/Netlify/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Neto/composer.json
+++ b/src/Neto/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Nextcloud/composer.json
+++ b/src/Nextcloud/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Nocks/composer.json
+++ b/src/Nocks/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Notion/composer.json
+++ b/src/Notion/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Nuvemshop/composer.json
+++ b/src/Nuvemshop/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/OAuthgen/composer.json
+++ b/src/OAuthgen/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/OSChina/composer.json
+++ b/src/OSChina/composer.json
@@ -26,7 +26,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Odnoklassniki/composer.json
+++ b/src/Odnoklassniki/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Okta/composer.json
+++ b/src/Okta/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Onelogin/composer.json
+++ b/src/Onelogin/composer.json
@@ -18,7 +18,6 @@
     ],
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/OnlineScoutManager/composer.json
+++ b/src/OnlineScoutManager/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.4",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/OpenStreetMap/composer.json
+++ b/src/OpenStreetMap/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Orcid/composer.json
+++ b/src/Orcid/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Ovh/composer.json
+++ b/src/Ovh/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "ovh/ovh": "^2.0",
         "socialiteproviders/manager": "^4.4"
     },

--- a/src/Patreon/composer.json
+++ b/src/Patreon/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/PayPal/composer.json
+++ b/src/PayPal/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/PayPalSandbox/composer.json
+++ b/src/PayPalSandbox/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Paymenter/composer.json
+++ b/src/Paymenter/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Paymill/composer.json
+++ b/src/Paymill/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/PeeringDB/composer.json
+++ b/src/PeeringDB/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Pinterest/composer.json
+++ b/src/Pinterest/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Pipedrive/composer.json
+++ b/src/Pipedrive/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Pixnet/composer.json
+++ b/src/Pixnet/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/PlanningCenter/composer.json
+++ b/src/PlanningCenter/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/PocketID/composer.json
+++ b/src/PocketID/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Podio/composer.json
+++ b/src/Podio/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Pr0gramm/composer.json
+++ b/src/Pr0gramm/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Procore/composer.json
+++ b/src/Procore/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/ProductHunt/composer.json
+++ b/src/ProductHunt/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/ProjectV/composer.json
+++ b/src/ProjectV/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/PropelAuth/composer.json
+++ b/src/PropelAuth/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Pushbullet/composer.json
+++ b/src/Pushbullet/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/QQ/composer.json
+++ b/src/QQ/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/QuickBooks/composer.json
+++ b/src/QuickBooks/composer.json
@@ -30,7 +30,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Readability/composer.json
+++ b/src/Readability/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Redbooth/composer.json
+++ b/src/Redbooth/composer.json
@@ -26,7 +26,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Reddit/composer.json
+++ b/src/Reddit/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Rekono/composer.json
+++ b/src/Rekono/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Roblox/composer.json
+++ b/src/Roblox/composer.json
@@ -21,7 +21,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/RunKeeper/composer.json
+++ b/src/RunKeeper/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/SURFconext/composer.json
+++ b/src/SURFconext/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Sage/composer.json
+++ b/src/Sage/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/SalesForce/composer.json
+++ b/src/SalesForce/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Salesloft/composer.json
+++ b/src/Salesloft/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "minimum-stability": "stable",

--- a/src/Salla/composer.json
+++ b/src/Salla/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Saml2/composer.json
+++ b/src/Saml2/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "litesaml/lightsaml": "^4.0",
         "socialiteproviders/manager": "^4.4"
     },

--- a/src/SapoId/composer.json
+++ b/src/SapoId/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/SciStarter/composer.json
+++ b/src/SciStarter/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/SharePoint/composer.json
+++ b/src/SharePoint/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Shopify/composer.json
+++ b/src/Shopify/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Slack/composer.json
+++ b/src/Slack/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Smashcast/composer.json
+++ b/src/Smashcast/composer.json
@@ -26,7 +26,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Snapchat/composer.json
+++ b/src/Snapchat/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/SoundCloud/composer.json
+++ b/src/SoundCloud/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Spotify/composer.json
+++ b/src/Spotify/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/StackExchange/composer.json
+++ b/src/StackExchange/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Starling/composer.json
+++ b/src/Starling/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/StartGg/composer.json
+++ b/src/StartGg/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Steam/composer.json
+++ b/src/Steam/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Steem/composer.json
+++ b/src/Steem/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/StockTwits/composer.json
+++ b/src/StockTwits/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Strava/composer.json
+++ b/src/Strava/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/StreamElements/composer.json
+++ b/src/StreamElements/composer.json
@@ -16,7 +16,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Streamlabs/composer.json
+++ b/src/Streamlabs/composer.json
@@ -16,7 +16,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Stripe/composer.json
+++ b/src/Stripe/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Subscribestar/composer.json
+++ b/src/Subscribestar/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/SuperOffice/composer.json
+++ b/src/SuperOffice/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/TVShowTime/composer.json
+++ b/src/TVShowTime/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Tailscale/composer.json
+++ b/src/Tailscale/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.3",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/TeamService/composer.json
+++ b/src/TeamService/composer.json
@@ -27,7 +27,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Teamleader/composer.json
+++ b/src/Teamleader/composer.json
@@ -26,7 +26,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Teamweek/composer.json
+++ b/src/Teamweek/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/ThirtySevenSignals/composer.json
+++ b/src/ThirtySevenSignals/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Threads/composer.json
+++ b/src/Threads/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Todoist/composer.json
+++ b/src/Todoist/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Toyhouse/composer.json
+++ b/src/Toyhouse/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Trakt/composer.json
+++ b/src/Trakt/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Trello/composer.json
+++ b/src/Trello/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Trovo/composer.json
+++ b/src/Trovo/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Tumblr/composer.json
+++ b/src/Tumblr/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/TwentyThreeAndMe/composer.json
+++ b/src/TwentyThreeAndMe/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/TwitCasting/composer.json
+++ b/src/TwitCasting/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Twitch/composer.json
+++ b/src/Twitch/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Twitter/composer.json
+++ b/src/Twitter/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/UAEPass/composer.json
+++ b/src/UAEPass/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.1",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/UCL/composer.json
+++ b/src/UCL/composer.json
@@ -25,7 +25,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/UFS/composer.json
+++ b/src/UFS/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Uber/composer.json
+++ b/src/Uber/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Ufutx/composer.json
+++ b/src/Ufutx/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Unsplash/composer.json
+++ b/src/Unsplash/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Untappd/composer.json
+++ b/src/Untappd/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Usos/composer.json
+++ b/src/Usos/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/VKID/composer.json
+++ b/src/VKID/composer.json
@@ -18,7 +18,6 @@
     ],
     "require": {
         "php": "^8.4",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/VKontakte/composer.json
+++ b/src/VKontakte/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Vatsim/composer.json
+++ b/src/Vatsim/composer.json
@@ -24,7 +24,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Venmo/composer.json
+++ b/src/Venmo/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Vercel/composer.json
+++ b/src/Vercel/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/VersionOne/composer.json
+++ b/src/VersionOne/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Vimeo/composer.json
+++ b/src/Vimeo/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Wave/composer.json
+++ b/src/Wave/composer.json
@@ -24,7 +24,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/WeChatServiceAccount/composer.json
+++ b/src/WeChatServiceAccount/composer.json
@@ -24,7 +24,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/WeChatWeb/composer.json
+++ b/src/WeChatWeb/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Webex/composer.json
+++ b/src/Webex/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Webflow/composer.json
+++ b/src/Webflow/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Weibo/composer.json
+++ b/src/Weibo/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Weixin/composer.json
+++ b/src/Weixin/composer.json
@@ -26,7 +26,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/WeixinWeb/composer.json
+++ b/src/WeixinWeb/composer.json
@@ -23,7 +23,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Whmcs/composer.json
+++ b/src/Whmcs/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Withings/composer.json
+++ b/src/Withings/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/WordPress/composer.json
+++ b/src/WordPress/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Worldcoin/composer.json
+++ b/src/Worldcoin/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Xero/composer.json
+++ b/src/Xero/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "firebase/php-jwt": "^7.0",
         "socialiteproviders/manager": "^4.4"
     },

--- a/src/Xing/composer.json
+++ b/src/Xing/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/YNAB/composer.json
+++ b/src/YNAB/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.1",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Yahoo/composer.json
+++ b/src/Yahoo/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Yammer/composer.json
+++ b/src/Yammer/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Yandex/composer.json
+++ b/src/Yandex/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Yiban/composer.json
+++ b/src/Yiban/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/YouTube/composer.json
+++ b/src/YouTube/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Zalo/composer.json
+++ b/src/Zalo/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Zendesk/composer.json
+++ b/src/Zendesk/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Zettle/composer.json
+++ b/src/Zettle/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.1",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Zitadel/composer.json
+++ b/src/Zitadel/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "minimum-stability": "stable",

--- a/src/Zoho/composer.json
+++ b/src/Zoho/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "minimum-stability": "stable",

--- a/src/Zoom/composer.json
+++ b/src/Zoom/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/xREL/composer.json
+++ b/src/xREL/composer.json
@@ -22,7 +22,6 @@
     },
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {


### PR DESCRIPTION
> For composer.json file that had ext-json in the require section, this requirement is no longer necessary if already requires php ^8.0.

https://php.watch/versions/8.0/ext-json