### PR TITLE
Adding missing configuration key - "scope"

### DIFF
--- a/src/Cognito/Provider.php
+++ b/src/Cognito/Provider.php
@@ -120,6 +120,7 @@ class Provider extends AbstractProvider
             'host',
             'logout_uri',
             'redirect',
+            'scope',
         ];
     }
 }


### PR DESCRIPTION
It was asked [earlier](https://github.com/SocialiteProviders/Cognito/pull/1#issuecomment-4083168336), why it is needed;

Without it, the call to `Socialite::driver('cognito')->redirect()` does not use the `scope` from the configuration and instead defaults to `openid profile`. Logically, it should use the current configuration by default, without requiring an explicit call to `scope()` before `redirect()`.