### PR TITLE
Add scope separator for PlanningCenter provider

### DIFF
--- a/src/PlanningCenter/Provider.php
+++ b/src/PlanningCenter/Provider.php
@@ -12,6 +12,8 @@ class Provider extends AbstractProvider
 
     protected $scopes = ['people'];
 
+    protected $scopeSeparator = ' ';
+
     protected function getAuthUrl($state): string
     {
         return $this->buildAuthUrlFromBase('https://api.planningcenteronline.com/oauth/authorize', $state);


### PR DESCRIPTION
This pull request introduces a minor update to the `Provider` class for Planning Center authentication. The main change is the addition of a `scopeSeparator` property, which defines how OAuth scopes are separated in authorization requests.

Authentication configuration:

* Added a protected `$scopeSeparator` property set to a space character in the `Provider` class to control how OAuth scopes are separated in requests.

This change was introduced because the Planning Center Authentication [documentation](https://api.planningcenteronline.com/docs/overview/authentication) notes that, 'The value should be a space-separated list of scopes'.

The default for `BaseProvider` is a comma.

Thank you!