### PR TITLE
fix: use PKCE for deviantART

### DIFF
--- a/src/Deviantart/Provider.php
+++ b/src/Deviantart/Provider.php
@@ -12,6 +12,8 @@ class Provider extends AbstractProvider
 
     protected $scopes = ['basic'];
 
+    protected $usesPKCE = true;
+
     protected function getAuthUrl($state): string
     {
         return $this->buildAuthUrlFromBase('https://www.deviantart.com/oauth2/authorize', $state);


### PR DESCRIPTION
Accidentally submitted this to the read-only split repo first. Whoops!

deviantART recently changed to [using OAuth 2.1 for newly registered applications](https://www.deviantart.com/developers/authentication#:~:text=OAuth%202.1%20and%20OAuth%202.0) and now requires the use of PKCE. This is just a small PR that adds in the `$usesPKCE = true` variable as added to Socialite [here](https://github.com/laravel/socialite/pull/518).

Thanks for your time!