### PR TITLE
fix: correct Paymenter API endpoint for user info

### DIFF
--- a/src/Paymenter/Provider.php
+++ b/src/Paymenter/Provider.php
@@ -43,7 +43,7 @@ class Provider extends AbstractProvider
      */
     protected function getUserByToken($token)
     {
-        $response = $this->getHttpClient()->get($this->getBaseUrl().'/api/oauth/me', [
+        $response = $this->getHttpClient()->get($this->getBaseUrl().'/api/me', [
             RequestOptions::HEADERS => [
                 'Authorization' => 'Bearer '.$token,
             ],


### PR DESCRIPTION
I made a mistake in my former PR https://github.com/SocialiteProviders/Providers/pull/1400. The user info endpoint should be `/api/me`, not `/api/oauth/me`.