### PR TITLE
fix: #1354 - allow customisable leeway for JWT issued time in Apple provider …

### DIFF
--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -59,12 +59,12 @@ class Provider extends AbstractProvider
      */
     protected function getAuthUrl($state): string
     {
-        return $this->buildAuthUrlFromBase(self::URL.'/auth/authorize', $state);
+        return $this->buildAuthUrlFromBase(self::URL . '/auth/authorize', $state);
     }
 
     protected function getTokenUrl(): string
     {
-        return self::URL.'/auth/token';
+        return self::URL . '/auth/token';
     }
 
     /**
@@ -82,7 +82,7 @@ class Provider extends AbstractProvider
 
         if ($this->usesState()) {
             $fields['state'] = $state;
-            $fields['nonce'] = Str::uuid().'.'.$state;
+            $fields['nonce'] = Str::uuid() . '.' . $state;
         }
 
         return array_merge($fields, $this->parameters);
@@ -94,7 +94,7 @@ class Provider extends AbstractProvider
     public function getAccessTokenResponse($code)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
-            RequestOptions::HEADERS        => ['Authorization' => 'Basic '.base64_encode($this->clientId.':'.$this->getClientSecret())],
+            RequestOptions::HEADERS        => ['Authorization' => 'Basic ' . base64_encode($this->clientId . ':' . $this->getClientSecret())],
             RequestOptions::FORM_PARAMS    => $this->getTokenFields($code),
         ]);
 
@@ -182,7 +182,7 @@ class Provider extends AbstractProvider
         $token = $this->getJwtConfig()->parser()->parse($jwt);
 
         $data = Cache::remember('socialite:Apple-JWKSet', 5 * 60, function () {
-            $response = (new Client)->get(self::URL.'/auth/keys');
+            $response = (new Client)->get(self::URL . '/auth/keys');
 
             return json_decode((string) $response->getBody(), true);
         });
@@ -196,7 +196,7 @@ class Provider extends AbstractProvider
                 new SignedWith(new Sha256, AppleSignerInMemory::plainText($publicKey['key'])),
                 new IssuedBy(self::URL),
                 // fix for #1354
-                new LooseValidAt(SystemClock::fromSystemTimezone(), new DateInterval('PT3S')),
+                new LooseValidAt(SystemClock::fromSystemTimezone(), new DateInterval($this->getConfig('jwt_issued_time_leeway', 'PT3S'))),
             ];
 
             try {
@@ -278,8 +278,8 @@ class Provider extends AbstractProvider
             $user['name'] = $userRequest['name'];
             $fullName = trim(
                 ($user['name']['firstName'] ?? '')
-                .' '
-                .($user['name']['lastName'] ?? '')
+                    . ' '
+                    . ($user['name']['lastName'] ?? '')
             );
         }
 
@@ -314,7 +314,7 @@ class Provider extends AbstractProvider
      */
     protected function getRevokeUrl(): string
     {
-        return self::URL.'/auth/revoke';
+        return self::URL . '/auth/revoke';
     }
 
     /**
@@ -365,6 +365,6 @@ class Provider extends AbstractProvider
      */
     public static function additionalConfigKeys()
     {
-        return ['private_key', 'passphrase', 'signer'];
+        return ['private_key', 'passphrase', 'signer', 'jwt_issued_time_leeway'];
     }
 }

--- a/src/Apple/README.md
+++ b/src/Apple/README.md
@@ -34,7 +34,9 @@ Add lines to the configuration as follows:
   'private_key' => env('APPLE_PRIVATE_KEY'), // Required. Must be absolute path, e.g. /var/www/cert/AuthKey_XYZ.p8
   'passphrase' => env('APPLE_PASSPHRASE'), // Optional. Set if your private key have a passphrase.
   'signer' => env('APPLE_SIGNER'), // Optional. Signer used for Configuration::forSymmetricSigner(). Default: \Lcobucci\JWT\Signer\Ecdsa\Sha256
-  'redirect' => env('APPLE_REDIRECT_URI') // Required.
+  'redirect' => env('APPLE_REDIRECT_URI'), // Required.
+
+  'jwt_issued_time_leeway' => env('APPLE_JWT_ISSUED_TIME_LEEWAY'), // Optional. Set this to add a leeway to your JWT issued_time value. See section below
 ],
 ```
 
@@ -85,6 +87,18 @@ return Socialite::driver('apple')->redirect();
 - ``id``
 - ``name``
 - ``email``
+
+### Known Issues
+
+#### JWT Issued_at
+Sometimes the plugin may throw an exception due to a mismatch in time - See #1354. Use `config('services.apple.jwt_issued_time_leeway')` to 'rewind' the time. Default value is 3 seconds (PT3S).
+
+Examples of possible values are PT3S -> 3 seconds, PT1M -> 1 Minute etc ...
+
+The thrown exception may look like this:
+```
+[object] (Laravel\\Socialite\\Two\\InvalidStateException(code: 0): The token violates some mandatory constraints, details:                                                                                           - The token was issued in the future at /vendor/socialiteproviders/apple/Provider.php:207)                      [stacktrace]              
+```
 
 ### Reference
 


### PR DESCRIPTION
allow customisable leeway for JWT issued time in Apple provider by adding config key: jwt_issued_time_leeway.

The hardcoded fix for #1354 in #1357 still ended up being too low for my use case. Adding customisable/adjustable jwt_issued_time_leeway would fix it for everyone as suggested by @SvenRtbg in https://github.com/SocialiteProviders/Providers/issues/1354#issuecomment-2860440280
