### PR TITLE
Add OpenID Connect

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "require-dev": {
         "composer/semver": "^3.0",
         "guzzlehttp/guzzle": "^7.9",
+        "illuminate/cache": "^12.0",
         "illuminate/http": "^12.0",
         "laravel/pint": "^1.18",
         "mockery/mockery": "^1.6",

--- a/src/OpenIDConnect/OpenIDConnectExtendSocialite.php
+++ b/src/OpenIDConnect/OpenIDConnectExtendSocialite.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SocialiteProviders\OpenIDConnect;
+
+use SocialiteProviders\Manager\SocialiteWasCalled;
+
+class OpenIDConnectExtendSocialite
+{
+    public function handle(SocialiteWasCalled $socialiteWasCalled): void
+    {
+        $socialiteWasCalled->extendSocialite('openidconnect', Provider::class);
+    }
+}

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -1,0 +1,538 @@
+<?php
+
+namespace SocialiteProviders\OpenIDConnect;
+
+use Exception;
+use Firebase\JWT\JWK;
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\RequestOptions;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use JsonException;
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
+use SocialiteProviders\Manager\OAuth2\User;
+
+class Provider extends AbstractProvider
+{
+    public const IDENTIFIER = 'OPENIDCONNECT';
+
+    public $configurations = null;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopes = [
+        'openid',
+        'email',
+        'profile',
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopeSeparator = ' ';
+
+    /**
+     * Indicates if the nonce should be utilized.
+     */
+    protected bool $usesNonce = true;
+
+    /**
+     * Use PKCE by default (Authorization Code Flow + PKCE).
+     * This follows OAuth 2.1 / current OIDC best practice.
+     */
+    protected $pkceEnabled = true;
+
+    /**
+     * Indicates if JWT signature verification should be enabled.
+     * Can be overridden by config 'verify_jwt'.
+     */
+    protected bool $verifyJwt = false;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function additionalConfigKeys(): array
+    {
+        return [
+            'base_url',
+            'scopes',
+            'verify_jwt',
+            'jwt_public_key',
+            'jwt_algorithm',
+            'issuer',
+            'token_auth_method',
+            'post_logout_redirect_uri',
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function redirect(): RedirectResponse
+    {
+        $state = null;
+
+        if ($this->usesState()) {
+            $this->request->session()->put('state', $state = $this->getState());
+        }
+
+        if ($this->usesNonce()) {
+            $this->request->session()->put('nonce', $this->getNonce());
+        }
+
+        if ($this->usesPKCE()) {
+            $this->request->session()->put('code_verifier', $this->getCodeVerifier());
+        }
+
+        return new RedirectResponse($this->getAuthUrl($state));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getScopes(): array
+    {
+        if ($this->getConfig('scopes')) {
+            return array_merge($this->scopes, explode(' ', $this->getConfig('scopes')));
+        }
+
+        return $this->scopes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenUrl(): string
+    {
+        return $this->getOpenIdConfig()['token_endpoint'];
+    }
+
+    /**
+     * Get the userinfo URL for the provider.
+     *
+     * @throws GuzzleException
+     */
+    protected function getUserInfoUrl(): string
+    {
+        return $this->getOpenIdConfig()['userinfo_endpoint'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAuthUrl($state): string
+    {
+        return $this->buildAuthUrlFromBase(
+            $this->getOpenIdConfig()['authorization_endpoint'],
+            $state
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getCodeFields($state = null): array
+    {
+        $fields = parent::getCodeFields($state);
+
+        if ($this->usesNonce()) {
+            $fields['nonce'] = $this->getCurrentNonce();
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Determine if the provider is operating with nonce.
+     */
+    protected function usesNonce(): bool
+    {
+        return $this->usesNonce;
+    }
+
+    /**
+     * Get a newly generated nonce.
+     */
+    protected function getNonce(): string
+    {
+        return Str::random(40);
+    }
+
+    /**
+     * Determine if JWT signature verification is enabled.
+     */
+    protected function shouldVerifyJwt(): bool
+    {
+        return (bool) $this->getConfig('verify_jwt', $this->verifyJwt);
+    }
+
+    /**
+     * Get the current nonce stored in the session.
+     */
+    protected function getCurrentNonce(): ?string
+    {
+        return $this->request->session()->get('nonce');
+    }
+
+    /**
+     * @throws GuzzleException
+     */
+    protected function getOpenIdConfig(): array
+    {
+        if ($this->configurations === null) {
+            $configUrl = rtrim($this->getConfig('base_url'), '/').'/.well-known/openid-configuration';
+            $cacheKey = 'openidconnect_discovery_'.md5($configUrl);
+
+            $this->configurations = Cache::remember($cacheKey, 3600, function () use ($configUrl) {
+                try {
+                    $response = $this->getHttpClient()->get($configUrl);
+
+                    return json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+                } catch (Exception $e) {
+                    throw new InvalidArgumentException('Unable to get the OIDC configuration from '.$configUrl.': '.$e->getMessage());
+                }
+            });
+        }
+
+        return $this->configurations;
+    }
+
+    /**
+     * Get the JSON Web Key Set from the OIDC provider.
+     *
+     * @throws GuzzleException
+     */
+    protected function getJwks(): array
+    {
+        $cacheKey = 'openidconnect_jwks_'.md5($this->getConfig('base_url'));
+
+        return Cache::remember($cacheKey, 3600, function () {
+            $config = $this->getOpenIdConfig();
+
+            if (! isset($config['jwks_uri'])) {
+                throw new InvalidArgumentException('JWKS URI not found in OIDC configuration');
+            }
+
+            try {
+                $response = $this->getHttpClient()->get($config['jwks_uri']);
+
+                return json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+            } catch (Exception $e) {
+                throw new InvalidArgumentException('Unable to fetch JWKS: '.$e->getMessage());
+            }
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function user()
+    {
+        if ($this->user) {
+            return $this->user;
+        }
+
+        if ($this->hasInvalidState()) {
+            throw new InvalidArgumentException('Callback: invalid state.', 401);
+        }
+
+        $tokenResponse = $this->getAccessTokenResponse($this->request->input('code'));
+
+        $payload = $this->decodeJWT($tokenResponse['id_token'], $tokenResponse['access_token'] ?? null);
+
+        if ($this->hasEmptyEmail($payload)) {
+            $payload = $this->getUserByToken($tokenResponse['access_token']);
+            if (empty($payload['email'] ?? null)) {
+                throw new InvalidArgumentException('JWT: User has no email.', 401);
+            }
+        }
+
+        $raw = (array) $payload;
+        $raw['id_token'] = $tokenResponse['id_token'];
+
+        $this->user = $this->mapUserToObject($raw);
+
+        return $this->user->setToken($tokenResponse['access_token'])
+            ->setRefreshToken($tokenResponse['refresh_token'] ?? null)
+            ->setExpiresIn($tokenResponse['expires_in']);
+    }
+
+    protected function decodeJWT(string $jwt, ?string $accessToken = null)
+    {
+        $header = $this->decodeJwtHeader($jwt);
+        $alg = $header->alg ?? null;
+
+        if ($this->shouldVerifyJwt()) {
+            $payload = $this->verifyAndDecodeJWT($jwt, $alg);
+        } else {
+            try {
+                [, $jwtPayload] = explode('.', $jwt);
+                $payload = json_decode($this->base64UrlDecode($jwtPayload));
+            } catch (Exception $e) {
+                throw new InvalidArgumentException('JWT: Failed to parse.', 401);
+            }
+        }
+
+        $this->validateIdTokenClaims($payload, $alg, $accessToken);
+
+        if ($this->usesNonce()) {
+            $this->request->session()->forget('nonce');
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Verify the JWT signature and decode it.
+     */
+    protected function verifyAndDecodeJWT(string $jwt, ?string $alg)
+    {
+        try {
+            $publicKey = $this->getConfig('jwt_public_key');
+            $configuredAlg = $this->getConfig('jwt_algorithm') ?: $alg ?: 'RS256';
+
+            if ($publicKey) {
+                $decoded = JWT::decode($jwt, new Key($publicKey, $configuredAlg));
+            } else {
+                $decoded = JWT::decode($jwt, JWK::parseKeySet($this->getJwks(), $configuredAlg));
+            }
+
+            return json_decode(json_encode($decoded));
+        } catch (Exception $e) {
+            throw new InvalidArgumentException('JWT: Verification failed - '.$e->getMessage(), 401);
+        }
+    }
+
+    protected function decodeJwtHeader(string $jwt)
+    {
+        try {
+            [$headerB64] = explode('.', $jwt);
+
+            return json_decode($this->base64UrlDecode($headerB64));
+        } catch (Exception $e) {
+            throw new InvalidArgumentException('JWT: Failed to parse header.', 401);
+        }
+    }
+
+    /**
+     * Validate the standard OIDC id_token claims: nonce, iss, aud, azp, at_hash.
+     */
+    protected function validateIdTokenClaims($payload, ?string $alg, ?string $accessToken): void
+    {
+        if ($this->isInvalidNonce($payload->nonce ?? null)) {
+            throw new InvalidArgumentException('JWT: Contains an invalid nonce.', 401);
+        }
+
+        $expectedIssuer = $this->getConfig('issuer') ?: ($this->getOpenIdConfig()['issuer'] ?? null);
+        if ($expectedIssuer !== null && ($payload->iss ?? null) !== $expectedIssuer) {
+            throw new InvalidArgumentException('JWT: Invalid issuer.', 401);
+        }
+
+        $aud = $payload->aud ?? null;
+        $audList = is_array($aud) ? $aud : [$aud];
+        if (! in_array($this->clientId, $audList, true)) {
+            throw new InvalidArgumentException('JWT: Invalid audience.', 401);
+        }
+
+        if (is_array($aud) && count($aud) > 1 && ($payload->azp ?? null) !== $this->clientId) {
+            throw new InvalidArgumentException('JWT: Invalid authorized party (azp).', 401);
+        }
+
+        if ($accessToken !== null && isset($payload->at_hash) && $alg) {
+            $this->validateAtHash($payload->at_hash, $accessToken, $alg);
+        }
+    }
+
+    protected function validateAtHash(string $atHash, string $accessToken, string $alg): void
+    {
+        $map = ['256' => 'sha256', '384' => 'sha384', '512' => 'sha512'];
+        $bits = substr($alg, -3);
+
+        if (! isset($map[$bits])) {
+            return;
+        }
+
+        $digest = hash($map[$bits], $accessToken, true);
+        $expected = $this->base64UrlEncode(substr($digest, 0, intdiv(strlen($digest), 2)));
+
+        if (! hash_equals($expected, $atHash)) {
+            throw new InvalidArgumentException('JWT: at_hash mismatch.', 401);
+        }
+    }
+
+    private function base64UrlDecode(string $data): string
+    {
+        return base64_decode(str_pad(strtr($data, '-_', '+/'), strlen($data) % 4, '=', STR_PAD_RIGHT));
+    }
+
+    private function base64UrlEncode(string $data): string
+    {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+
+    /**
+     * Determine if the current token has a mismatching nonce.
+     */
+    protected function isInvalidNonce($nonce): bool
+    {
+        if (! $this->usesNonce()) {
+            return false;
+        }
+
+        return ! (is_string($nonce) && strlen($nonce) > 0 && $nonce === $this->getCurrentNonce());
+    }
+
+    protected function hasEmptyEmail($payload): bool
+    {
+        if (is_array($payload)) {
+            return empty($payload['email'] ?? null);
+        }
+
+        return empty($payload->email ?? null);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return (new User)->setRaw($user)->map([
+            'id'          => $user['sub'] ?? null,
+            'email'       => $user['email'] ?? null,
+            'name'        => $user['name'] ?? null,
+            'nickname'    => $user['nickname'] ?? null,
+            'given_name'  => $user['given_name'] ?? null,
+            'family_name' => $user['family_name'] ?? null,
+            'idp'         => $user['idp'] ?? null,
+            'role'        => $user['role'] ?? null,
+            'groups'      => $user['groups'] ?? null,
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws JsonException|GuzzleException
+     */
+    public function getAccessTokenResponse($code)
+    {
+        $fields = array_merge(
+            $this->getTokenFields($code),
+            ['grant_type' => 'authorization_code']
+        );
+
+        $response = $this->getHttpClient()->post($this->getTokenUrl(), $this->tokenRequestOptions($fields));
+
+        return json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * Build Guzzle request options for the token endpoint, applying the
+     * configured client authentication method (client_secret_post or
+     * client_secret_basic).
+     */
+    protected function tokenRequestOptions(array $fields): array
+    {
+        $method = $this->resolveTokenAuthMethod();
+
+        $options = [RequestOptions::HEADERS => ['Accept' => 'application/json']];
+
+        if ($method === 'client_secret_basic') {
+            $options[RequestOptions::AUTH] = [$this->clientId, $this->clientSecret];
+            unset($fields['client_id'], $fields['client_secret']);
+        }
+
+        $options[RequestOptions::FORM_PARAMS] = $fields;
+
+        return $options;
+    }
+
+    /**
+     * Pick the client authentication method. Explicit config wins; otherwise
+     * we consult `token_endpoint_auth_methods_supported` from discovery and
+     * prefer client_secret_basic (the OIDC-registered default) when offered.
+     */
+    protected function resolveTokenAuthMethod(): string
+    {
+        $configured = $this->getConfig('token_auth_method');
+        if ($configured) {
+            return $configured;
+        }
+
+        $supported = $this->getOpenIdConfig()['token_endpoint_auth_methods_supported'] ?? [];
+        if (in_array('client_secret_basic', $supported, true)) {
+            return 'client_secret_basic';
+        }
+
+        return 'client_secret_post';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByToken($token)
+    {
+        $response = $this->getHttpClient()->get($this->getUserInfoUrl(), [
+            RequestOptions::HEADERS => [
+                'Accept'        => 'application/json',
+                'Authorization' => 'Bearer '.$token,
+            ],
+        ]);
+
+        return json_decode((string) $response->getBody(), true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function refreshToken($refreshToken)
+    {
+        $response = $this->getHttpClient()->post($this->getTokenUrl(), $this->tokenRequestOptions([
+            'client_id'     => $this->clientId,
+            'client_secret' => $this->clientSecret,
+            'grant_type'    => 'refresh_token',
+            'refresh_token' => $refreshToken,
+        ]));
+
+        return json_decode((string) $response->getBody(), true);
+    }
+
+    /**
+     * Build an RP-initiated logout redirect.
+     *
+     * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html
+     *
+     * @param  string|null  $idToken                 id_token returned at login; most IdPs require it as `id_token_hint`.
+     * @param  string|null  $postLogoutRedirectUri  Optional override; falls back to the `post_logout_redirect_uri` config.
+     * @param  array        $extra                   Additional query params (e.g. `ui_locales`).
+     *
+     * @throws GuzzleException
+     */
+    public function logout(?string $idToken = null, ?string $postLogoutRedirectUri = null, array $extra = []): RedirectResponse
+    {
+        $config = $this->getOpenIdConfig();
+
+        if (empty($config['end_session_endpoint'])) {
+            throw new InvalidArgumentException('Provider does not advertise an end_session_endpoint.');
+        }
+
+        $state = Str::random(40);
+        if ($this->request->hasSession()) {
+            $this->request->session()->put('logout_state', $state);
+        }
+
+        $params = array_filter(array_merge([
+            'id_token_hint'            => $idToken,
+            'client_id'                => $this->clientId,
+            'post_logout_redirect_uri' => $postLogoutRedirectUri ?? $this->getConfig('post_logout_redirect_uri'),
+            'state'                    => $state,
+        ], $extra), fn ($v) => $v !== null && $v !== '');
+
+        return new RedirectResponse($config['end_session_endpoint'].'?'.http_build_query($params));
+    }
+}

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -67,6 +67,7 @@ class Provider extends AbstractProvider
             'issuer',
             'token_auth_method',
             'post_logout_redirect_uri',
+            'cache_ttl',
         ];
     }
 
@@ -172,6 +173,14 @@ class Provider extends AbstractProvider
     }
 
     /**
+     * TTL (in seconds) for the cached discovery document and JWKS.
+     */
+    protected function getCacheTtl(): int
+    {
+        return (int) ($this->getConfig('cache_ttl') ?: 3600);
+    }
+
+    /**
      * Get the current nonce stored in the session.
      */
     protected function getCurrentNonce(): ?string
@@ -188,7 +197,7 @@ class Provider extends AbstractProvider
             $configUrl = rtrim($this->getConfig('base_url'), '/').'/.well-known/openid-configuration';
             $cacheKey = 'openidconnect_discovery_'.md5($configUrl);
 
-            $this->configurations = Cache::remember($cacheKey, 3600, function () use ($configUrl) {
+            $this->configurations = Cache::remember($cacheKey, $this->getCacheTtl(), function () use ($configUrl) {
                 try {
                     $response = $this->getHttpClient()->get($configUrl);
 
@@ -209,9 +218,7 @@ class Provider extends AbstractProvider
      */
     protected function getJwks(): array
     {
-        $cacheKey = 'openidconnect_jwks_'.md5($this->getConfig('base_url'));
-
-        return Cache::remember($cacheKey, 3600, function () {
+        return Cache::remember($this->jwksCacheKey(), $this->getCacheTtl(), function () {
             $config = $this->getOpenIdConfig();
 
             if (! isset($config['jwks_uri'])) {
@@ -299,13 +306,37 @@ class Provider extends AbstractProvider
             if ($publicKey) {
                 $decoded = JWT::decode($jwt, new Key($publicKey, $configuredAlg));
             } else {
-                $decoded = JWT::decode($jwt, JWK::parseKeySet($this->getJwks(), $configuredAlg));
+                $kid = $this->decodeJwtHeader($jwt)->kid ?? null;
+                $jwks = $this->getJwks();
+
+                if ($kid && ! $this->jwksContainsKid($jwks, $kid)) {
+                    Cache::forget($this->jwksCacheKey());
+                    $jwks = $this->getJwks();
+                }
+
+                $decoded = JWT::decode($jwt, JWK::parseKeySet($jwks, $configuredAlg));
             }
 
             return json_decode(json_encode($decoded));
         } catch (Exception $e) {
             throw new InvalidArgumentException('JWT: Verification failed - '.$e->getMessage(), 401);
         }
+    }
+
+    protected function jwksContainsKid(array $jwks, string $kid): bool
+    {
+        foreach ($jwks['keys'] ?? [] as $key) {
+            if (($key['kid'] ?? null) === $kid) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function jwksCacheKey(): string
+    {
+        return 'openidconnect_jwks_'.md5($this->getConfig('base_url'));
     }
 
     protected function decodeJwtHeader(string $jwt)

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -623,4 +623,37 @@ class Provider extends AbstractProvider
 
         return new RedirectResponse($config['end_session_endpoint'].'?'.http_build_query($params));
     }
+
+    /**
+     * Revoke an access or refresh token at the IdP's revocation endpoint.
+     *
+     * @see https://datatracker.ietf.org/doc/html/rfc7009
+     *
+     * @param  string  $token          The token to revoke.
+     * @param  string  $tokenTypeHint  'access_token' or 'refresh_token'.
+     *
+     * @throws GuzzleException
+     */
+    public function revoke(string $token, string $tokenTypeHint = 'refresh_token'): bool
+    {
+        $config = $this->getOpenIdConfig();
+
+        if (empty($config['revocation_endpoint'])) {
+            throw new InvalidArgumentException('Provider does not advertise a revocation_endpoint.');
+        }
+
+        $response = $this->getHttpClient()->post(
+            $config['revocation_endpoint'],
+            $this->tokenRequestOptions([
+                'token'           => $token,
+                'token_type_hint' => $tokenTypeHint,
+                'client_id'       => $this->clientId,
+                'client_secret'   => $this->clientSecret,
+            ])
+        );
+
+        // RFC 7009: a successful response is 200, regardless of whether the
+        // token was valid. Some IdPs return 204.
+        return in_array($response->getStatusCode(), [200, 204], true);
+    }
 }

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -656,4 +656,60 @@ class Provider extends AbstractProvider
         // token was valid. Some IdPs return 204.
         return in_array($response->getStatusCode(), [200, 204], true);
     }
+
+    /**
+     * Verify a back-channel logout token posted to the RP by the IdP.
+     *
+     * @see https://openid.net/specs/openid-connect-backchannel-1_0.html
+     *
+     * Performs signature verification (always — unlike id_token decoding, the
+     * logout token has no session nonce and must be trusted purely on its
+     * signature), then enforces the spec's claim rules. Returns the decoded
+     * payload so the caller can destroy sessions matching `sid` / `sub`.
+     *
+     * The caller is responsible for:
+     *   - ensuring the jti has not been seen before (replay protection),
+     *   - mapping `sid`/`sub` to local sessions and invalidating them.
+     *
+     * @throws InvalidArgumentException if the token is invalid.
+     */
+    public function verifyLogoutToken(string $logoutToken): array
+    {
+        $header = $this->decodeJwtHeader($logoutToken);
+        $alg = $header->alg ?? null;
+
+        $payload = $this->verifyAndDecodeJWT($logoutToken, $alg);
+
+        $expectedIssuer = $this->getConfig('issuer') ?: ($this->getOpenIdConfig()['issuer'] ?? null);
+        if ($expectedIssuer !== null && ($payload->iss ?? null) !== $expectedIssuer) {
+            throw new InvalidArgumentException('Logout token: invalid issuer.', 401);
+        }
+
+        $aud = $payload->aud ?? null;
+        $audList = is_array($aud) ? $aud : [$aud];
+        if (! in_array($this->clientId, $audList, true)) {
+            throw new InvalidArgumentException('Logout token: invalid audience.', 401);
+        }
+
+        $this->validateTimeClaims($payload);
+
+        if (empty($payload->jti ?? null)) {
+            throw new InvalidArgumentException('Logout token: missing jti.', 401);
+        }
+
+        if (isset($payload->nonce)) {
+            throw new InvalidArgumentException('Logout token: must not contain a nonce.', 401);
+        }
+
+        $events = (array) ($payload->events ?? []);
+        if (! array_key_exists('http://schemas.openid.net/event/backchannel-logout', $events)) {
+            throw new InvalidArgumentException('Logout token: missing backchannel-logout event.', 401);
+        }
+
+        if (empty($payload->sub ?? null) && empty($payload->sid ?? null)) {
+            throw new InvalidArgumentException('Logout token: must contain sub and/or sid.', 401);
+        }
+
+        return (array) $payload;
+    }
 }

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -68,6 +68,9 @@ class Provider extends AbstractProvider
             'token_auth_method',
             'post_logout_redirect_uri',
             'cache_ttl',
+            'clock_skew',
+            'http_timeout',
+            'http_connect_timeout',
         ];
     }
 
@@ -181,6 +184,24 @@ class Provider extends AbstractProvider
     }
 
     /**
+     * {@inheritdoc}
+     *
+     * Apply connect/read timeouts so a slow or hanging IdP doesn't tie up
+     * PHP workers. Defaults: 5s connect, 10s total.
+     */
+    protected function getHttpClient()
+    {
+        if (is_null($this->httpClient)) {
+            $this->httpClient = new \GuzzleHttp\Client([
+                'connect_timeout' => (float) ($this->getConfig('http_connect_timeout') ?: 5),
+                'timeout'         => (float) ($this->getConfig('http_timeout') ?: 10),
+            ]);
+        }
+
+        return $this->httpClient;
+    }
+
+    /**
      * Get the current nonce stored in the session.
      */
     protected function getCurrentNonce(): ?string
@@ -244,8 +265,17 @@ class Provider extends AbstractProvider
             return $this->user;
         }
 
+        if ($this->request->filled('error')) {
+            $description = $this->request->input('error_description') ?: $this->request->input('error');
+            throw new InvalidArgumentException('Callback: IdP returned error - '.$description, 401);
+        }
+
         if ($this->hasInvalidState()) {
             throw new InvalidArgumentException('Callback: invalid state.', 401);
+        }
+
+        if (! $this->request->filled('code')) {
+            throw new InvalidArgumentException('Callback: missing authorization code.', 401);
         }
 
         $tokenResponse = $this->getAccessTokenResponse($this->request->input('code'));
@@ -300,6 +330,8 @@ class Provider extends AbstractProvider
     protected function verifyAndDecodeJWT(string $jwt, ?string $alg)
     {
         try {
+            JWT::$leeway = (int) ($this->getConfig('clock_skew') ?? 0);
+
             $publicKey = $this->getConfig('jwt_public_key');
             $configuredAlg = $this->getConfig('jwt_algorithm') ?: $alg ?: 'RS256';
 
@@ -376,6 +408,31 @@ class Provider extends AbstractProvider
 
         if ($accessToken !== null && isset($payload->at_hash) && $alg) {
             $this->validateAtHash($payload->at_hash, $accessToken, $alg);
+        }
+
+        $this->validateTimeClaims($payload);
+    }
+
+    /**
+     * Validate exp/nbf/iat with configurable leeway. Runs in both verified
+     * and unverified paths so a stale id_token is never accepted even when
+     * signature verification is disabled.
+     */
+    protected function validateTimeClaims($payload): void
+    {
+        $now = time();
+        $leeway = (int) ($this->getConfig('clock_skew') ?? 0);
+
+        if (isset($payload->exp) && $now - $leeway >= (int) $payload->exp) {
+            throw new InvalidArgumentException('JWT: Token has expired.', 401);
+        }
+
+        if (isset($payload->nbf) && $now + $leeway < (int) $payload->nbf) {
+            throw new InvalidArgumentException('JWT: Token not yet valid.', 401);
+        }
+
+        if (isset($payload->iat) && $now + $leeway < (int) $payload->iat) {
+            throw new InvalidArgumentException('JWT: Token issued in the future.', 401);
         }
     }
 

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -326,18 +326,48 @@ class Provider extends AbstractProvider
 
     /**
      * Verify the JWT signature and decode it.
+     *
+     * The accepted signing algorithms are pinned by the RP and the token's own
+     * `alg` header is only ever checked against that allow list, never used to
+     * choose the verification algorithm. Deriving it from the header is the
+     * algorithm substitution attack of RFC 8725 section 2.1: php-jwt's only
+     * algorithm check compares the header against the Key it was handed, so if
+     * both come from the header an attacker can claim `alg: HS256` and
+     * HMAC-sign the token with the (non-secret) PEM public key as the MAC
+     * secret. OIDC Core 3.1.3.7 step 7 requires the registered
+     * `id_token_signed_response_alg` instead.
      */
     protected function verifyAndDecodeJWT(string $jwt, ?string $alg)
     {
+        $allowed = $this->getAllowedSigningAlgorithms();
+
+        if ($alg === null || ! in_array($alg, $allowed, true)) {
+            throw new InvalidArgumentException(
+                'JWT: Disallowed signing algorithm ['.($alg ?? 'missing').']; expected one of ['.implode(', ', $allowed).'].',
+                401
+            );
+        }
+
         try {
             JWT::$leeway = (int) ($this->getConfig('clock_skew') ?? 0);
 
             $publicKey = $this->getConfig('jwt_public_key');
-            $configuredAlg = $this->getConfig('jwt_algorithm') ?: $alg ?: 'RS256';
 
             if ($publicKey) {
-                $decoded = JWT::decode($jwt, new Key($publicKey, $configuredAlg));
+                // A PEM public key or certificate is not secret, so it must
+                // never be usable as an HMAC secret.
+                if ($this->isHmacAlgorithm($alg) && $this->isAsymmetricKey($publicKey)) {
+                    throw new InvalidArgumentException('HMAC algorithms cannot be used with an asymmetric public key.');
+                }
+
+                $decoded = JWT::decode($jwt, new Key($publicKey, $alg));
             } else {
+                // A JWKS distributes asymmetric public keys; an HMAC secret is
+                // never published this way.
+                if ($this->isHmacAlgorithm($alg)) {
+                    throw new InvalidArgumentException('HMAC algorithms cannot be verified against a JWKS.');
+                }
+
                 $kid = $this->decodeJwtHeader($jwt)->kid ?? null;
                 $jwks = $this->getJwks();
 
@@ -346,13 +376,65 @@ class Provider extends AbstractProvider
                     $jwks = $this->getJwks();
                 }
 
-                $decoded = JWT::decode($jwt, JWK::parseKeySet($jwks, $configuredAlg));
+                $decoded = JWT::decode($jwt, JWK::parseKeySet($jwks, $alg));
             }
 
             return json_decode(json_encode($decoded));
         } catch (Exception $e) {
             throw new InvalidArgumentException('JWT: Verification failed - '.$e->getMessage(), 401);
         }
+    }
+
+    /**
+     * The signing algorithms this client accepts, in order of preference:
+     * the pinned `jwt_algorithm` config, else the OP's advertised
+     * `id_token_signing_alg_values_supported`, else RS256.
+     *
+     * `none` is never accepted.
+     *
+     * @return string[]
+     *
+     * @throws GuzzleException
+     */
+    protected function getAllowedSigningAlgorithms(): array
+    {
+        $configured = $this->getConfig('jwt_algorithm');
+
+        if ($configured) {
+            $algorithms = is_array($configured)
+                ? $configured
+                : preg_split('/[\s,]+/', (string) $configured, -1, PREG_SPLIT_NO_EMPTY);
+        } else {
+            $algorithms = (array) ($this->getOpenIdConfig()['id_token_signing_alg_values_supported'] ?? []);
+        }
+
+        $algorithms = array_values(array_filter(
+            array_map(static fn ($alg) => is_string($alg) ? trim($alg) : null, $algorithms),
+            static fn (?string $alg) => $alg !== null && $alg !== '' && strcasecmp($alg, 'none') !== 0
+        ));
+
+        return $algorithms ?: ['RS256'];
+    }
+
+    /**
+     * Determine if the algorithm is a symmetric (HMAC) one.
+     */
+    protected function isHmacAlgorithm(string $alg): bool
+    {
+        return str_starts_with(strtoupper($alg), 'HS');
+    }
+
+    /**
+     * Determine if the key material is an asymmetric public key or certificate,
+     * i.e. public information that must not double as an HMAC secret.
+     */
+    protected function isAsymmetricKey(mixed $key): bool
+    {
+        if ($key instanceof \OpenSSLAsymmetricKey || $key instanceof \OpenSSLCertificate) {
+            return true;
+        }
+
+        return is_string($key) && str_contains($key, '-----BEGIN');
     }
 
     protected function jwksContainsKid(array $jwks, string $kid): bool

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -367,7 +367,7 @@ class Provider extends AbstractProvider
     protected function getCurrentNonce(): ?string
     {
         return $this->request->hasSession()
-            ? $this->request->session()->get('nonce')
+            ? $this->request->session()->get('openidconnect_nonce')
             : null;
     }
 
@@ -575,7 +575,7 @@ class Provider extends AbstractProvider
         $this->validateIdTokenClaims($payload, $alg, $accessToken);
 
         if ($this->usesNonce() && $this->request->hasSession()) {
-            $this->request->session()->forget('nonce');
+            $this->request->session()->forget('openidconnect_nonce');
         }
 
         return $payload;

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -92,6 +92,7 @@ class Provider extends AbstractProvider
             'issuer',
             'token_auth_method',
             'post_logout_redirect_uri',
+            'logout_token_replay_ttl',
             'cache_ttl',
             'clock_skew',
             'http_timeout',

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -1161,9 +1161,14 @@ class Provider extends AbstractProvider
      * `verify_jwt`, followed by the spec's claim rules. Returns the decoded
      * payload so the caller can destroy sessions matching `sid` / `sub`.
      *
-     * The caller is responsible for:
-     *   - ensuring the jti has not been seen before (replay protection),
-     *   - mapping `sid`/`sub` to local sessions and invalidating them.
+     * Replay protection is handled here: section 2.6 requires the RP to reject
+     * a `jti` it has already acted on, and leaving that to every caller meant
+     * every caller reimplementing it, or -- more often -- not. Set
+     * `logout_token_replay_ttl` to 0 to opt out and do it yourself.
+     *
+     * The caller remains responsible for mapping `sid`/`sub` to local sessions
+     * and invalidating them, which is the only part that depends on how the
+     * application stores sessions.
      *
      * @throws InvalidArgumentException if the token is invalid.
      */
@@ -1204,6 +1209,66 @@ class Provider extends AbstractProvider
             throw new InvalidArgumentException('Logout token: must contain sub and/or sid.', 401);
         }
 
+        // Claimed last, once the token is known to be genuine. Claiming
+        // earlier would let a forged token carrying a guessed jti burn the
+        // identifier of a legitimate one that had not arrived yet.
+        $this->assertLogoutTokenNotReplayed((string) $payload->jti, $payload->exp ?? null);
+
         return (array) $payload;
+    }
+
+    /**
+     * Record a logout token's `jti`, refusing one already acted on.
+     *
+     * Cache::add is the whole mechanism: it writes only when the key is
+     * absent, and does so atomically, so two deliveries of the same token
+     * racing each other cannot both win. A plain has()/put() pair would let
+     * both through, which matters because the identity provider retries.
+     *
+     * @param  int|float|null  $expiresAt  the token's `exp`, if it carries one
+     */
+    protected function assertLogoutTokenNotReplayed(string $jti, $expiresAt = null): void
+    {
+        $ttl = $this->logoutTokenReplayTtl($expiresAt);
+
+        if ($ttl <= 0) {
+            return;
+        }
+
+        $key = 'openidconnect_logout_jti_'.md5($this->getBaseUrl().'|'.$this->clientId.'|'.$jti);
+
+        if (! Cache::add($key, true, $ttl)) {
+            throw new InvalidArgumentException('Logout token: already used.', 401);
+        }
+    }
+
+    /**
+     * How long to remember a `jti`.
+     *
+     * Long enough to outlive the token, since a token that has expired is
+     * refused on its own merits and needs no further memory. Where the token
+     * says when that is, the answer is derived from it -- an identity provider
+     * that mints long-lived logout tokens should not need this tuned to match.
+     *
+     * @param  int|float|null  $expiresAt
+     */
+    protected function logoutTokenReplayTtl($expiresAt = null): int
+    {
+        $configured = $this->getConfig('logout_token_replay_ttl');
+
+        if ($configured !== null) {
+            return (int) $configured;
+        }
+
+        if (is_numeric($expiresAt)) {
+            // Past its own expiry, plus a margin for the clock skew already
+            // tolerated when the expiry itself was checked.
+            $remaining = (int) ceil((float) $expiresAt - time());
+            $skew = (int) ($this->getConfig('clock_skew') ?? 0);
+
+            return max(60, $remaining + $skew + 60);
+        }
+
+        return 900;
     }
 }

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -336,7 +336,9 @@ class Provider extends AbstractProvider
      */
     protected function getCacheTtl(): int
     {
-        return (int) ($this->getConfig('cache_ttl') ?: 3600);
+        $ttl = $this->getConfig('cache_ttl');
+
+        return ($ttl === null || $ttl === '') ? 3600 : (int) $ttl;
     }
 
     /**

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -18,6 +18,7 @@ use InvalidArgumentException;
 use JsonException;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
+use stdClass;
 
 class Provider extends AbstractProvider
 {
@@ -556,10 +557,11 @@ class Provider extends AbstractProvider
         } else {
             // Unverified: claims are read as-is, so sub/email/groups/role are
             // only as trustworthy as the TLS connection to the token endpoint.
-            try {
-                [, $jwtPayload] = explode('.', $jwt);
-                $payload = json_decode($this->base64UrlDecode($jwtPayload));
-            } catch (Exception $e) {
+            [, $payloadSegment] = $this->jwtSegments($jwt);
+
+            $payload = json_decode($this->base64UrlDecode($payloadSegment));
+
+            if (! $payload instanceof stdClass) {
                 throw new InvalidArgumentException('JWT: Failed to parse.', 401);
             }
         }
@@ -704,13 +706,35 @@ class Provider extends AbstractProvider
 
     protected function decodeJwtHeader(string $jwt)
     {
-        try {
-            [$headerB64] = explode('.', $jwt);
+        [$headerSegment] = $this->jwtSegments($jwt);
 
-            return json_decode($this->base64UrlDecode($headerB64));
-        } catch (Exception $e) {
+        $header = json_decode($this->base64UrlDecode($headerSegment));
+
+        if (! $header instanceof stdClass) {
             throw new InvalidArgumentException('JWT: Failed to parse header.', 401);
         }
+
+        return $header;
+    }
+
+    /**
+     * Split a JWT into its three segments.
+     *
+     * Destructuring explode() directly meant a token with no '.' produced a
+     * warning and then a TypeError from the null segment -- an Error, so it
+     * escaped the surrounding catch (Exception) entirely.
+     *
+     * @return string[]
+     */
+    protected function jwtSegments(string $jwt): array
+    {
+        $segments = explode('.', $jwt);
+
+        if (count($segments) !== 3) {
+            throw new InvalidArgumentException('JWT: Malformed token, expected three segments.', 401);
+        }
+
+        return $segments;
     }
 
     /**
@@ -808,9 +832,27 @@ class Provider extends AbstractProvider
         }
     }
 
+    /**
+     * Decode a base64url segment, rejecting anything malformed.
+     *
+     * Strict mode is the point of padding correctly: without it, base64_decode
+     * silently discards characters outside the alphabet and returns plausible
+     * bytes for input that was never valid base64. These segments are
+     * attacker-supplied, and the resulting garbage previously surfaced much
+     * later as a confusing "invalid nonce" rather than as a parse failure.
+     */
     private function base64UrlDecode(string $data): string
     {
-        return base64_decode(str_pad(strtr($data, '-_', '+/'), intdiv(strlen($data) + 3, 4) * 4, '=', STR_PAD_RIGHT));
+        $decoded = base64_decode(
+            str_pad(strtr($data, '-_', '+/'), intdiv(strlen($data) + 3, 4) * 4, '=', STR_PAD_RIGHT),
+            true
+        );
+
+        if ($decoded === false) {
+            throw new InvalidArgumentException('JWT: Malformed base64url segment.', 401);
+        }
+
+        return $decoded;
     }
 
     private function base64UrlEncode(string $data): string

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -45,7 +45,7 @@ class Provider extends AbstractProvider
      * Use PKCE by default (Authorization Code Flow + PKCE).
      * This follows OAuth 2.1 / current OIDC best practice.
      */
-    protected $pkceEnabled = true;
+    protected $usesPKCE = true;
 
     /**
      * Indicates if JWT signature verification should be enabled.

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -6,6 +6,7 @@ use Exception;
 use Firebase\JWT\JWK;
 use Firebase\JWT\JWT;
 use Firebase\JWT\Key;
+use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\RequestOptions;
 use Illuminate\Http\RedirectResponse;
@@ -343,8 +344,8 @@ class Provider extends AbstractProvider
      */
     protected function getHttpClient()
     {
-        if (is_null($this->httpClient)) {
-            $this->httpClient = new \GuzzleHttp\Client([
+        if ($this->httpClient === null) {
+            $this->httpClient = new Client([
                 'connect_timeout' => (float) ($this->getConfig('http_connect_timeout') ?: 5),
                 'timeout'         => (float) ($this->getConfig('http_timeout') ?: 10),
             ]);
@@ -991,9 +992,9 @@ class Provider extends AbstractProvider
      *
      * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html
      *
-     * @param  string|null  $idToken                 id_token returned at login; most IdPs require it as `id_token_hint`.
+     * @param  string|null  $idToken  id_token returned at login; most IdPs require it as `id_token_hint`.
      * @param  string|null  $postLogoutRedirectUri  Optional override; falls back to the `post_logout_redirect_uri` config.
-     * @param  array        $extra                   Additional query params (e.g. `ui_locales`).
+     * @param  array  $extra  Additional query params (e.g. `ui_locales`).
      *
      * @throws GuzzleException
      */
@@ -1059,7 +1060,7 @@ class Provider extends AbstractProvider
      *
      * @see https://datatracker.ietf.org/doc/html/rfc7009
      *
-     * @param  string  $token          The token to revoke.
+     * @param  string  $token  The token to revoke.
      * @param  string  $tokenTypeHint  'access_token' or 'refresh_token'.
      *
      * @throws GuzzleException

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -470,6 +470,8 @@ class Provider extends AbstractProvider
             throw new InvalidArgumentException('Token endpoint: malformed response.', 401);
         }
 
+        $this->credentialsResponseBody = $tokenResponse;
+
         // Not every IdP signals failure with a 4xx -- some return 200 with an
         // error body, which Guzzle will not raise for us.
         if (Arr::has($tokenResponse, 'error')) {
@@ -500,17 +502,23 @@ class Provider extends AbstractProvider
             }
         }
 
-        $raw = (array) $payload;
-        $raw['id_token'] = $idToken;
+        $this->user = $this->mapUserToObject((array) $payload);
 
-        $this->user = $this->mapUserToObject($raw);
+        // Reimplementing user() means re-establishing what the Manager's base
+        // sets, or this provider alone returns null for the standard
+        // accessTokenResponseBody and approvedScopes. The former is also where
+        // the id_token belongs, rather than being folded into the raw claims.
+        if ($this->user instanceof User) {
+            $this->user->setAccessTokenResponseBody($this->credentialsResponseBody);
+        }
 
         // expires_in is optional (RFC 6749 4.2.2), as are access_token and
         // refresh_token here, so read them all defensively -- as Socialite's
         // and the Manager's own user() implementations do.
         return $this->user->setToken($accessToken)
-            ->setRefreshToken(Arr::get($tokenResponse, 'refresh_token'))
-            ->setExpiresIn(Arr::get($tokenResponse, 'expires_in'));
+            ->setRefreshToken($this->parseRefreshToken($tokenResponse))
+            ->setExpiresIn($this->parseExpiresIn($tokenResponse))
+            ->setApprovedScopes($this->parseApprovedScopes($tokenResponse));
     }
 
     /**

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -810,7 +810,7 @@ class Provider extends AbstractProvider
 
     private function base64UrlDecode(string $data): string
     {
-        return base64_decode(str_pad(strtr($data, '-_', '+/'), strlen($data) % 4, '=', STR_PAD_RIGHT));
+        return base64_decode(str_pad(strtr($data, '-_', '+/'), intdiv(strlen($data) + 3, 4) * 4, '=', STR_PAD_RIGHT));
     }
 
     private function base64UrlEncode(string $data): string

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -124,7 +124,7 @@ class Provider extends AbstractProvider
             if (! $this->request->hasSession()) {
                 throw new InvalidArgumentException(
                     'OIDC: PKCE requires a session to carry the code_verifier from the redirect to the callback. '
-                    .'Bind a session, or call withoutPKCE() to opt out.'
+                        .'Bind a session, or call withoutPKCE() to opt out.'
                 );
             }
 
@@ -236,8 +236,9 @@ class Provider extends AbstractProvider
         }
 
         [$base, $fragment] = array_pad(explode('#', $url, 2), 2, null);
-        $withQuery = $base . (str_contains($base, '?') ? '&' : '?') . $query;
-        return $fragment !== null ? $withQuery . '#' . $fragment : $withQuery;
+        $withQuery = $base.(str_contains($base, '?') ? '&' : '?').$query;
+
+        return $fragment !== null ? $withQuery.'#'.$fragment : $withQuery;
     }
 
     /**

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -67,6 +67,7 @@ class Provider extends AbstractProvider
         return [
             'base_url',
             'scopes',
+            'use_nonce',
             'verify_jwt',
             'jwt_public_key',
             'jwt_algorithm',
@@ -96,6 +97,18 @@ class Provider extends AbstractProvider
         }
 
         if ($this->usesPKCE()) {
+            // Socialite carries the verifier in the session between the
+            // redirect and the callback (getCodeChallenge() and
+            // getTokenFields() both read it back), so without a session bound
+            // this would fail later with an opaque "Session store not set on
+            // request." from deep inside the parent.
+            if (! $this->request->hasSession()) {
+                throw new InvalidArgumentException(
+                    'OIDC: PKCE requires a session to carry the code_verifier from the redirect to the callback. '
+                    .'Bind a session, or call withoutPKCE() to opt out.'
+                );
+            }
+
             $this->request->session()->put('code_verifier', $this->getCodeVerifier());
         }
 
@@ -158,11 +171,54 @@ class Provider extends AbstractProvider
     }
 
     /**
-     * Determine if the provider is operating with nonce.
+     * Determine if the provider is operating with a nonce.
+     *
+     * The nonce is minted at the redirect and compared at the callback, which
+     * means it has to survive in the session between two requests. A stateless
+     * flow has no such session, so requiring one there would fail every login.
+     * Dropping it is safe for the authorization code flow used here: the code
+     * is bound to this client by PKCE and the exchange happens over the back
+     * channel. OIDC Core 3.1.2.1 only makes the nonce REQUIRED for the
+     * implicit and hybrid flows, where the token travels via the browser.
      */
     protected function usesNonce(): bool
     {
+        if ($this->isStateless()) {
+            return false;
+        }
+
+        $config = $this->getConfig();
+
+        // Read the raw config for the same reason as shouldVerifyJwt():
+        // getConfig() cannot distinguish an explicit false from an absent key.
+        if (is_array($config) && isset($config['use_nonce'])) {
+            return filter_var($config['use_nonce'], FILTER_VALIDATE_BOOLEAN);
+        }
+
         return $this->usesNonce;
+    }
+
+    /**
+     * Disable the nonce for this request.
+     */
+    public function withoutNonce(): static
+    {
+        $this->usesNonce = false;
+
+        return $this;
+    }
+
+    /**
+     * Disable PKCE for this request.
+     *
+     * Socialite ships enablePKCE() but no counterpart, and its PKCE support
+     * requires a session, so a flow without one needs a way to opt out.
+     */
+    public function withoutPKCE(): static
+    {
+        $this->usesPKCE = false;
+
+        return $this;
     }
 
     /**
@@ -223,7 +279,9 @@ class Provider extends AbstractProvider
      */
     protected function getCurrentNonce(): ?string
     {
-        return $this->request->session()->get('nonce');
+        return $this->request->hasSession()
+            ? $this->request->session()->get('nonce')
+            : null;
     }
 
     /**
@@ -387,7 +445,7 @@ class Provider extends AbstractProvider
 
         $this->validateIdTokenClaims($payload, $alg, $accessToken);
 
-        if ($this->usesNonce()) {
+        if ($this->usesNonce() && $this->request->hasSession()) {
             $this->request->session()->forget('nonce');
         }
 

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -338,9 +338,24 @@ class Provider extends AbstractProvider
      */
     protected function getCacheTtl(): int
     {
-        $ttl = $this->getConfig('cache_ttl');
+        $ttl = $this->rawConfig('cache_ttl');
 
         return ($ttl === null || $ttl === '') ? 3600 : (int) $ttl;
+    }
+
+    /**
+     * Read a config value without the manager's empty() collapse.
+     *
+     * ConfigTrait::getConfig() returns the default whenever the stored value
+     * is empty(), which folds a deliberate 0 -- and the '0' an environment
+     * variable produces -- into "not configured". For a TTL, 0 is a real
+     * setting and has to survive.
+     */
+    protected function rawConfig(string $key)
+    {
+        $config = $this->getConfig();
+
+        return is_array($config) ? ($config[$key] ?? null) : null;
     }
 
     /**
@@ -1268,9 +1283,9 @@ class Provider extends AbstractProvider
      */
     protected function logoutTokenReplayTtl($expiresAt = null): int
     {
-        $configured = $this->getConfig('logout_token_replay_ttl');
+        $configured = $this->rawConfig('logout_token_replay_ttl');
 
-        if ($configured !== null) {
+        if ($configured !== null && $configured !== '') {
             return (int) $configured;
         }
 

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -656,14 +656,29 @@ class Provider extends AbstractProvider
      * Validate exp/nbf/iat with configurable leeway. Runs in both verified
      * and unverified paths so a stale id_token is never accepted even when
      * signature verification is disabled.
+     *
+     * exp is required, not optional: OIDC Core 3.1.3.7 step 9 requires the
+     * current time to be before it. php-jwt is no backstop here because its
+     * own decode() gates the exp check on isset() too (JWT.php), so a token
+     * that simply omits the claim would be accepted forever by both paths.
+     *
+     * @param  bool  $requireIat  Back-Channel Logout 2.4 requires iat as well.
      */
-    protected function validateTimeClaims($payload): void
+    protected function validateTimeClaims($payload, bool $requireIat = false): void
     {
         $now = time();
         $leeway = (int) ($this->getConfig('clock_skew') ?? 0);
 
-        if (isset($payload->exp) && $now - $leeway >= (int) $payload->exp) {
+        if (! isset($payload->exp) || ! is_numeric($payload->exp)) {
+            throw new InvalidArgumentException('JWT: Missing required exp claim.', 401);
+        }
+
+        if ($now - $leeway >= (int) $payload->exp) {
             throw new InvalidArgumentException('JWT: Token has expired.', 401);
+        }
+
+        if ($requireIat && (! isset($payload->iat) || ! is_numeric($payload->iat))) {
+            throw new InvalidArgumentException('JWT: Missing required iat claim.', 401);
         }
 
         if (isset($payload->nbf) && $now + $leeway < (int) $payload->nbf) {
@@ -934,7 +949,7 @@ class Provider extends AbstractProvider
             throw new InvalidArgumentException('Logout token: invalid audience.', 401);
         }
 
-        $this->validateTimeClaims($payload);
+        $this->validateTimeClaims($payload, requireIat: true);
 
         if (empty($payload->jti ?? null)) {
             throw new InvalidArgumentException('Logout token: missing jti.', 401);

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -26,7 +26,14 @@ class Provider extends AbstractProvider
     /**
      * {@inheritdoc}
      */
-    protected $scopes = [
+    protected $scopes = self::DEFAULT_SCOPES;
+
+    /**
+     * Tracked separately so a configured `scopes` list can replace the
+     * defaults without discarding anything added through Socialite's fluent
+     * scopes() API.
+     */
+    protected const DEFAULT_SCOPES = [
         'openid',
         'email',
         'profile',
@@ -121,11 +128,46 @@ class Provider extends AbstractProvider
      */
     public function getScopes(): array
     {
-        if ($this->getConfig('scopes')) {
-            return array_merge($this->scopes, explode(' ', $this->getConfig('scopes')));
+        $configured = $this->parseScopeList($this->getConfig('scopes'));
+
+        if ($configured === []) {
+            $scopes = $this->scopes;
+        } else {
+            // Replace the defaults rather than extend them, so an OP that does
+            // not support `profile` can be narrowed down. Anything added via
+            // Socialite's fluent scopes() is still honoured.
+            $scopes = array_merge($configured, array_diff($this->scopes, self::DEFAULT_SCOPES));
         }
 
-        return $this->scopes;
+        // `openid` is what makes this an OIDC request at all -- without it the
+        // OP returns no id_token -- so it is always sent.
+        array_unshift($scopes, 'openid');
+
+        // Repeated values are malformed, and some OPs (Azure AD B2C among
+        // them) reject the request outright.
+        return array_values(array_unique($scopes));
+    }
+
+    /**
+     * Normalise a scope list given as an array, or as a string separated by
+     * whitespace and/or commas.
+     *
+     * @return string[]
+     */
+    protected function parseScopeList(mixed $scopes): array
+    {
+        if ($scopes === null || $scopes === '' || $scopes === []) {
+            return [];
+        }
+
+        $list = is_array($scopes)
+            ? $scopes
+            : preg_split('/[\s,]+/', (string) $scopes, -1, PREG_SPLIT_NO_EMPTY);
+
+        return array_values(array_filter(
+            array_map(static fn ($scope) => is_string($scope) ? trim($scope) : null, $list ?: []),
+            static fn (?string $scope) => $scope !== null && $scope !== ''
+        ));
     }
 
     /**

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -9,6 +9,7 @@ use Firebase\JWT\Key;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\RequestOptions;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
@@ -395,23 +396,51 @@ class Provider extends AbstractProvider
 
         $tokenResponse = $this->getAccessTokenResponse($this->request->input('code'));
 
-        $payload = $this->decodeJWT($tokenResponse['id_token'], $tokenResponse['access_token'] ?? null);
+        if (! is_array($tokenResponse)) {
+            throw new InvalidArgumentException('Token endpoint: malformed response.', 401);
+        }
+
+        // Not every IdP signals failure with a 4xx -- some return 200 with an
+        // error body, which Guzzle will not raise for us.
+        if (Arr::has($tokenResponse, 'error')) {
+            $description = Arr::get($tokenResponse, 'error_description') ?: Arr::get($tokenResponse, 'error');
+            throw new InvalidArgumentException('Token endpoint: returned error - '.$description, 401);
+        }
+
+        $idToken = Arr::get($tokenResponse, 'id_token');
+
+        if (! is_string($idToken) || $idToken === '') {
+            throw new InvalidArgumentException('Token endpoint: response contained no id_token.', 401);
+        }
+
+        $accessToken = Arr::get($tokenResponse, 'access_token');
+
+        $payload = $this->decodeJWT($idToken, $accessToken);
 
         if ($this->hasEmptyEmail($payload)) {
-            $payload = $this->getUserByToken($tokenResponse['access_token']);
-            if (empty($payload['email'] ?? null)) {
+            // The userinfo endpoint is only reachable with an access token;
+            // an id_token-only response leaves the id_token claims as all we
+            // have to go on.
+            if (is_string($accessToken) && $accessToken !== '') {
+                $payload = $this->getUserByToken($accessToken);
+            }
+
+            if ($this->hasEmptyEmail($payload)) {
                 throw new InvalidArgumentException('JWT: User has no email.', 401);
             }
         }
 
         $raw = (array) $payload;
-        $raw['id_token'] = $tokenResponse['id_token'];
+        $raw['id_token'] = $idToken;
 
         $this->user = $this->mapUserToObject($raw);
 
-        return $this->user->setToken($tokenResponse['access_token'])
-            ->setRefreshToken($tokenResponse['refresh_token'] ?? null)
-            ->setExpiresIn($tokenResponse['expires_in']);
+        // expires_in is optional (RFC 6749 4.2.2), as are access_token and
+        // refresh_token here, so read them all defensively -- as Socialite's
+        // and the Manager's own user() implementations do.
+        return $this->user->setToken($accessToken)
+            ->setRefreshToken(Arr::get($tokenResponse, 'refresh_token'))
+            ->setExpiresIn(Arr::get($tokenResponse, 'expires_in'));
     }
 
     /**

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -733,7 +733,16 @@ class Provider extends AbstractProvider
             throw new InvalidArgumentException('JWT: Invalid audience.', 401);
         }
 
-        if (is_array($aud) && count($aud) > 1 && ($payload->azp ?? null) !== $this->clientId) {
+        // OIDC Core 3.1.3.7 step 4: multiple audiences should carry an azp.
+        if (is_array($aud) && count($aud) > 1 && ! isset($payload->azp)) {
+            throw new InvalidArgumentException('JWT: Multiple audiences require an azp claim.', 401);
+        }
+
+        // Step 5: whenever an azp is present it must be our client_id. This is
+        // not conditional on the audience count -- a token naming us as an
+        // audience but authorized to a different party (aud: us, azp: them) is
+        // not ours to accept.
+        if (isset($payload->azp) && $payload->azp !== $this->clientId) {
             throw new InvalidArgumentException('JWT: Invalid authorized party (azp).', 401);
         }
 

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -938,18 +938,26 @@ class Provider extends AbstractProvider
             throw new InvalidArgumentException('Provider does not advertise a revocation_endpoint.');
         }
 
-        $response = $this->getHttpClient()->post(
-            $config['revocation_endpoint'],
-            $this->tokenRequestOptions([
-                'token'           => $token,
-                'token_type_hint' => $tokenTypeHint,
-                'client_id'       => $this->clientId,
-                'client_secret'   => $this->clientSecret,
-            ])
-        );
+        $options = $this->tokenRequestOptions([
+            'token'           => $token,
+            'token_type_hint' => $tokenTypeHint,
+            'client_id'       => $this->clientId,
+            'client_secret'   => $this->clientSecret,
+        ]);
 
-        // RFC 7009: a successful response is 200, regardless of whether the
-        // token was valid. Some IdPs return 204.
+        // Guzzle raises on 4xx/5xx by default, which would leave the return
+        // value below unreachable -- only a 2xx could ever get there, so the
+        // result was always true. Worse, a non-conforming IdP answering 400
+        // for an already-revoked token would throw a ClientException out of
+        // the caller's logout flow. Branch on the status instead.
+        $options[RequestOptions::HTTP_ERRORS] = false;
+
+        $response = $this->getHttpClient()->post($config['revocation_endpoint'], $options);
+
+        // RFC 7009 section 2.2: a conforming server answers 200 whether or not
+        // the token was still valid. Some answer 204. Anything else means the
+        // revocation did not happen -- a 400 for an already-revoked token, or
+        // a 401 for rejected client credentials.
         return in_array($response->getStatusCode(), [200, 204], true);
     }
 

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -48,10 +48,16 @@ class Provider extends AbstractProvider
     protected $usesPKCE = true;
 
     /**
-     * Indicates if JWT signature verification should be enabled.
+     * Indicates if id_token signature verification should be enabled.
      * Can be overridden by config 'verify_jwt'.
+     *
+     * OIDC Core 3.1.3.7 step 6 permits skipping signature validation for an
+     * id_token fetched over the back channel, substituting TLS server
+     * validation of the token endpoint. That exemption is only as good as the
+     * transport, so this defaults to on and getBaseUrl() refuses plaintext
+     * issuers; an OP that genuinely cannot serve a JWKS has to opt out.
      */
-    protected bool $verifyJwt = false;
+    protected bool $verifyJwt = true;
 
     /**
      * {@inheritdoc}
@@ -168,11 +174,22 @@ class Provider extends AbstractProvider
     }
 
     /**
-     * Determine if JWT signature verification is enabled.
+     * Determine if id_token signature verification is enabled.
+     *
+     * Read straight from the config array rather than via getConfig(), which
+     * treats any falsy value as absent and would therefore make an explicit
+     * `verify_jwt => false` indistinguishable from "unset" -- leaving no way
+     * to opt out now that the default is true.
      */
     protected function shouldVerifyJwt(): bool
     {
-        return (bool) $this->getConfig('verify_jwt', $this->verifyJwt);
+        $config = $this->getConfig();
+
+        if (is_array($config) && isset($config['verify_jwt'])) {
+            return filter_var($config['verify_jwt'], FILTER_VALIDATE_BOOLEAN);
+        }
+
+        return $this->verifyJwt;
     }
 
     /**
@@ -210,12 +227,52 @@ class Provider extends AbstractProvider
     }
 
     /**
+     * The issuer base URL, validated to be on a secure transport.
+     *
+     * Every endpoint this provider talks to is derived from `base_url`, so a
+     * plaintext issuer would expose the discovery document, the JWKS and the
+     * token exchange to tampering. That matters doubly because OIDC Core
+     * 3.1.3.7 step 6 lets an RP substitute TLS server validation for id_token
+     * signature checking -- an exemption that is worthless without TLS.
+     *
+     * Loopback hosts are exempt so local development still works.
+     */
+    protected function getBaseUrl(): string
+    {
+        $baseUrl = rtrim((string) $this->getConfig('base_url'), '/');
+
+        if ($baseUrl === '') {
+            throw new InvalidArgumentException('OIDC: base_url is not configured.');
+        }
+
+        $scheme = strtolower((string) parse_url($baseUrl, PHP_URL_SCHEME));
+        $host = strtolower((string) parse_url($baseUrl, PHP_URL_HOST));
+
+        if ($scheme !== 'https' && ! ($scheme === 'http' && $this->isLoopbackHost($host))) {
+            throw new InvalidArgumentException(
+                'OIDC: base_url must use https (got '.($scheme ?: 'no scheme').'); plaintext is only permitted for loopback hosts.'
+            );
+        }
+
+        return $baseUrl;
+    }
+
+    /**
+     * Loopback hosts, where plaintext HTTP is not remotely interceptable.
+     */
+    protected function isLoopbackHost(string $host): bool
+    {
+        return in_array($host, ['localhost', '127.0.0.1', '[::1]', '::1'], true)
+            || str_ends_with($host, '.localhost');
+    }
+
+    /**
      * @throws GuzzleException
      */
     protected function getOpenIdConfig(): array
     {
         if ($this->configurations === null) {
-            $configUrl = rtrim($this->getConfig('base_url'), '/').'/.well-known/openid-configuration';
+            $configUrl = $this->getBaseUrl().'/.well-known/openid-configuration';
             $cacheKey = 'openidconnect_discovery_'.md5($configUrl);
 
             $this->configurations = Cache::remember($cacheKey, $this->getCacheTtl(), function () use ($configUrl) {
@@ -299,6 +356,17 @@ class Provider extends AbstractProvider
             ->setExpiresIn($tokenResponse['expires_in']);
     }
 
+    /**
+     * Decode an id_token received over the back channel from the token
+     * endpoint.
+     *
+     * Trust model: this token is the response to a request *we* initiated over
+     * TLS, and it is bound to this session by the nonce and PKCE verifier.
+     * That is what lets signature verification be optional here at all (OIDC
+     * Core 3.1.3.7 step 6) -- though it is on by default, since the exemption
+     * rests entirely on the transport. Contrast verifyLogoutToken(), which
+     * handles an unsolicited token and can never make that trade.
+     */
     protected function decodeJWT(string $jwt, ?string $accessToken = null)
     {
         $header = $this->decodeJwtHeader($jwt);
@@ -307,6 +375,8 @@ class Provider extends AbstractProvider
         if ($this->shouldVerifyJwt()) {
             $payload = $this->verifyAndDecodeJWT($jwt, $alg);
         } else {
+            // Unverified: claims are read as-is, so sub/email/groups/role are
+            // only as trustworthy as the TLS connection to the token endpoint.
             try {
                 [, $jwtPayload] = explode('.', $jwt);
                 $payload = json_decode($this->base64UrlDecode($jwtPayload));
@@ -450,7 +520,7 @@ class Provider extends AbstractProvider
 
     protected function jwksCacheKey(): string
     {
-        return 'openidconnect_jwks_'.md5($this->getConfig('base_url'));
+        return 'openidconnect_jwks_'.md5($this->getBaseUrl());
     }
 
     protected function decodeJwtHeader(string $jwt)
@@ -744,9 +814,13 @@ class Provider extends AbstractProvider
      *
      * @see https://openid.net/specs/openid-connect-backchannel-1_0.html
      *
-     * Performs signature verification (always — unlike id_token decoding, the
-     * logout token has no session nonce and must be trusted purely on its
-     * signature), then enforces the spec's claim rules. Returns the decoded
+     * Trust model: unlike decodeJWT(), this token arrives unsolicited from the
+     * public internet on an unauthenticated endpoint. There is no session
+     * nonce, no PKCE verifier and no request of ours for it to answer, so the
+     * TLS-in-place-of-signature exemption of OIDC Core 3.1.3.7 step 6 does not
+     * apply and cannot be opted out of: the signature is the only control.
+     * Verification is therefore always performed here regardless of
+     * `verify_jwt`, followed by the spec's claim rules. Returns the decoded
      * payload so the caller can destroy sessions matching `sid` / `sub`.
      *
      * The caller is responsible for:

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -201,6 +201,34 @@ class Provider extends AbstractProvider
 
     /**
      * {@inheritdoc}
+     *
+     * Overridden because the parent hardcodes '?'. Discovered endpoints are
+     * not necessarily bare paths -- multi-tenant deployments advertise things
+     * like https://idp.example.com/authorize?realm=prod -- and a second '?'
+     * folds every parameter after it into the preceding value.
+     */
+    protected function buildAuthUrlFromBase($url, $state): string
+    {
+        return $this->appendQuery(
+            $url,
+            http_build_query($this->getCodeFields($state), '', '&', $this->encodingType)
+        );
+    }
+
+    /**
+     * Append an already-built query string to a URL that may carry one.
+     */
+    protected function appendQuery(string $url, string $query): string
+    {
+        if ($query === '') {
+            return $url;
+        }
+
+        return $url.(str_contains($url, '?') ? '&' : '?').$query;
+    }
+
+    /**
+     * {@inheritdoc}
      */
     protected function getCodeFields($state = null): array
     {
@@ -927,7 +955,7 @@ class Provider extends AbstractProvider
             'state'                    => $state,
         ], $extra), fn ($v) => $v !== null && $v !== '');
 
-        return new RedirectResponse($config['end_session_endpoint'].'?'.http_build_query($params));
+        return new RedirectResponse($this->appendQuery($config['end_session_endpoint'], http_build_query($params)));
     }
 
     /**

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -827,7 +827,17 @@ class Provider extends AbstractProvider
         $options = [RequestOptions::HEADERS => ['Accept' => 'application/json']];
 
         if ($method === 'client_secret_basic') {
-            $options[RequestOptions::AUTH] = [$this->clientId, $this->clientSecret];
+            // Built by hand rather than via Guzzle's `auth` option, which
+            // base64s the raw "id:secret" pair. RFC 6749 2.3.1 requires each
+            // half to be form-urlencoded first, and the two only agree for
+            // alphanumeric credentials. A secret containing +, /, =, a space
+            // or non-ASCII would otherwise come back as an opaque
+            // invalid_client -- and base64-derived secrets routinely contain
+            // + and /.
+            $options[RequestOptions::HEADERS]['Authorization'] = 'Basic '.base64_encode(
+                urlencode($this->clientId).':'.urlencode($this->clientSecret)
+            );
+
             unset($fields['client_id'], $fields['client_secret']);
         }
 

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -599,6 +599,12 @@ class Provider extends AbstractProvider
             );
         }
 
+        // JWT::$leeway is global static state. In a long-running worker
+        // (Octane, RoadRunner, queues) leaving it set would apply this
+        // provider's clock skew to every later JWT validation in the process,
+        // so it is restored whichever way the decode exits.
+        $previousLeeway = JWT::$leeway;
+
         try {
             JWT::$leeway = (int) ($this->getConfig('clock_skew') ?? 0);
 
@@ -633,6 +639,8 @@ class Provider extends AbstractProvider
             return json_decode(json_encode($decoded));
         } catch (Exception $e) {
             throw new InvalidArgumentException('JWT: Verification failed - '.$e->getMessage(), 401);
+        } finally {
+            JWT::$leeway = $previousLeeway;
         }
     }
 

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -9,6 +9,7 @@ use Firebase\JWT\Key;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\RequestOptions;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
@@ -1004,9 +1005,13 @@ class Provider extends AbstractProvider
             throw new InvalidArgumentException('Provider does not advertise an end_session_endpoint.');
         }
 
-        $state = Str::random(40);
+        // Only sent when it can actually be stored, and therefore checked
+        // later by validateLogoutState(). Emitting a state with nowhere to
+        // remember it would look like protection without being any.
+        $state = null;
+
         if ($this->request->hasSession()) {
-            $this->request->session()->put('logout_state', $state);
+            $this->request->session()->put('logout_state', $state = Str::random(40));
         }
 
         $params = array_filter(array_merge([
@@ -1017,6 +1022,36 @@ class Provider extends AbstractProvider
         ], $extra), fn ($v) => $v !== null && $v !== '');
 
         return new RedirectResponse($this->appendQuery($config['end_session_endpoint'], http_build_query($params)));
+    }
+
+    /**
+     * Validate the `state` the IdP returns to the post_logout_redirect_uri.
+     *
+     * logout() mints a state and stores it in the session; this is the other
+     * half, and without calling it the state is decorative. Consume it in the
+     * controller backing your post_logout_redirect_uri before acting on the
+     * redirect.
+     *
+     * The stored value is pulled, so a state is good for exactly one
+     * round trip and a replayed redirect fails.
+     *
+     * @param  Request|null  $request  Defaults to the provider's request.
+     */
+    public function validateLogoutState(?Request $request = null): bool
+    {
+        $request ??= $this->request;
+
+        if (! $request->hasSession()) {
+            return false;
+        }
+
+        $expected = $request->session()->pull('logout_state');
+        $returned = $request->input('state');
+
+        return is_string($expected)
+            && $expected !== ''
+            && is_string($returned)
+            && hash_equals($expected, $returned);
     }
 
     /**

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -68,6 +68,12 @@ class Provider extends AbstractProvider
     protected bool $verifyJwt = true;
 
     /**
+     * Indicates if a missing email should fail the login.
+     * Can be overridden by config 'require_email'.
+     */
+    protected bool $requireEmail = false;
+
+    /**
      * {@inheritdoc}
      */
     public static function additionalConfigKeys(): array
@@ -76,6 +82,7 @@ class Provider extends AbstractProvider
             'base_url',
             'scopes',
             'use_nonce',
+            'require_email',
             'verify_jwt',
             'jwt_public_key',
             'jwt_algorithm',
@@ -487,22 +494,27 @@ class Provider extends AbstractProvider
 
         $accessToken = Arr::get($tokenResponse, 'access_token');
 
-        $payload = $this->decodeJWT($idToken, $accessToken);
+        $claims = (array) $this->decodeJWT($idToken, $accessToken);
 
-        if ($this->hasEmptyEmail($payload)) {
-            // The userinfo endpoint is only reachable with an access token;
-            // an id_token-only response leaves the id_token claims as all we
-            // have to go on.
-            if (is_string($accessToken) && $accessToken !== '') {
-                $payload = $this->getUserByToken($accessToken);
-            }
-
-            if ($this->hasEmptyEmail($payload)) {
-                throw new InvalidArgumentException('JWT: User has no email.', 401);
-            }
+        // sub is the only identifier the OP must return (OIDC Core 2), so it
+        // is the one claim worth insisting on.
+        if (empty($claims['sub'])) {
+            throw new InvalidArgumentException('JWT: Missing required sub claim.', 401);
         }
 
-        $this->user = $this->mapUserToObject((array) $payload);
+        // The userinfo endpoint is only reachable with an access token; an
+        // id_token-only response leaves the id_token claims as all we have.
+        if ($this->hasEmptyEmail($claims) && is_string($accessToken) && $accessToken !== '') {
+            $claims = $this->mergeUserInfoClaims($claims, $this->getUserByToken($accessToken));
+        }
+
+        // email depends on the `email` scope being granted and is not
+        // guaranteed, so it is only fatal when explicitly required.
+        if ($this->requiresEmail() && $this->hasEmptyEmail($claims)) {
+            throw new InvalidArgumentException('JWT: User has no email.', 401);
+        }
+
+        $this->user = $this->mapUserToObject($claims);
 
         // Reimplementing user() means re-establishing what the Manager's base
         // sets, or this provider alone returns null for the standard
@@ -805,6 +817,47 @@ class Provider extends AbstractProvider
         }
 
         return ! (is_string($nonce) && strlen($nonce) > 0 && $nonce === $this->getCurrentNonce());
+    }
+
+    /**
+     * Merge the UserInfo response over the id_token claims.
+     *
+     * OIDC Core 5.3.2 requires the sub of the UserInfo response to be verified
+     * against the sub of the id_token, and the response not to be used if they
+     * do not match exactly.
+     *
+     * Merged rather than substituted so claims the id_token carried but
+     * UserInfo does not -- groups and role, typically -- are not lost.
+     */
+    protected function mergeUserInfoClaims(array $claims, $userInfo): array
+    {
+        if (! is_array($userInfo)) {
+            return $claims;
+        }
+
+        if (($userInfo['sub'] ?? null) !== $claims['sub']) {
+            throw new InvalidArgumentException('UserInfo: sub does not match the id_token.', 401);
+        }
+
+        return array_merge($claims, array_filter($userInfo, static fn ($value) => $value !== null));
+    }
+
+    /**
+     * Determine if a missing email should fail the login.
+     *
+     * Off by default: email is not a guaranteed claim, since it depends on the
+     * `email` scope being granted, and OIDC Core 2 makes sub the only
+     * identifier an OP must return.
+     */
+    protected function requiresEmail(): bool
+    {
+        $config = $this->getConfig();
+
+        if (is_array($config) && isset($config['require_email'])) {
+            return filter_var($config['require_email'], FILTER_VALIDATE_BOOLEAN);
+        }
+
+        return $this->requireEmail;
     }
 
     protected function hasEmptyEmail($payload): bool

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -111,7 +111,7 @@ class Provider extends AbstractProvider
         }
 
         if ($this->usesNonce()) {
-            $this->request->session()->put('nonce', $this->getNonce());
+            $this->request->session()->put('openidconnect_nonce', $this->getNonce());
         }
 
         if ($this->usesPKCE()) {

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -234,7 +234,9 @@ class Provider extends AbstractProvider
             return $url;
         }
 
-        return $url.(str_contains($url, '?') ? '&' : '?').$query;
+        [$base, $fragment] = array_pad(explode('#', $url, 2), 2, null);
+        $withQuery = $base . (str_contains($base, '?') ? '&' : '?') . $query;
+        return $fragment !== null ? $withQuery . '#' . $fragment : $withQuery;
     }
 
     /**

--- a/src/OpenIDConnect/README.md
+++ b/src/OpenIDConnect/README.md
@@ -188,24 +188,91 @@ Both tokens are bearer credentials — always encrypt them at rest (`encrypted` 
 
 ### Back-Channel Logout
 
-If you register a `backchannel_logout_uri` with the IdP, the IdP will POST a signed `logout_token` to that URL whenever the user logs out elsewhere. Verify the token and destroy the matching local session:
+If you register a `backchannel_logout_uri` with the IdP, the IdP will POST a signed `logout_token` to that URL whenever the user logs out elsewhere (for example, another client in the same SSO federation). Your app must verify the token and destroy the matching local session.
+
+#### Mapping IdP sessions to Laravel sessions
+
+The IdP has no idea what your Laravel session ID is. It identifies the session by a `sid` claim that it mints itself and includes in both the id_token at login and the logout_token at logout. You are responsible for storing a mapping from `sid` → Laravel session ID at login time, and consulting it at logout time.
+
+Prerequisites:
+
+- The IdP advertises `backchannel_logout_session_supported: true` in its discovery document.
+- Your client registration has `backchannel_logout_session_required` enabled so the IdP actually includes `sid` in issued tokens.
+
+If the IdP does not support `sid`, logout tokens will only carry `sub`. You can still implement back-channel logout — you just have to kill **all** of the user's local sessions instead of only the one that ended. That is correct but coarser: a user logged in on three devices will be signed out of all three when they log out of one.
+
+```php
+// Migration
+Schema::create('oidc_sessions', function (Blueprint $table) {
+    $table->string('sid')->primary();             // the IdP's session id
+    $table->string('laravel_session_id');         // session()->getId()
+    $table->foreignId('user_id')->constrained();
+    $table->timestamps();
+    $table->index('user_id');
+});
+```
+
+#### Recording the mapping at login
+
+```php
+$oidcUser = Socialite::driver('openidconnect')->user();
+// ...find or create $user, Auth::login($user)...
+
+if ($sid = $oidcUser->user['sid'] ?? null) {
+    DB::table('oidc_sessions')->updateOrInsert(
+        ['sid' => $sid],
+        [
+            'laravel_session_id' => session()->getId(),
+            'user_id'            => $user->id,
+            'updated_at'         => now(),
+            'created_at'         => now(),
+        ],
+    );
+}
+```
+
+`sid` arrives via the raw id_token claims on the user (`$oidcUser->user['sid']`), not as a first-class field on the Socialite user — it's a session attribute, not a user attribute.
+
+#### Handling the logout POST
 
 ```php
 Route::post('/oidc/backchannel-logout', function (Request $request) {
-    $claims = Socialite::driver('openidconnect')
-        ->verifyLogoutToken($request->input('logout_token'));
-
-    // Replay protection: refuse tokens you've already seen.
-    if (Cache::has('oidc_logout_jti_'.$claims['jti'])) {
+    try {
+        $claims = Socialite::driver('openidconnect')
+            ->verifyLogoutToken($request->input('logout_token'));
+    } catch (\InvalidArgumentException $e) {
         return response('', 400);
     }
-    Cache::put('oidc_logout_jti_'.$claims['jti'], true, now()->addHour());
 
-    // Destroy sessions matching $claims['sid'] and/or $claims['sub'].
-    // (How you do that depends on your session store.)
+    // Replay protection: refuse a jti we've already processed.
+    $jtiKey = 'oidc_logout_jti_'.$claims['jti'];
+    if (Cache::has($jtiKey)) {
+        return response('', 400);
+    }
+    Cache::put($jtiKey, true, now()->addHour());
+
+    // Prefer sid (per-session); fall back to sub (all sessions for that user).
+    $rows = ! empty($claims['sid'])
+        ? DB::table('oidc_sessions')->where('sid', $claims['sid'])->get()
+        : DB::table('oidc_sessions')
+            ->join('users', 'users.id', '=', 'oidc_sessions.user_id')
+            ->where('users.oidc_sub', $claims['sub'] ?? '')
+            ->select('oidc_sessions.*')
+            ->get();
+
+    $handler = Session::getHandler();
+    foreach ($rows as $row) {
+        $handler->destroy($row->laravel_session_id);
+    }
+
+    DB::table('oidc_sessions')
+        ->whereIn('laravel_session_id', $rows->pluck('laravel_session_id'))
+        ->delete();
 
     return response('', 200);
-})->withoutMiddleware(['web']); // the IdP request has no CSRF token or session cookie
+})->withoutMiddleware(['web']); // no CSRF token or session cookie on IdP requests
 ```
+
+The `sub`-fallback path assumes you store the IdP's `sub` claim on the user record (e.g. in an `oidc_sub` column) at login. If you don't need that fallback — because your IdP always emits `sid` — you can skip it.
 
 `verifyLogoutToken()` validates the signature, `iss`, `aud`, `iat`/`exp`, `jti`, the required `events` claim, and the absence of a `nonce`. The caller is responsible for replay protection (de-duping `jti`) and actually invalidating the session.

--- a/src/OpenIDConnect/README.md
+++ b/src/OpenIDConnect/README.md
@@ -1,0 +1,112 @@
+# OpenID Connect
+
+```bash
+composer require socialiteproviders/openidconnect
+```
+
+A generic [OpenID Connect](https://openid.net/connect/) provider for Laravel Socialite. The provider discovers its endpoints via the issuer's `/.well-known/openid-configuration` document, supports JWT signature verification (JWKS or a configured public key), nonce validation, and PKCE.
+
+## Installation & Basic Usage
+
+Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
+then follow the provider specific instructions below.
+
+### Add configuration to `config/services.php`
+
+```php
+'openidconnect' => [
+    'base_url'       => env('OIDC_BASE_URL'),
+    'client_id'      => env('OIDC_CLIENT_ID'),
+    'client_secret'  => env('OIDC_CLIENT_SECRET'),
+    'redirect'       => env('OIDC_REDIRECT_URI'),
+
+    // Optional: space-separated list of extra scopes to request in addition
+    // to the defaults ('openid email profile').
+    'scopes'         => env('OIDC_SCOPES'),
+
+    // Optional: when true, id_token signatures will be verified using the
+    // provider's JWKS (or 'jwt_public_key' below if set).
+    'verify_jwt'     => env('OIDC_VERIFY_JWT', false),
+
+    // Optional: PEM-encoded public key used to verify id_token signatures
+    // instead of fetching the JWKS.
+    'jwt_public_key' => env('OIDC_JWT_PUBLIC_KEY'),
+
+    // Optional: signing algorithm hint (e.g. RS256, RS512, ES256, PS256).
+    // Defaults to the alg in the id_token header, or RS256.
+    'jwt_algorithm'  => env('OIDC_JWT_ALGORITHM'),
+
+    // Optional: override the expected `iss` claim. Defaults to the issuer
+    // reported by the discovery document.
+    'issuer'         => env('OIDC_ISSUER'),
+
+    // Optional: client authentication method at the token endpoint.
+    // Accepts 'client_secret_basic' or 'client_secret_post'. If omitted,
+    // the provider picks whichever the IdP advertises (preferring basic).
+    'token_auth_method'        => env('OIDC_TOKEN_AUTH_METHOD'),
+
+    // Optional: default post-logout redirect URI used by the logout() helper.
+    'post_logout_redirect_uri' => env('OIDC_POST_LOGOUT_REDIRECT_URI'),
+],
+```
+
+The Authorization Code Flow with PKCE is used by default (`response_type=code`, PKCE is enabled on the `Provider`).
+
+`base_url` is the OIDC issuer URL (for example `https://id.example.com`). The provider appends `/.well-known/openid-configuration` automatically.
+
+### Add provider event listener
+
+#### Laravel 11+
+
+In Laravel 11, the default `EventServiceProvider` provider was removed. Instead, add the listener using the `listen` method on the `Event` facade, in your `AppServiceProvider` `boot` method.
+
+```php
+Event::listen(function (\SocialiteProviders\Manager\SocialiteWasCalled $event) {
+    $event->extendSocialite('openidconnect', \SocialiteProviders\OpenIDConnect\Provider::class);
+});
+```
+
+<details>
+<summary>
+Laravel 10 or below
+</summary>
+Configure the package's listener to listen for `SocialiteWasCalled` events.
+
+Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. See the [Base Installation Guide](https://socialiteproviders.com/usage/) for detailed instructions.
+
+```php
+protected $listen = [
+    \SocialiteProviders\Manager\SocialiteWasCalled::class => [
+        // ... other providers
+        \SocialiteProviders\OpenIDConnect\OpenIDConnectExtendSocialite::class.'@handle',
+    ],
+];
+```
+</details>
+
+### Usage
+
+```php
+return Socialite::driver('openidconnect')->redirect();
+```
+
+```php
+$user = Socialite::driver('openidconnect')->user();
+```
+
+The returned user is populated from the `id_token` claims, falling back to the `userinfo` endpoint when the id_token does not contain an email. Mapped fields include `id` (`sub`), `email`, `name`, `nickname`, `given_name`, `family_name`, `idp`, `role`, and `groups`. The raw user also contains `id_token`, which you should stash in the session at login if you want to drive RP-initiated logout later.
+
+### RP-Initiated Logout
+
+If the IdP advertises an `end_session_endpoint` in its discovery document, you can build a logout redirect:
+
+```php
+// In your login callback, stash the id_token so you can pass it back at logout.
+session(['oidc_id_token' => $user->user['id_token']]);
+
+// In your logout controller:
+return Socialite::driver('openidconnect')
+    ->logout(session('oidc_id_token'), route('home'));
+```
+
+Most IdPs require `id_token_hint` (the id_token from login) and a `post_logout_redirect_uri` that has been pre-registered with the client.

--- a/src/OpenIDConnect/README.md
+++ b/src/OpenIDConnect/README.md
@@ -127,10 +127,64 @@ Most IdPs require `id_token_hint` (the id_token from login) and a `post_logout_r
 If the IdP advertises a `revocation_endpoint` (RFC 7009), you can revoke an access or refresh token server-side — useful at logout to invalidate the refresh token immediately rather than waiting for it to expire:
 
 ```php
-Socialite::driver('openidconnect')->revoke($refreshToken, 'refresh_token');
+// In your login callback, stash the refresh_token alongside the id_token.
+$oidcUser = Socialite::driver('openidconnect')->user();
+session([
+    'oidc_id_token'      => $oidcUser->user['id_token'],
+    'oidc_refresh_token' => $oidcUser->refreshToken,
+]);
+
+// In your logout controller:
+if ($refresh = session('oidc_refresh_token')) {
+    Socialite::driver('openidconnect')->revoke($refresh, 'refresh_token');
+}
+
+return Socialite::driver('openidconnect')
+    ->logout(session('oidc_id_token'), route('home'));
 ```
 
-The second argument is a hint (`access_token` or `refresh_token`) and defaults to `refresh_token`. Returns `true` on a successful (200/204) response.
+The second argument to `revoke()` is a hint (`access_token` or `refresh_token`) and defaults to `refresh_token`. Returns `true` on a successful (200/204) response.
+
+### Storing tokens persistently
+
+The examples above use the session, which is fine when the user always logs out from the same browser session they logged in with. If you need refresh tokens to survive session expiry — for example, to call `revoke()` from a back-channel logout handler, or to refresh access tokens for background jobs — store them on the user record instead:
+
+```php
+// Migration
+Schema::table('users', function (Blueprint $table) {
+    $table->text('oidc_id_token')->nullable();
+    $table->text('oidc_refresh_token')->nullable();
+});
+
+// User model
+protected $casts = [
+    'oidc_id_token'      => 'encrypted',
+    'oidc_refresh_token' => 'encrypted',
+];
+
+// Login callback
+$oidcUser = Socialite::driver('openidconnect')->user();
+$user = User::updateOrCreate(
+    ['email' => $oidcUser->email],
+    [
+        'name'               => $oidcUser->name,
+        'oidc_id_token'      => $oidcUser->user['id_token'],
+        'oidc_refresh_token' => $oidcUser->refreshToken,
+    ],
+);
+Auth::login($user);
+
+// Logout controller
+if ($user->oidc_refresh_token) {
+    Socialite::driver('openidconnect')->revoke($user->oidc_refresh_token, 'refresh_token');
+}
+$idToken = $user->oidc_id_token;
+$user->update(['oidc_id_token' => null, 'oidc_refresh_token' => null]);
+
+return Socialite::driver('openidconnect')->logout($idToken, route('home'));
+```
+
+Both tokens are bearer credentials — always encrypt them at rest (`encrypted` cast) and never expose them to the browser via JavaScript-readable storage.
 
 ### Back-Channel Logout
 

--- a/src/OpenIDConnect/README.md
+++ b/src/OpenIDConnect/README.md
@@ -51,6 +51,13 @@ then follow the provider specific instructions below.
     // Optional: TTL (in seconds) for the cached discovery document and JWKS.
     // Defaults to 3600 (1 hour).
     'cache_ttl'                => env('OIDC_CACHE_TTL'),
+
+    // Optional: clock skew leeway (in seconds) applied to exp/nbf/iat. 0 by default.
+    'clock_skew'               => env('OIDC_CLOCK_SKEW'),
+
+    // Optional: Guzzle connect/read timeouts for IdP calls. Defaults: 5s/10s.
+    'http_connect_timeout'     => env('OIDC_HTTP_CONNECT_TIMEOUT'),
+    'http_timeout'             => env('OIDC_HTTP_TIMEOUT'),
 ],
 ```
 

--- a/src/OpenIDConnect/README.md
+++ b/src/OpenIDConnect/README.md
@@ -47,6 +47,10 @@ then follow the provider specific instructions below.
 
     // Optional: default post-logout redirect URI used by the logout() helper.
     'post_logout_redirect_uri' => env('OIDC_POST_LOGOUT_REDIRECT_URI'),
+
+    // Optional: TTL (in seconds) for the cached discovery document and JWKS.
+    // Defaults to 3600 (1 hour).
+    'cache_ttl'                => env('OIDC_CACHE_TTL'),
 ],
 ```
 

--- a/src/OpenIDConnect/README.md
+++ b/src/OpenIDConnect/README.md
@@ -131,3 +131,27 @@ Socialite::driver('openidconnect')->revoke($refreshToken, 'refresh_token');
 ```
 
 The second argument is a hint (`access_token` or `refresh_token`) and defaults to `refresh_token`. Returns `true` on a successful (200/204) response.
+
+### Back-Channel Logout
+
+If you register a `backchannel_logout_uri` with the IdP, the IdP will POST a signed `logout_token` to that URL whenever the user logs out elsewhere. Verify the token and destroy the matching local session:
+
+```php
+Route::post('/oidc/backchannel-logout', function (Request $request) {
+    $claims = Socialite::driver('openidconnect')
+        ->verifyLogoutToken($request->input('logout_token'));
+
+    // Replay protection: refuse tokens you've already seen.
+    if (Cache::has('oidc_logout_jti_'.$claims['jti'])) {
+        return response('', 400);
+    }
+    Cache::put('oidc_logout_jti_'.$claims['jti'], true, now()->addHour());
+
+    // Destroy sessions matching $claims['sid'] and/or $claims['sub'].
+    // (How you do that depends on your session store.)
+
+    return response('', 200);
+})->withoutMiddleware(['web']); // the IdP request has no CSRF token or session cookie
+```
+
+`verifyLogoutToken()` validates the signature, `iss`, `aud`, `iat`/`exp`, `jti`, the required `events` claim, and the absence of a `nonce`. The caller is responsible for replay protection (de-duping `jti`) and actually invalidating the session.

--- a/src/OpenIDConnect/README.md
+++ b/src/OpenIDConnect/README.md
@@ -121,3 +121,13 @@ return Socialite::driver('openidconnect')
 ```
 
 Most IdPs require `id_token_hint` (the id_token from login) and a `post_logout_redirect_uri` that has been pre-registered with the client.
+
+### Token Revocation
+
+If the IdP advertises a `revocation_endpoint` (RFC 7009), you can revoke an access or refresh token server-side — useful at logout to invalidate the refresh token immediately rather than waiting for it to expire:
+
+```php
+Socialite::driver('openidconnect')->revoke($refreshToken, 'refresh_token');
+```
+
+The second argument is a hint (`access_token` or `refresh_token`) and defaults to `refresh_token`. Returns `true` on a successful (200/204) response.

--- a/src/OpenIDConnect/README.md
+++ b/src/OpenIDConnect/README.md
@@ -174,6 +174,21 @@ return Socialite::driver('openidconnect')
 
 Most IdPs require `id_token_hint` (the id_token from login) and a `post_logout_redirect_uri` that has been pre-registered with the client.
 
+`logout()` mints a `state` and stores it in the session. It is only meaningful if you check it when the IdP redirects back, so validate it in the controller backing your `post_logout_redirect_uri`:
+
+```php
+// In the controller for your post_logout_redirect_uri:
+if (! Socialite::driver('openidconnect')->validateLogoutState($request)) {
+    // The redirect did not originate from a logout this session started.
+    abort(403);
+}
+
+Auth::logout();
+$request->session()->invalidate();
+```
+
+The stored value is consumed on the first call, so a state is good for exactly one round trip and a replayed redirect fails. If the request has no session there is nothing to compare against, so `logout()` sends no `state` and `validateLogoutState()` returns `false`.
+
 ### Token Revocation
 
 If the IdP advertises a `revocation_endpoint` (RFC 7009), you can revoke an access or refresh token server-side — useful at logout to invalidate the refresh token immediately rather than waiting for it to expire:

--- a/src/OpenIDConnect/README.md
+++ b/src/OpenIDConnect/README.md
@@ -170,14 +170,21 @@ session([
 
 // In your logout controller:
 if ($refresh = session('oidc_refresh_token')) {
-    Socialite::driver('openidconnect')->revoke($refresh, 'refresh_token');
+    try {
+        Socialite::driver('openidconnect')->revoke($refresh, 'refresh_token');
+    } catch (Throwable $e) {
+        // Revocation is best-effort: never block the logout on it.
+        report($e);
+    }
 }
 
 return Socialite::driver('openidconnect')
     ->logout(session('oidc_id_token'), route('home'));
 ```
 
-The second argument to `revoke()` is a hint (`access_token` or `refresh_token`) and defaults to `refresh_token`. Returns `true` on a successful (200/204) response.
+The second argument to `revoke()` is a hint (`access_token` or `refresh_token`) and defaults to `refresh_token`.
+
+It returns `true` for a 200/204 and `false` for any other status, so an IdP that answers 400 for an already-revoked token gives you `false` rather than an exception. A transport failure (timeout, DNS, connection refused) still throws, which is why the example above wraps the call — you generally want the user logged out even when the IdP is unreachable.
 
 ### Storing tokens persistently
 

--- a/src/OpenIDConnect/README.md
+++ b/src/OpenIDConnect/README.md
@@ -23,8 +23,11 @@ then follow the provider specific instructions below.
     'client_secret'  => env('OIDC_CLIENT_SECRET'),
     'redirect'       => env('OIDC_REDIRECT_URI'),
 
-    // Optional: space-separated list of extra scopes to request in addition
-    // to the defaults ('openid email profile').
+    // Optional: the scopes to request, replacing the defaults
+    // ('openid email profile'). Accepts an array, or a string separated by
+    // whitespace and/or commas. 'openid' is always sent whether listed or not,
+    // and duplicates are removed. Set it to narrow the request for an OP that
+    // rejects one of the defaults, e.g. 'email' for one without 'profile'.
     'scopes'         => env('OIDC_SCOPES'),
 
     // Optional: verify id_token signatures using the provider's JWKS (or

--- a/src/OpenIDConnect/README.md
+++ b/src/OpenIDConnect/README.md
@@ -60,6 +60,12 @@ then follow the provider specific instructions below.
     // Optional: default post-logout redirect URI used by the logout() helper.
     'post_logout_redirect_uri' => env('OIDC_POST_LOGOUT_REDIRECT_URI'),
 
+    // Optional: how long a back-channel logout token's `jti` is remembered,
+    // in seconds, so the same token cannot be acted on twice. Defaults to the
+    // token's own `exp` plus the tolerated clock skew. Set to 0 to turn it off
+    // and handle replay protection yourself.
+    'logout_token_replay_ttl'  => env('OIDC_LOGOUT_TOKEN_REPLAY_TTL'),
+
     // Optional: TTL (in seconds) for the cached discovery document and JWKS.
     // Defaults to 3600 (1 hour).
     'cache_ttl'                => env('OIDC_CACHE_TTL'),
@@ -318,13 +324,6 @@ Route::post('/oidc/backchannel-logout', function (Request $request) {
         return response('', 400);
     }
 
-    // Replay protection: refuse a jti we've already processed.
-    $jtiKey = 'oidc_logout_jti_'.$claims['jti'];
-    if (Cache::has($jtiKey)) {
-        return response('', 400);
-    }
-    Cache::put($jtiKey, true, now()->addHour());
-
     // Prefer sid (per-session); fall back to sub (all sessions for that user).
     $rows = ! empty($claims['sid'])
         ? DB::table('oidc_sessions')->where('sid', $claims['sid'])->get()
@@ -349,4 +348,4 @@ Route::post('/oidc/backchannel-logout', function (Request $request) {
 
 The `sub`-fallback path assumes you store the IdP's `sub` claim on the user record (e.g. in an `oidc_sub` column) at login. If you don't need that fallback — because your IdP always emits `sid` — you can skip it.
 
-`verifyLogoutToken()` validates the signature, `iss`, `aud`, `iat`/`exp`, `jti`, the required `events` claim, and the absence of a `nonce`. The caller is responsible for replay protection (de-duping `jti`) and actually invalidating the session.
+`verifyLogoutToken()` validates the signature, `iss`, `aud`, `iat`/`exp`, `jti`, the required `events` claim, and the absence of a `nonce`. It also records the `jti` and refuses a token that has already been acted on, so the `catch` above covers replays too — the write is atomic, which a `has()`/`put()` pair is not, and the IdP retries when it gets no answer. The caller remains responsible for invalidating the session, which is the only part that depends on how the application stores them.

--- a/src/OpenIDConnect/README.md
+++ b/src/OpenIDConnect/README.md
@@ -64,6 +64,10 @@ then follow the provider specific instructions below.
     // Optional: clock skew leeway (in seconds) applied to exp/nbf/iat. 0 by default.
     'clock_skew'               => env('OIDC_CLOCK_SKEW'),
 
+    // Optional: send and validate a nonce. Defaults to true, and is ignored
+    // (always off) in stateless mode, where there is no session to carry it.
+    'use_nonce'                => env('OIDC_USE_NONCE', true),
+
     // Optional: Guzzle connect/read timeouts for IdP calls. Defaults: 5s/10s.
     'http_connect_timeout'     => env('OIDC_HTTP_CONNECT_TIMEOUT'),
     'http_timeout'             => env('OIDC_HTTP_TIMEOUT'),
@@ -73,6 +77,24 @@ then follow the provider specific instructions below.
 The Authorization Code Flow with PKCE is used by default (`response_type=code`, PKCE is enabled on the `Provider`).
 
 `base_url` is the OIDC issuer URL (for example `https://id.example.com`). The provider appends `/.well-known/openid-configuration` automatically.
+
+### Stateless usage
+
+The nonce is minted at the redirect and compared at the callback, so it needs a
+session to survive between the two requests. In stateless mode it is therefore
+skipped automatically — this is safe for the authorization code flow, where the
+code is bound to the client by PKCE and exchanged over the back channel. It can
+also be turned off explicitly with the `use_nonce` config or `withoutNonce()`.
+
+PKCE has the same session dependency, and it is Socialite that owns it: the
+`code_verifier` is written to the session at the redirect and read back when the
+code is exchanged. It therefore still works in stateless mode as long as a
+session store is bound to the request. If there is genuinely no session, call
+`withoutPKCE()` to opt out:
+
+```php
+Socialite::driver('openidconnect')->stateless()->withoutPKCE()->redirect();
+```
 
 ### Add provider event listener
 

--- a/src/OpenIDConnect/README.md
+++ b/src/OpenIDConnect/README.md
@@ -15,6 +15,9 @@ then follow the provider specific instructions below.
 
 ```php
 'openidconnect' => [
+    // The issuer base URL. Must be https:// -- every endpoint is derived from
+    // it. Plaintext http:// is only accepted for loopback hosts (localhost,
+    // 127.0.0.1, ::1, *.localhost) so local development still works.
     'base_url'       => env('OIDC_BASE_URL'),
     'client_id'      => env('OIDC_CLIENT_ID'),
     'client_secret'  => env('OIDC_CLIENT_SECRET'),
@@ -24,9 +27,12 @@ then follow the provider specific instructions below.
     // to the defaults ('openid email profile').
     'scopes'         => env('OIDC_SCOPES'),
 
-    // Optional: when true, id_token signatures will be verified using the
-    // provider's JWKS (or 'jwt_public_key' below if set).
-    'verify_jwt'     => env('OIDC_VERIFY_JWT', false),
+    // Optional: verify id_token signatures using the provider's JWKS (or
+    // 'jwt_public_key' below if set). Defaults to true. Set it to false only
+    // for an OP that cannot serve a JWKS -- claims are then trusted on the
+    // strength of the TLS connection to the token endpoint alone. Back-channel
+    // logout tokens are always verified regardless of this setting.
+    'verify_jwt'     => env('OIDC_VERIFY_JWT', true),
 
     // Optional: PEM-encoded public key used to verify id_token signatures
     // instead of fetching the JWKS.

--- a/src/OpenIDConnect/README.md
+++ b/src/OpenIDConnect/README.md
@@ -139,7 +139,17 @@ return Socialite::driver('openidconnect')->redirect();
 $user = Socialite::driver('openidconnect')->user();
 ```
 
-The returned user is populated from the `id_token` claims, falling back to the `userinfo` endpoint when the id_token does not contain an email. Mapped fields include `id` (`sub`), `email`, `name`, `nickname`, `given_name`, `family_name`, `idp`, `role`, and `groups`. The raw user also contains `id_token`, which you should stash in the session at login if you want to drive RP-initiated logout later.
+The returned user is populated from the `id_token` claims, falling back to the `userinfo` endpoint when the id_token does not contain an email. Mapped fields include `id` (`sub`), `email`, `name`, `nickname`, `given_name`, `family_name`, `idp`, `role`, and `groups`.
+
+The full token endpoint response is available on the standard `accessTokenResponseBody` property, so `$user->accessTokenResponseBody['id_token']` is where you read the id_token — stash it at login if you want to drive RP-initiated logout later. `$user->approvedScopes` holds the scopes the IdP actually granted, which is how you check whether something optional such as `offline_access` was honoured:
+
+```php
+$user = Socialite::driver('openidconnect')->user();
+
+$user->accessTokenResponseBody['id_token'];  // the raw id_token
+$user->approvedScopes;                        // e.g. ['openid', 'email', 'offline_access']
+$user->getRaw();                              // the id_token (or userinfo) claims
+```
 
 ### RP-Initiated Logout
 
@@ -147,7 +157,7 @@ If the IdP advertises an `end_session_endpoint` in its discovery document, you c
 
 ```php
 // In your login callback, stash the id_token so you can pass it back at logout.
-session(['oidc_id_token' => $user->user['id_token']]);
+session(['oidc_id_token' => $user->accessTokenResponseBody['id_token']]);
 
 // In your logout controller:
 return Socialite::driver('openidconnect')
@@ -164,7 +174,7 @@ If the IdP advertises a `revocation_endpoint` (RFC 7009), you can revoke an acce
 // In your login callback, stash the refresh_token alongside the id_token.
 $oidcUser = Socialite::driver('openidconnect')->user();
 session([
-    'oidc_id_token'      => $oidcUser->user['id_token'],
+    'oidc_id_token'      => $oidcUser->accessTokenResponseBody['id_token'],
     'oidc_refresh_token' => $oidcUser->refreshToken,
 ]);
 
@@ -209,7 +219,7 @@ $user = User::updateOrCreate(
     ['email' => $oidcUser->email],
     [
         'name'               => $oidcUser->name,
-        'oidc_id_token'      => $oidcUser->user['id_token'],
+        'oidc_id_token'      => $oidcUser->accessTokenResponseBody['id_token'],
         'oidc_refresh_token' => $oidcUser->refreshToken,
     ],
 );

--- a/src/OpenIDConnect/README.md
+++ b/src/OpenIDConnect/README.md
@@ -115,7 +115,7 @@ Socialite::driver('openidconnect')->stateless()->withoutPKCE()->redirect();
 
 #### Laravel 11+
 
-In Laravel 11, the default `EventServiceProvider` provider was removed. Instead, add the listener using the `listen` method on the `Event` facade, in your `AppServiceProvider` `boot` method.
+In Laravel 11, the default `EventServiceProvider` was removed. Instead, add the listener using the `listen` method on the `Event` facade, in your `AppServiceProvider` `boot` method.
 
 ```php
 Event::listen(function (\SocialiteProviders\Manager\SocialiteWasCalled $event) {
@@ -139,6 +139,7 @@ protected $listen = [
     ],
 ];
 ```
+
 </details>
 
 ### Usage

--- a/src/OpenIDConnect/README.md
+++ b/src/OpenIDConnect/README.md
@@ -32,8 +32,11 @@ then follow the provider specific instructions below.
     // instead of fetching the JWKS.
     'jwt_public_key' => env('OIDC_JWT_PUBLIC_KEY'),
 
-    // Optional: signing algorithm hint (e.g. RS256, RS512, ES256, PS256).
-    // Defaults to the alg in the id_token header, or RS256.
+    // Optional: pin the accepted signing algorithm(s), e.g. 'RS256' or
+    // 'RS256,ES256'. If omitted, the provider accepts the algorithms the IdP
+    // advertises in 'id_token_signing_alg_values_supported', falling back to
+    // RS256. The alg in the token header is only ever checked against this
+    // list, never trusted to select the algorithm; 'none' is always rejected.
     'jwt_algorithm'  => env('OIDC_JWT_ALGORITHM'),
 
     // Optional: override the expected `iss` claim. Defaults to the issuer

--- a/src/OpenIDConnect/README.md
+++ b/src/OpenIDConnect/README.md
@@ -71,6 +71,12 @@ then follow the provider specific instructions below.
     // (always off) in stateless mode, where there is no session to carry it.
     'use_nonce'                => env('OIDC_USE_NONCE', true),
 
+    // Optional: fail the login when no email can be obtained. Defaults to
+    // false, since email depends on the 'email' scope being granted and is not
+    // a claim the IdP is obliged to return -- only 'sub' is. Enable it if your
+    // application genuinely cannot create a user without one.
+    'require_email'            => env('OIDC_REQUIRE_EMAIL', false),
+
     // Optional: Guzzle connect/read timeouts for IdP calls. Defaults: 5s/10s.
     'http_connect_timeout'     => env('OIDC_HTTP_CONNECT_TIMEOUT'),
     'http_timeout'             => env('OIDC_HTTP_TIMEOUT'),
@@ -139,7 +145,9 @@ return Socialite::driver('openidconnect')->redirect();
 $user = Socialite::driver('openidconnect')->user();
 ```
 
-The returned user is populated from the `id_token` claims, falling back to the `userinfo` endpoint when the id_token does not contain an email. Mapped fields include `id` (`sub`), `email`, `name`, `nickname`, `given_name`, `family_name`, `idp`, `role`, and `groups`.
+The returned user is populated from the `id_token` claims. When the id_token carries no email and an access token is available, the `userinfo` endpoint is consulted and its claims merged over the id_token's — its `sub` is verified against the id_token first, as OIDC Core 5.3.2 requires. Mapped fields include `id` (`sub`), `email`, `name`, `nickname`, `given_name`, `family_name`, `idp`, `role`, and `groups`.
+
+Only `sub` is required; a login is rejected without it. `email` is not guaranteed — it depends on the `email` scope being granted — so a user without one is returned with a null email rather than failing. Set `require_email` if your application cannot proceed without it.
 
 The full token endpoint response is available on the standard `accessTokenResponseBody` property, so `$user->accessTokenResponseBody['id_token']` is where you read the id_token — stash it at login if you want to drive RP-initiated logout later. `$user->approvedScopes` holds the scopes the IdP actually granted, which is how you check whether something optional such as `offline_access` was honoured:
 

--- a/src/OpenIDConnect/composer.json
+++ b/src/OpenIDConnect/composer.json
@@ -1,0 +1,38 @@
+{
+    "name": "socialiteproviders/openidconnect",
+    "description": "Generic OpenID Connect OAuth2 Provider for Laravel Socialite",
+    "license": "MIT",
+    "keywords": [
+        "openid",
+        "openid-connect",
+        "oidc",
+        "laravel",
+        "oauth",
+        "provider",
+        "socialite"
+    ],
+    "authors": [
+        {
+            "name": "SocialiteProviders",
+            "homepage": "https://socialiteproviders.com"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/socialiteproviders/providers/issues",
+        "source": "https://github.com/socialiteproviders/providers",
+        "docs": "https://socialiteproviders.com/openidconnect"
+    },
+    "require": {
+        "php": "^8.1",
+        "ext-json": "*",
+        "socialiteproviders/manager": "^4.4",
+        "illuminate/http": "^9.0 | ^10.0 | ^11.0 | ^12.0 | ^13.0",
+        "illuminate/support": "^9.0 | ^10.0 | ^11.0 | ^12.0 | ^13.0",
+        "firebase/php-jwt": "^6.4|^7.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialiteProviders\\OpenIDConnect\\": ""
+        }
+    }
+}

--- a/src/OpenIDConnect/composer.json
+++ b/src/OpenIDConnect/composer.json
@@ -28,7 +28,7 @@
         "socialiteproviders/manager": "^4.4",
         "illuminate/http": "^9.0 | ^10.0 | ^11.0 | ^12.0 | ^13.0",
         "illuminate/support": "^9.0 | ^10.0 | ^11.0 | ^12.0 | ^13.0",
-        "firebase/php-jwt": "^6.4|^7.0"
+        "firebase/php-jwt": "^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/OpenIDConnect/AuthorizedPartyTest.php
+++ b/tests/OpenIDConnect/AuthorizedPartyTest.php
@@ -21,7 +21,7 @@ class AuthorizedPartyTest extends TestCase
     {
         $this->seedJwks();
 
-        $provider = $this->oidcProvider([], $this->request(session: ['nonce' => self::NONCE]));
+        $provider = $this->oidcProvider([], $this->request(session: ['openidconnect_nonce' => self::NONCE]));
 
         return $provider->callDecodeJWT($this->idToken($claims + ['nonce' => self::NONCE]));
     }

--- a/tests/OpenIDConnect/AuthorizedPartyTest.php
+++ b/tests/OpenIDConnect/AuthorizedPartyTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect;
+
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * OIDC Core 3.1.3.7 keeps the two azp rules separate:
+ *
+ *   step 4 - multiple audiences should carry an azp claim;
+ *   step 5 - a present azp must be our client_id, whatever the audience count.
+ *
+ * Gating step 5 on the audience count conflates them and lets a token
+ * authorized to another party through.
+ */
+class AuthorizedPartyTest extends TestCase
+{
+    private const NONCE = 'test-nonce-value';
+
+    private function decode(array $claims)
+    {
+        $this->seedJwks();
+
+        $provider = $this->oidcProvider([], $this->request(session: ['nonce' => self::NONCE]));
+
+        return $provider->callDecodeJWT($this->idToken($claims + ['nonce' => self::NONCE]));
+    }
+
+    #[Test]
+    public function a_single_audience_token_authorized_to_another_party_is_rejected(): void
+    {
+        // The hole: aud names us, but the token was issued for someone else.
+        $this->expectExceptionMessage('Invalid authorized party');
+
+        $this->decode([
+            'aud' => self::CLIENT_ID,
+            'azp' => 'some-other-client',
+        ]);
+    }
+
+    #[Test]
+    public function a_single_element_audience_array_authorized_to_another_party_is_rejected(): void
+    {
+        $this->expectExceptionMessage('Invalid authorized party');
+
+        $this->decode([
+            'aud' => [self::CLIENT_ID],
+            'azp' => 'some-other-client',
+        ]);
+    }
+
+    #[Test]
+    public function a_multi_audience_token_authorized_to_another_party_is_rejected(): void
+    {
+        $this->expectExceptionMessage('Invalid authorized party');
+
+        $this->decode([
+            'aud' => [self::CLIENT_ID, 'another-client'],
+            'azp' => 'another-client',
+        ]);
+    }
+
+    #[Test]
+    public function a_multi_audience_token_without_an_azp_is_rejected(): void
+    {
+        // Step 4, which the previous merged condition enforced only by
+        // accident and which the suggested replacement would have dropped.
+        $this->expectExceptionMessage('Multiple audiences require an azp');
+
+        $this->decode(['aud' => [self::CLIENT_ID, 'another-client']]);
+    }
+
+    #[Test]
+    public function a_matching_azp_is_accepted_with_a_single_audience(): void
+    {
+        $payload = $this->decode([
+            'aud' => self::CLIENT_ID,
+            'azp' => self::CLIENT_ID,
+        ]);
+
+        $this->assertSame('user-1', $payload->sub);
+    }
+
+    #[Test]
+    public function a_matching_azp_is_accepted_with_multiple_audiences(): void
+    {
+        $payload = $this->decode([
+            'aud' => [self::CLIENT_ID, 'another-client'],
+            'azp' => self::CLIENT_ID,
+        ]);
+
+        $this->assertSame('user-1', $payload->sub);
+    }
+
+    #[Test]
+    public function a_single_audience_token_without_an_azp_is_accepted(): void
+    {
+        // azp is optional for a single-audience token.
+        $payload = $this->decode(['aud' => self::CLIENT_ID]);
+
+        $this->assertSame('user-1', $payload->sub);
+    }
+}

--- a/tests/OpenIDConnect/CacheTtlTest.php
+++ b/tests/OpenIDConnect/CacheTtlTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect;
+
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * `cache_ttl` gates how long discovery and JWKS responses are held. Resolving
+ * it with `?:` treated a deliberate 0 as "unset" and substituted the hour-long
+ * default, so anyone turning caching off to debug an IdP kept getting the
+ * cached document.
+ */
+class CacheTtlTest extends TestCase
+{
+    #[Test]
+    public function a_zero_ttl_is_honoured_rather_than_defaulted(): void
+    {
+        $this->assertSame(0, $this->oidcProvider(['cache_ttl' => 0])->callGetCacheTtl());
+    }
+
+    #[Test]
+    public function a_zero_ttl_given_as_a_string_is_also_honoured(): void
+    {
+        // Config that has been through the environment arrives as a string.
+        $this->assertSame(0, $this->oidcProvider(['cache_ttl' => '0'])->callGetCacheTtl());
+    }
+
+    #[Test]
+    public function an_unset_ttl_falls_back_to_an_hour(): void
+    {
+        $this->assertSame(3600, $this->oidcProvider()->callGetCacheTtl());
+    }
+
+    #[Test]
+    public function an_empty_ttl_falls_back_to_an_hour(): void
+    {
+        // An unset environment variable reads as '', which is absence, not 0.
+        $this->assertSame(3600, $this->oidcProvider(['cache_ttl' => ''])->callGetCacheTtl());
+    }
+
+    #[Test]
+    public function a_configured_ttl_is_used(): void
+    {
+        $this->assertSame(7200, $this->oidcProvider(['cache_ttl' => 7200])->callGetCacheTtl());
+        $this->assertSame(7200, $this->oidcProvider(['cache_ttl' => '7200'])->callGetCacheTtl());
+    }
+}

--- a/tests/OpenIDConnect/ClientSecretBasicTest.php
+++ b/tests/OpenIDConnect/ClientSecretBasicTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect;
+
+use GuzzleHttp\RequestOptions;
+use PHPUnit\Framework\Attributes\Test;
+use SocialiteProviders\Manager\Config;
+
+/**
+ * RFC 6749 2.3.1 requires the client id and secret to be form-urlencoded
+ * before they are joined and base64'd for the Basic header. Guzzle's `auth`
+ * option base64s the raw pair, which only agrees for alphanumeric credentials.
+ */
+class ClientSecretBasicTest extends TestCase
+{
+    private function providerWithCredentials(string $clientId, string $clientSecret): ProviderStub
+    {
+        $provider = new ProviderStub($this->request(), $clientId, $clientSecret, self::REDIRECT);
+
+        $provider->setConfig(new Config($clientId, $clientSecret, self::REDIRECT, [
+            'base_url'          => self::BASE_URL,
+            'token_auth_method' => 'client_secret_basic',
+        ]));
+
+        $provider->configurations = $this->discoveryDocument();
+
+        return $provider;
+    }
+
+    private function authorizationHeader(ProviderStub $provider): string
+    {
+        return $provider->callTokenRequestOptions(['code' => 'c'])[RequestOptions::HEADERS]['Authorization'];
+    }
+
+    #[Test]
+    public function a_secret_containing_plus_and_slash_is_encoded(): void
+    {
+        // The common case: a base64-derived secret.
+        $provider = $this->providerWithCredentials('client-id', 'abc+def/ghi=');
+
+        $this->assertSame(
+            'Basic '.base64_encode('client-id:abc%2Bdef%2Fghi%3D'),
+            $this->authorizationHeader($provider)
+        );
+    }
+
+    #[Test]
+    public function the_raw_pair_is_not_what_gets_sent(): void
+    {
+        $secret = 'abc+def/ghi=';
+        $provider = $this->providerWithCredentials('client-id', $secret);
+
+        $this->assertNotSame(
+            'Basic '.base64_encode('client-id:'.$secret),
+            $this->authorizationHeader($provider)
+        );
+    }
+
+    #[Test]
+    public function a_secret_containing_a_space_is_encoded(): void
+    {
+        $provider = $this->providerWithCredentials('client-id', 'two words');
+
+        $this->assertSame(
+            'Basic '.base64_encode('client-id:two+words'),
+            $this->authorizationHeader($provider)
+        );
+    }
+
+    #[Test]
+    public function a_non_ascii_secret_is_encoded(): void
+    {
+        $provider = $this->providerWithCredentials('client-id', 'påsswörd');
+
+        $this->assertSame(
+            'Basic '.base64_encode('client-id:'.urlencode('påsswörd')),
+            $this->authorizationHeader($provider)
+        );
+    }
+
+    #[Test]
+    public function a_client_id_needing_encoding_is_encoded_too(): void
+    {
+        $provider = $this->providerWithCredentials('client id+1', 'secret');
+
+        $this->assertSame(
+            'Basic '.base64_encode('client+id%2B1:secret'),
+            $this->authorizationHeader($provider)
+        );
+    }
+
+    #[Test]
+    public function an_alphanumeric_secret_is_unaffected(): void
+    {
+        // Confirms the change is a no-op for credentials that need no encoding.
+        $provider = $this->providerWithCredentials('client-id', 'plainsecret123');
+
+        $this->assertSame(
+            'Basic '.base64_encode('client-id:plainsecret123'),
+            $this->authorizationHeader($provider)
+        );
+    }
+
+    #[Test]
+    public function guzzles_auth_option_is_no_longer_used(): void
+    {
+        $provider = $this->providerWithCredentials('client-id', 'secret');
+
+        $options = $provider->callTokenRequestOptions(['code' => 'c']);
+
+        $this->assertArrayNotHasKey(RequestOptions::AUTH, $options);
+    }
+
+    #[Test]
+    public function the_credentials_are_kept_out_of_the_form_body(): void
+    {
+        $provider = $this->providerWithCredentials('client-id', 'secret');
+
+        $options = $provider->callTokenRequestOptions([
+            'client_id'     => 'client-id',
+            'client_secret' => 'secret',
+            'code'          => 'c',
+        ]);
+
+        $this->assertArrayNotHasKey('client_id', $options[RequestOptions::FORM_PARAMS]);
+        $this->assertArrayNotHasKey('client_secret', $options[RequestOptions::FORM_PARAMS]);
+    }
+
+    #[Test]
+    public function the_accept_header_is_retained(): void
+    {
+        $provider = $this->providerWithCredentials('client-id', 'secret');
+
+        $headers = $provider->callTokenRequestOptions(['code' => 'c'])[RequestOptions::HEADERS];
+
+        $this->assertSame('application/json', $headers['Accept']);
+    }
+
+    #[Test]
+    public function the_post_method_sends_no_authorization_header(): void
+    {
+        $provider = $this->oidcProvider(['token_auth_method' => 'client_secret_post']);
+
+        $headers = $provider->callTokenRequestOptions(['code' => 'c'])[RequestOptions::HEADERS];
+
+        $this->assertArrayNotHasKey('Authorization', $headers);
+    }
+}

--- a/tests/OpenIDConnect/EndpointQueryTest.php
+++ b/tests/OpenIDConnect/EndpointQueryTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect;
+
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Discovered endpoints are not always bare paths. Multi-tenant deployments
+ * advertise endpoints that already carry a query, and a hardcoded '?' folds
+ * every subsequent parameter into the preceding value.
+ */
+class EndpointQueryTest extends TestCase
+{
+    private function queryFrom(string $url): array
+    {
+        parse_str(parse_url($url, PHP_URL_QUERY) ?: '', $query);
+
+        return $query;
+    }
+
+    #[Test]
+    public function logout_appends_to_an_endpoint_that_already_has_a_query(): void
+    {
+        $provider = $this->oidcProvider(discovery: $this->discoveryDocument([
+            'end_session_endpoint' => self::BASE_URL.'/logout?realm=prod',
+        ]));
+
+        $url = $provider->logout('the-id-token', 'https://app.test/bye')->getTargetUrl();
+
+        $this->assertStringNotContainsString('?realm=prod?', $url);
+
+        $query = $this->queryFrom($url);
+
+        // The realm must survive intact rather than swallowing everything.
+        $this->assertSame('prod', $query['realm']);
+        $this->assertSame('the-id-token', $query['id_token_hint']);
+        $this->assertSame('https://app.test/bye', $query['post_logout_redirect_uri']);
+        $this->assertSame(self::CLIENT_ID, $query['client_id']);
+    }
+
+    #[Test]
+    public function logout_still_works_for_a_bare_endpoint(): void
+    {
+        $provider = $this->oidcProvider();
+
+        $url = $provider->logout('the-id-token')->getTargetUrl();
+
+        $this->assertStringStartsWith(self::BASE_URL.'/logout?', $url);
+        $this->assertSame('the-id-token', $this->queryFrom($url)['id_token_hint']);
+    }
+
+    #[Test]
+    public function the_authorize_endpoint_may_also_carry_a_query(): void
+    {
+        // The same defect one method away: this one breaks login, not logout.
+        $request = $this->request();
+        $provider = $this->oidcProvider(
+            request: $request,
+            discovery: $this->discoveryDocument([
+                'authorization_endpoint' => self::BASE_URL.'/authorize?realm=prod',
+            ])
+        );
+
+        $url = $provider->redirect()->getTargetUrl();
+
+        $this->assertStringNotContainsString('?realm=prod?', $url);
+
+        $query = $this->queryFrom($url);
+
+        $this->assertSame('prod', $query['realm']);
+        $this->assertSame(self::CLIENT_ID, $query['client_id']);
+        $this->assertSame('code', $query['response_type']);
+        $this->assertArrayHasKey('code_challenge', $query);
+        $this->assertSame($request->session()->get('state'), $query['state']);
+    }
+
+    #[Test]
+    public function the_authorize_endpoint_still_works_when_bare(): void
+    {
+        $provider = $this->oidcProvider();
+
+        $url = $provider->redirect()->getTargetUrl();
+
+        $this->assertStringStartsWith(self::BASE_URL.'/authorize?', $url);
+        $this->assertSame('code', $this->queryFrom($url)['response_type']);
+    }
+
+    #[Test]
+    public function extra_logout_parameters_survive_an_existing_query(): void
+    {
+        $provider = $this->oidcProvider(discovery: $this->discoveryDocument([
+            'end_session_endpoint' => self::BASE_URL.'/logout?realm=prod&tenant=eu',
+        ]));
+
+        $url = $provider->logout('the-id-token', null, ['ui_locales' => 'en-GB'])->getTargetUrl();
+
+        $query = $this->queryFrom($url);
+
+        $this->assertSame('prod', $query['realm']);
+        $this->assertSame('eu', $query['tenant']);
+        $this->assertSame('en-GB', $query['ui_locales']);
+    }
+}

--- a/tests/OpenIDConnect/EndpointQueryTest.php
+++ b/tests/OpenIDConnect/EndpointQueryTest.php
@@ -86,6 +86,57 @@ class EndpointQueryTest extends TestCase
     }
 
     #[Test]
+    public function a_fragment_stays_at_the_end_of_the_logout_url(): void
+    {
+        // Appending blindly would produce '/logout#done?id_token_hint=...',
+        // burying the whole query inside the fragment where the IdP never
+        // sees it.
+        $provider = $this->oidcProvider(discovery: $this->discoveryDocument([
+            'end_session_endpoint' => self::BASE_URL.'/logout#done',
+        ]));
+
+        $url = $provider->logout('the-id-token')->getTargetUrl();
+
+        $this->assertStringNotContainsString('#done?', $url);
+        $this->assertStringEndsWith('#done', $url);
+        $this->assertSame('the-id-token', $this->queryFrom($url)['id_token_hint']);
+    }
+
+    #[Test]
+    public function a_fragment_survives_alongside_an_existing_query(): void
+    {
+        $provider = $this->oidcProvider(discovery: $this->discoveryDocument([
+            'end_session_endpoint' => self::BASE_URL.'/logout?realm=prod#done',
+        ]));
+
+        $url = $provider->logout('the-id-token')->getTargetUrl();
+
+        $this->assertStringEndsWith('#done', $url);
+
+        $query = $this->queryFrom($url);
+
+        $this->assertSame('prod', $query['realm']);
+        $this->assertSame('the-id-token', $query['id_token_hint']);
+    }
+
+    #[Test]
+    public function a_fragment_on_the_authorize_endpoint_is_handled_too(): void
+    {
+        $provider = $this->oidcProvider(discovery: $this->discoveryDocument([
+            'authorization_endpoint' => self::BASE_URL.'/authorize#app',
+        ]));
+
+        $url = $provider->redirect()->getTargetUrl();
+
+        $this->assertStringEndsWith('#app', $url);
+
+        $query = $this->queryFrom($url);
+
+        $this->assertSame(self::CLIENT_ID, $query['client_id']);
+        $this->assertSame('code', $query['response_type']);
+    }
+
+    #[Test]
     public function extra_logout_parameters_survive_an_existing_query(): void
     {
         $provider = $this->oidcProvider(discovery: $this->discoveryDocument([

--- a/tests/OpenIDConnect/IdTokenClaimsTest.php
+++ b/tests/OpenIDConnect/IdTokenClaimsTest.php
@@ -14,7 +14,7 @@ class IdTokenClaimsTest extends TestCase
 
         return $this->oidcProvider(
             $config,
-            $this->request(session: ['nonce' => self::NONCE]),
+            $this->request(session: ['openidconnect_nonce' => self::NONCE]),
             $discovery
         );
     }
@@ -32,13 +32,13 @@ class IdTokenClaimsTest extends TestCase
     #[Test]
     public function the_nonce_is_cleared_once_consumed(): void
     {
-        $request = $this->request(session: ['nonce' => self::NONCE]);
+        $request = $this->request(session: ['openidconnect_nonce' => self::NONCE]);
         $this->seedJwks();
         $provider = $this->oidcProvider([], $request);
 
         $provider->callDecodeJWT($this->idToken(['nonce' => self::NONCE]));
 
-        $this->assertNull($request->session()->get('nonce'));
+        $this->assertNull($request->session()->get('openidconnect_nonce'));
     }
 
     #[Test]
@@ -136,7 +136,7 @@ class IdTokenClaimsTest extends TestCase
     #[Test]
     public function an_expired_token_is_rejected_even_when_signature_verification_is_off(): void
     {
-        $request = $this->request(session: ['nonce' => self::NONCE]);
+        $request = $this->request(session: ['openidconnect_nonce' => self::NONCE]);
         $provider = $this->oidcProvider(['verify_jwt' => false], $request);
 
         $this->expectExceptionMessage('expired');
@@ -160,7 +160,7 @@ class IdTokenClaimsTest extends TestCase
     #[Test]
     public function a_token_that_is_not_yet_valid_is_rejected(): void
     {
-        $request = $this->request(session: ['nonce' => self::NONCE]);
+        $request = $this->request(session: ['openidconnect_nonce' => self::NONCE]);
         $provider = $this->oidcProvider(['verify_jwt' => false], $request);
 
         $this->expectExceptionMessage('not yet valid');
@@ -171,7 +171,7 @@ class IdTokenClaimsTest extends TestCase
     #[Test]
     public function a_token_issued_in_the_future_is_rejected(): void
     {
-        $request = $this->request(session: ['nonce' => self::NONCE]);
+        $request = $this->request(session: ['openidconnect_nonce' => self::NONCE]);
         $provider = $this->oidcProvider(['verify_jwt' => false], $request);
 
         $this->expectExceptionMessage('issued in the future');

--- a/tests/OpenIDConnect/IdTokenClaimsTest.php
+++ b/tests/OpenIDConnect/IdTokenClaimsTest.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect;
+
+use PHPUnit\Framework\Attributes\Test;
+
+class IdTokenClaimsTest extends TestCase
+{
+    protected const NONCE = 'test-nonce-value';
+
+    private function providerWithNonce(array $config = [], ?array $discovery = null): ProviderStub
+    {
+        $this->seedJwks();
+
+        return $this->oidcProvider(
+            $config,
+            $this->request(session: ['nonce' => self::NONCE]),
+            $discovery
+        );
+    }
+
+    #[Test]
+    public function a_valid_token_is_accepted(): void
+    {
+        $provider = $this->providerWithNonce();
+
+        $payload = $provider->callDecodeJWT($this->idToken(['nonce' => self::NONCE]));
+
+        $this->assertSame('user-1', $payload->sub);
+    }
+
+    #[Test]
+    public function the_nonce_is_cleared_once_consumed(): void
+    {
+        $request = $this->request(session: ['nonce' => self::NONCE]);
+        $this->seedJwks();
+        $provider = $this->oidcProvider([], $request);
+
+        $provider->callDecodeJWT($this->idToken(['nonce' => self::NONCE]));
+
+        $this->assertNull($request->session()->get('nonce'));
+    }
+
+    #[Test]
+    public function a_mismatched_nonce_is_rejected(): void
+    {
+        $provider = $this->providerWithNonce();
+
+        $this->expectExceptionMessage('invalid nonce');
+
+        $provider->callDecodeJWT($this->idToken(['nonce' => 'attacker-nonce']));
+    }
+
+    #[Test]
+    public function a_missing_nonce_is_rejected(): void
+    {
+        $provider = $this->providerWithNonce();
+
+        $this->expectExceptionMessage('invalid nonce');
+
+        $provider->callDecodeJWT($this->idToken());
+    }
+
+    #[Test]
+    public function a_mismatched_issuer_is_rejected(): void
+    {
+        $provider = $this->providerWithNonce();
+
+        $this->expectExceptionMessage('Invalid issuer');
+
+        $provider->callDecodeJWT($this->idToken(['nonce' => self::NONCE, 'iss' => 'https://evil.test']));
+    }
+
+    #[Test]
+    public function the_issuer_config_overrides_discovery(): void
+    {
+        $provider = $this->providerWithNonce(['issuer' => 'https://override.test']);
+
+        $payload = $provider->callDecodeJWT($this->idToken([
+            'nonce' => self::NONCE,
+            'iss'   => 'https://override.test',
+        ]));
+
+        $this->assertSame('https://override.test', $payload->iss);
+    }
+
+    #[Test]
+    public function a_token_for_another_audience_is_rejected(): void
+    {
+        $provider = $this->providerWithNonce();
+
+        $this->expectExceptionMessage('Invalid audience');
+
+        $provider->callDecodeJWT($this->idToken(['nonce' => self::NONCE, 'aud' => 'another-client']));
+    }
+
+    #[Test]
+    public function an_audience_array_containing_the_client_id_is_accepted(): void
+    {
+        $provider = $this->providerWithNonce();
+
+        $payload = $provider->callDecodeJWT($this->idToken([
+            'nonce' => self::NONCE,
+            'aud'   => [self::CLIENT_ID],
+        ]));
+
+        $this->assertSame('user-1', $payload->sub);
+    }
+
+    #[Test]
+    public function a_multi_audience_token_requires_a_matching_azp(): void
+    {
+        $provider = $this->providerWithNonce();
+
+        $this->expectExceptionMessage('authorized party');
+
+        $provider->callDecodeJWT($this->idToken([
+            'nonce' => self::NONCE,
+            'aud'   => [self::CLIENT_ID, 'another-client'],
+            'azp'   => 'another-client',
+        ]));
+    }
+
+    #[Test]
+    public function an_expired_token_is_rejected(): void
+    {
+        $provider = $this->providerWithNonce();
+
+        // php-jwt rejects this during signature verification ("Expired token");
+        // validateTimeClaims() is the backstop when verification is disabled.
+        $this->expectExceptionMessageMatches('/expired/i');
+
+        $provider->callDecodeJWT($this->idToken(['nonce' => self::NONCE, 'exp' => time() - 3600]));
+    }
+
+    #[Test]
+    public function an_expired_token_is_rejected_even_when_signature_verification_is_off(): void
+    {
+        $request = $this->request(session: ['nonce' => self::NONCE]);
+        $provider = $this->oidcProvider(['verify_jwt' => false], $request);
+
+        $this->expectExceptionMessage('expired');
+
+        $provider->callDecodeJWT($this->idToken(['nonce' => self::NONCE, 'exp' => time() - 3600]));
+    }
+
+    #[Test]
+    public function clock_skew_tolerates_a_marginally_expired_token(): void
+    {
+        $provider = $this->providerWithNonce(['clock_skew' => 300]);
+
+        $payload = $provider->callDecodeJWT($this->idToken([
+            'nonce' => self::NONCE,
+            'exp'   => time() - 30,
+        ]));
+
+        $this->assertSame('user-1', $payload->sub);
+    }
+
+    #[Test]
+    public function a_token_that_is_not_yet_valid_is_rejected(): void
+    {
+        $request = $this->request(session: ['nonce' => self::NONCE]);
+        $provider = $this->oidcProvider(['verify_jwt' => false], $request);
+
+        $this->expectExceptionMessage('not yet valid');
+
+        $provider->callDecodeJWT($this->idToken(['nonce' => self::NONCE, 'nbf' => time() + 3600]));
+    }
+
+    #[Test]
+    public function a_token_issued_in_the_future_is_rejected(): void
+    {
+        $request = $this->request(session: ['nonce' => self::NONCE]);
+        $provider = $this->oidcProvider(['verify_jwt' => false], $request);
+
+        $this->expectExceptionMessage('issued in the future');
+
+        $provider->callDecodeJWT($this->idToken(['nonce' => self::NONCE, 'iat' => time() + 3600]));
+    }
+
+    #[Test]
+    public function a_valid_at_hash_is_accepted(): void
+    {
+        $provider = $this->providerWithNonce();
+        $accessToken = 'the-access-token';
+
+        $payload = $provider->callDecodeJWT(
+            $this->idToken(['nonce' => self::NONCE, 'at_hash' => $this->atHash($accessToken)]),
+            $accessToken
+        );
+
+        $this->assertSame('user-1', $payload->sub);
+    }
+
+    #[Test]
+    public function a_mismatched_at_hash_is_rejected(): void
+    {
+        $provider = $this->providerWithNonce();
+
+        $this->expectExceptionMessage('at_hash mismatch');
+
+        $provider->callDecodeJWT(
+            $this->idToken(['nonce' => self::NONCE, 'at_hash' => $this->atHash('a-different-token')]),
+            'the-access-token'
+        );
+    }
+
+    private function atHash(string $accessToken): string
+    {
+        $digest = hash('sha256', $accessToken, true);
+
+        return $this->base64UrlEncode(substr($digest, 0, intdiv(strlen($digest), 2)));
+    }
+}

--- a/tests/OpenIDConnect/JwtAlgorithmTest.php
+++ b/tests/OpenIDConnect/JwtAlgorithmTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect;
+
+use Firebase\JWT\JWT;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Regression cover for the algorithm substitution attack (RFC 8725 section 2.1,
+ * OIDC Core 3.1.3.7 step 7): the verification algorithm must be pinned by the
+ * RP, never read from the token's own header.
+ */
+class JwtAlgorithmTest extends TestCase
+{
+    #[Test]
+    public function legitimate_rs256_token_is_accepted_against_a_configured_public_key(): void
+    {
+        $provider = $this->oidcProvider(['jwt_public_key' => $this->publicKey]);
+
+        $payload = $provider->callVerifyFromToken($this->idToken(['sub' => 'alice']));
+
+        $this->assertSame('alice', $payload->sub);
+    }
+
+    #[Test]
+    public function token_forged_by_hmac_signing_with_the_public_key_is_rejected(): void
+    {
+        $provider = $this->oidcProvider(['jwt_public_key' => $this->publicKey]);
+
+        // The attacker holds no private key -- only the PEM public key, which
+        // is not secret -- and HMAC-signs with it while claiming alg: HS256.
+        $forged = JWT::encode($this->claims(['sub' => 'admin']), $this->publicKey, 'HS256', self::KID);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $provider->callVerifyFromToken($forged);
+    }
+
+    #[Test]
+    public function forged_token_is_rejected_even_when_the_op_advertises_hs256(): void
+    {
+        // The allow list alone is not enough here: HS256 is legitimately
+        // advertised, so the asymmetric-key guard has to catch it.
+        $provider = $this->oidcProvider(
+            ['jwt_public_key' => $this->publicKey],
+            discovery: $this->discoveryDocument([
+                'id_token_signing_alg_values_supported' => ['RS256', 'HS256'],
+            ])
+        );
+
+        $forged = JWT::encode($this->claims(['sub' => 'admin']), $this->publicKey, 'HS256', self::KID);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $provider->callVerifyFromToken($forged);
+    }
+
+    #[Test]
+    public function hmac_is_rejected_on_the_jwks_path(): void
+    {
+        $this->seedJwks();
+
+        $provider = $this->oidcProvider(discovery: $this->discoveryDocument([
+            'id_token_signing_alg_values_supported' => ['RS256', 'HS256'],
+        ]));
+
+        $forged = JWT::encode($this->claims(['sub' => 'admin']), str_repeat('a', 64), 'HS256', self::KID);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $provider->callVerifyFromToken($forged);
+    }
+
+    #[Test]
+    public function legitimate_token_verifies_against_the_jwks(): void
+    {
+        $this->seedJwks();
+
+        $provider = $this->oidcProvider();
+
+        $payload = $provider->callVerifyFromToken($this->idToken(['sub' => 'alice']));
+
+        $this->assertSame('alice', $payload->sub);
+    }
+
+    #[Test]
+    public function algorithm_outside_the_allow_list_is_rejected(): void
+    {
+        $provider = $this->oidcProvider([
+            'jwt_public_key' => $this->publicKey,
+            'jwt_algorithm'  => 'RS256',
+        ]);
+
+        $rs512 = $this->idToken([], 'RS512');
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $provider->callVerifyFromToken($rs512);
+    }
+
+    #[Test]
+    public function configured_algorithm_list_is_honoured(): void
+    {
+        $provider = $this->oidcProvider([
+            'jwt_public_key' => $this->publicKey,
+            'jwt_algorithm'  => 'RS256, RS512',
+        ]);
+
+        $this->assertSame(['RS256', 'RS512'], $provider->callAllowedSigningAlgorithms());
+        $this->assertSame('user-1', $provider->callVerifyFromToken($this->idToken([], 'RS512'))->sub);
+    }
+
+    #[Test]
+    public function allowed_algorithms_fall_back_to_the_discovery_document(): void
+    {
+        $provider = $this->oidcProvider(discovery: $this->discoveryDocument([
+            'id_token_signing_alg_values_supported' => ['ES256', 'RS256'],
+        ]));
+
+        $this->assertSame(['ES256', 'RS256'], $provider->callAllowedSigningAlgorithms());
+    }
+
+    #[Test]
+    public function allowed_algorithms_fall_back_to_rs256(): void
+    {
+        $provider = $this->oidcProvider(discovery: $this->discoveryDocument([
+            'id_token_signing_alg_values_supported' => [],
+        ]));
+
+        $this->assertSame(['RS256'], $provider->callAllowedSigningAlgorithms());
+    }
+
+    #[Test]
+    public function alg_none_is_never_accepted(): void
+    {
+        $provider = $this->oidcProvider(
+            ['jwt_algorithm' => 'none'],
+            discovery: $this->discoveryDocument([
+                'id_token_signing_alg_values_supported' => ['none'],
+            ])
+        );
+
+        $this->assertSame(['RS256'], $provider->callAllowedSigningAlgorithms());
+    }
+
+    #[Test]
+    public function unsigned_token_is_rejected(): void
+    {
+        $this->seedJwks();
+
+        $provider = $this->oidcProvider();
+
+        $header = $this->base64UrlEncode(json_encode(['alg' => 'none', 'typ' => 'JWT']));
+        $body = $this->base64UrlEncode(json_encode($this->claims(['sub' => 'admin'])));
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $provider->callVerifyFromToken($header.'.'.$body.'.');
+    }
+}

--- a/tests/OpenIDConnect/JwtLeewayTest.php
+++ b/tests/OpenIDConnect/JwtLeewayTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect;
+
+use Firebase\JWT\JWT;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * JWT::$leeway is a global static in firebase/php-jwt. The provider sets it
+ * from `clock_skew` before decoding, so it has to put it back afterwards --
+ * otherwise this provider's skew tolerance silently applies to every later JWT
+ * validation in the process, which in a long-running worker (Octane,
+ * RoadRunner, queues) means for the life of the worker.
+ */
+class JwtLeewayTest extends TestCase
+{
+    private int $originalLeeway;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalLeeway = JWT::$leeway;
+    }
+
+    protected function tearDown(): void
+    {
+        JWT::$leeway = $this->originalLeeway;
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function leeway_is_restored_after_a_successful_verification(): void
+    {
+        $this->seedJwks();
+
+        JWT::$leeway = 0;
+
+        $provider = $this->oidcProvider(['clock_skew' => 300]);
+
+        $this->assertSame('user-1', $provider->callVerifyFromToken($this->idToken())->sub);
+        $this->assertSame(0, JWT::$leeway);
+    }
+
+    #[Test]
+    public function leeway_is_restored_after_a_failed_verification(): void
+    {
+        $this->seedJwks();
+
+        JWT::$leeway = 0;
+
+        $provider = $this->oidcProvider(['clock_skew' => 300]);
+
+        // Same header and payload, so the kid still resolves; only the
+        // signature is junk, which fails inside JWT::decode().
+        $tampered = substr($this->idToken(), 0, -4).'AAAA';
+
+        try {
+            $provider->callVerifyFromToken($tampered);
+            $this->fail('Expected verification to fail.');
+        } catch (InvalidArgumentException) {
+            // Expected.
+        }
+
+        $this->assertSame(0, JWT::$leeway);
+    }
+
+    #[Test]
+    public function a_preexisting_leeway_is_preserved_rather_than_zeroed(): void
+    {
+        // A provider with no clock_skew configured sets the leeway to 0. If it
+        // did not restore, it would tighten validation for whoever set this.
+        $this->seedJwks();
+
+        JWT::$leeway = 60;
+
+        $provider = $this->oidcProvider();
+
+        $this->assertSame('user-1', $provider->callVerifyFromToken($this->idToken())->sub);
+        $this->assertSame(60, JWT::$leeway);
+    }
+
+    #[Test]
+    public function clock_skew_still_applies_during_the_decode(): void
+    {
+        // Restoring the value must not defeat the setting: a token that expired
+        // within the configured skew is still accepted.
+        $this->seedJwks();
+
+        $provider = $this->oidcProvider(['clock_skew' => 300]);
+
+        $token = $this->idToken(['exp' => time() - 60]);
+
+        $this->assertSame('user-1', $provider->callVerifyFromToken($token)->sub);
+    }
+}

--- a/tests/OpenIDConnect/LogoutStateTest.php
+++ b/tests/OpenIDConnect/LogoutStateTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect;
+
+use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * logout() mints a state; without the matching check on the way back it is
+ * decorative rather than protective.
+ */
+class LogoutStateTest extends TestCase
+{
+    private function stateFrom(string $url): ?string
+    {
+        parse_str(parse_url($url, PHP_URL_QUERY) ?: '', $query);
+
+        return $query['state'] ?? null;
+    }
+
+    #[Test]
+    public function a_matching_state_validates(): void
+    {
+        $request = $this->request();
+        $provider = $this->oidcProvider(request: $request);
+
+        $state = $this->stateFrom($provider->logout('id-token')->getTargetUrl());
+
+        $this->assertNotNull($state);
+        $this->assertSame($state, $request->session()->get('logout_state'));
+
+        $callback = $this->request(['state' => $state]);
+        $callback->session()->put('logout_state', $state);
+
+        $this->assertTrue($provider->validateLogoutState($callback));
+    }
+
+    #[Test]
+    public function a_mismatched_state_does_not_validate(): void
+    {
+        $provider = $this->oidcProvider();
+
+        $callback = $this->request(['state' => 'attacker-supplied']);
+        $callback->session()->put('logout_state', 'the-real-state');
+
+        $this->assertFalse($provider->validateLogoutState($callback));
+    }
+
+    #[Test]
+    public function a_missing_returned_state_does_not_validate(): void
+    {
+        $provider = $this->oidcProvider();
+
+        $callback = $this->request();
+        $callback->session()->put('logout_state', 'the-real-state');
+
+        $this->assertFalse($provider->validateLogoutState($callback));
+    }
+
+    #[Test]
+    public function a_state_with_nothing_stored_does_not_validate(): void
+    {
+        $provider = $this->oidcProvider();
+
+        $this->assertFalse($provider->validateLogoutState($this->request(['state' => 'anything'])));
+    }
+
+    #[Test]
+    public function an_empty_state_on_both_sides_does_not_validate(): void
+    {
+        $provider = $this->oidcProvider();
+
+        $callback = $this->request(['state' => '']);
+        $callback->session()->put('logout_state', '');
+
+        $this->assertFalse($provider->validateLogoutState($callback));
+    }
+
+    #[Test]
+    public function a_state_is_good_for_only_one_round_trip(): void
+    {
+        $provider = $this->oidcProvider();
+
+        $callback = $this->request(['state' => 'the-state']);
+        $callback->session()->put('logout_state', 'the-state');
+
+        $this->assertTrue($provider->validateLogoutState($callback));
+        $this->assertFalse($provider->validateLogoutState($callback));
+    }
+
+    #[Test]
+    public function no_state_is_sent_when_there_is_no_session_to_store_it(): void
+    {
+        // Emitting one would look like protection that cannot be checked.
+        $provider = $this->oidcProvider(request: Request::create(self::REDIRECT, 'GET'));
+
+        $url = $provider->logout('id-token')->getTargetUrl();
+
+        $this->assertNull($this->stateFrom($url));
+    }
+
+    #[Test]
+    public function validation_fails_without_a_session(): void
+    {
+        $provider = $this->oidcProvider();
+
+        $this->assertFalse(
+            $provider->validateLogoutState(Request::create(self::REDIRECT, 'GET', ['state' => 'x']))
+        );
+    }
+
+    #[Test]
+    public function the_providers_own_request_is_used_by_default(): void
+    {
+        $request = $this->request(['state' => 'the-state']);
+        $request->session()->put('logout_state', 'the-state');
+
+        $this->assertTrue($this->oidcProvider(request: $request)->validateLogoutState());
+    }
+}

--- a/tests/OpenIDConnect/LogoutTokenReplayTest.php
+++ b/tests/OpenIDConnect/LogoutTokenReplayTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect;
+
+use Firebase\JWT\JWT;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use SocialiteProviders\OpenIDConnect\Provider;
+
+/**
+ * A back-channel logout token is delivered by the IdP, which retries. Acting
+ * on the same jti twice has to be refused, and the window for remembering it
+ * has to be tunable -- which means `logout_token_replay_ttl` must actually
+ * reach the provider's config.
+ */
+class LogoutTokenReplayTest extends TestCase
+{
+    private const EVENT = 'http://schemas.openid.net/event/backchannel-logout';
+
+    private function logoutToken(array $overrides = []): string
+    {
+        $claims = array_merge([
+            'iss'    => self::BASE_URL,
+            'aud'    => self::CLIENT_ID,
+            'sub'    => 'user-1',
+            'sid'    => 'session-1',
+            'iat'    => time(),
+            'exp'    => time() + 300,
+            'jti'    => 'unique-token-id',
+            'events' => [self::EVENT => new \stdClass],
+        ], $overrides);
+
+        return JWT::encode($claims, $this->privateKey, 'RS256', self::KID);
+    }
+
+    #[Test]
+    public function logout_token_replay_ttl_is_an_accepted_config_key(): void
+    {
+        // Without this the option is silently dropped before getConfig() ever
+        // sees it, and every value below would resolve to the default.
+        $this->assertContains('logout_token_replay_ttl', Provider::additionalConfigKeys());
+    }
+
+    #[Test]
+    public function replaying_a_logout_token_is_refused(): void
+    {
+        $this->seedJwks();
+
+        $provider = $this->oidcProvider();
+        $token = $this->logoutToken();
+
+        $this->assertSame('user-1', $provider->verifyLogoutToken($token)['sub']);
+
+        $this->expectExceptionMessage('already used');
+
+        $provider->verifyLogoutToken($token);
+    }
+
+    #[Test]
+    public function a_zero_ttl_opts_out_of_replay_protection(): void
+    {
+        // For deployments that track jti themselves.
+        $this->seedJwks();
+
+        $provider = $this->oidcProvider(['logout_token_replay_ttl' => 0]);
+        $token = $this->logoutToken();
+
+        $this->assertSame('user-1', $provider->verifyLogoutToken($token)['sub']);
+        $this->assertSame('user-1', $provider->verifyLogoutToken($token)['sub']);
+    }
+
+    #[Test]
+    public function a_configured_ttl_overrides_the_value_derived_from_exp(): void
+    {
+        $provider = $this->oidcProvider(['logout_token_replay_ttl' => 42]);
+
+        $this->assertSame(42, $provider->callLogoutTokenReplayTtl(time() + 100000));
+    }
+
+    #[Test]
+    public function the_ttl_otherwise_outlives_the_token(): void
+    {
+        $provider = $this->oidcProvider(['clock_skew' => 30]);
+
+        // 300s remaining + 30s skew + 60s margin.
+        $this->assertSame(390, $provider->callLogoutTokenReplayTtl(time() + 300));
+    }
+
+    #[Test]
+    public function a_token_without_exp_gets_a_fixed_window(): void
+    {
+        $this->assertSame(900, $this->oidcProvider()->callLogoutTokenReplayTtl(null));
+    }
+
+    #[Test]
+    public function two_different_tokens_do_not_collide(): void
+    {
+        $this->seedJwks();
+
+        $provider = $this->oidcProvider();
+
+        $provider->verifyLogoutToken($this->logoutToken(['jti' => 'first']));
+
+        try {
+            $provider->verifyLogoutToken($this->logoutToken(['jti' => 'second']));
+        } catch (InvalidArgumentException $e) {
+            $this->fail('A distinct jti was treated as a replay: '.$e->getMessage());
+        }
+
+        $this->addToAssertionCount(1);
+    }
+}

--- a/tests/OpenIDConnect/LogoutTokenTest.php
+++ b/tests/OpenIDConnect/LogoutTokenTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect;
+
+use Firebase\JWT\JWT;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Back-channel logout tokens arrive on an unauthenticated endpoint, so the
+ * signature and claim rules are the only thing standing in the way.
+ *
+ * @see https://openid.net/specs/openid-connect-backchannel-1_0.html
+ */
+class LogoutTokenTest extends TestCase
+{
+    private const EVENT = 'http://schemas.openid.net/event/backchannel-logout';
+
+    private function logoutToken(array $overrides = [], string $alg = 'RS256', mixed $key = null): string
+    {
+        $claims = array_merge([
+            'iss'    => self::BASE_URL,
+            'aud'    => self::CLIENT_ID,
+            'sub'    => 'user-1',
+            'sid'    => 'session-1',
+            'iat'    => time(),
+            'exp'    => time() + 300,
+            'jti'    => 'unique-token-id',
+            'events' => [self::EVENT => new \stdClass],
+        ], $overrides);
+
+        return JWT::encode($claims, $key ?? $this->privateKey, $alg, self::KID);
+    }
+
+    #[Test]
+    public function a_valid_logout_token_is_accepted(): void
+    {
+        $this->seedJwks();
+
+        $payload = $this->oidcProvider()->verifyLogoutToken($this->logoutToken());
+
+        $this->assertSame('user-1', $payload['sub']);
+        $this->assertSame('session-1', $payload['sid']);
+    }
+
+    #[Test]
+    public function a_logout_token_forged_with_the_public_key_is_rejected(): void
+    {
+        // The attack that matters most here: this endpoint has no session and
+        // no user, so the signature is the sole control.
+        $provider = $this->oidcProvider(['jwt_public_key' => $this->publicKey]);
+
+        $forged = $this->logoutToken(['sub' => 'admin'], 'HS256', $this->publicKey);
+
+        $this->expectExceptionMessageMatches('/algorithm/i');
+
+        $provider->verifyLogoutToken($forged);
+    }
+
+    #[Test]
+    public function a_logout_token_from_another_issuer_is_rejected(): void
+    {
+        $this->seedJwks();
+
+        $this->expectExceptionMessage('invalid issuer');
+
+        $this->oidcProvider()->verifyLogoutToken($this->logoutToken(['iss' => 'https://evil.test']));
+    }
+
+    #[Test]
+    public function a_logout_token_for_another_audience_is_rejected(): void
+    {
+        $this->seedJwks();
+
+        $this->expectExceptionMessage('invalid audience');
+
+        $this->oidcProvider()->verifyLogoutToken($this->logoutToken(['aud' => 'another-client']));
+    }
+
+    #[Test]
+    public function a_logout_token_without_a_jti_is_rejected(): void
+    {
+        $this->seedJwks();
+
+        $this->expectExceptionMessage('missing jti');
+
+        $this->oidcProvider()->verifyLogoutToken($this->logoutToken(['jti' => null]));
+    }
+
+    #[Test]
+    public function a_logout_token_containing_a_nonce_is_rejected(): void
+    {
+        $this->seedJwks();
+
+        $this->expectExceptionMessage('must not contain a nonce');
+
+        $this->oidcProvider()->verifyLogoutToken($this->logoutToken(['nonce' => 'should-not-be-here']));
+    }
+
+    #[Test]
+    public function a_logout_token_without_the_backchannel_event_is_rejected(): void
+    {
+        $this->seedJwks();
+
+        $this->expectExceptionMessage('missing backchannel-logout event');
+
+        $this->oidcProvider()->verifyLogoutToken($this->logoutToken(['events' => new \stdClass]));
+    }
+
+    #[Test]
+    public function a_logout_token_without_sub_or_sid_is_rejected(): void
+    {
+        $this->seedJwks();
+
+        $this->expectExceptionMessage('must contain sub and/or sid');
+
+        $this->oidcProvider()->verifyLogoutToken($this->logoutToken(['sub' => null, 'sid' => null]));
+    }
+
+    #[Test]
+    public function an_expired_logout_token_is_rejected(): void
+    {
+        $this->seedJwks();
+
+        $this->expectExceptionMessageMatches('/expired/i');
+
+        $this->oidcProvider()->verifyLogoutToken($this->logoutToken(['exp' => time() - 3600]));
+    }
+}

--- a/tests/OpenIDConnect/MalformedTokenTest.php
+++ b/tests/OpenIDConnect/MalformedTokenTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect;
+
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Malformed tokens should fail where they are malformed, not several checks
+ * later. base64_decode() in non-strict mode silently discards characters
+ * outside the alphabet and returns plausible bytes for input that was never
+ * valid base64.
+ */
+class MalformedTokenTest extends TestCase
+{
+    private const NONCE = 'test-nonce-value';
+
+    private function providerFor(array $config = [], $request = null, ?array $discovery = null): ProviderStub
+    {
+        return $this->oidcProvider(
+            $config,
+            $request ?? $this->request(session: ['nonce' => self::NONCE]),
+            $discovery
+        );
+    }
+
+    private function segment(array $data): string
+    {
+        return $this->base64UrlEncode(json_encode($data));
+    }
+
+    #[Test]
+    public function a_token_with_no_separators_is_reported(): void
+    {
+        // Previously a warning followed by a TypeError, which is an Error and
+        // so escaped the surrounding catch (Exception) altogether.
+        $this->expectExceptionMessage('expected three segments');
+
+        $this->providerFor()->callDecodeJWT('not-a-jwt-at-all');
+    }
+
+    #[Test]
+    public function a_two_segment_token_is_reported(): void
+    {
+        $this->expectExceptionMessage('expected three segments');
+
+        $this->providerFor()->callDecodeJWT($this->segment(['alg' => 'RS256']).'.'.$this->segment(['sub' => 'x']));
+    }
+
+    #[Test]
+    public function a_four_segment_token_is_reported(): void
+    {
+        $this->expectExceptionMessage('expected three segments');
+
+        $this->providerFor()->callDecodeJWT('a.b.c.d');
+    }
+
+    #[Test]
+    public function an_out_of_alphabet_header_is_reported(): void
+    {
+        $this->expectExceptionMessage('Malformed base64url segment');
+
+        $this->providerFor()->callDecodeJWT('abc$%^&*def.'.$this->segment(['sub' => 'x']).'.sig');
+    }
+
+    #[Test]
+    public function an_out_of_alphabet_payload_is_reported(): void
+    {
+        $provider = $this->providerFor(['verify_jwt' => false]);
+
+        $this->expectExceptionMessage('Malformed base64url segment');
+
+        $provider->callDecodeJWT($this->segment(['alg' => 'RS256']).'.abc$%^&*def.sig');
+    }
+
+    #[Test]
+    public function a_header_that_is_not_json_is_reported(): void
+    {
+        $this->expectExceptionMessage('Failed to parse header');
+
+        $this->providerFor()->callDecodeJWT(
+            $this->base64UrlEncode('this is not json').'.'.$this->segment(['sub' => 'x']).'.sig'
+        );
+    }
+
+    #[Test]
+    public function a_header_that_is_not_an_object_is_reported(): void
+    {
+        $this->expectExceptionMessage('Failed to parse header');
+
+        $this->providerFor()->callDecodeJWT(
+            $this->base64UrlEncode('"a string"').'.'.$this->segment(['sub' => 'x']).'.sig'
+        );
+    }
+
+    #[Test]
+    public function a_payload_that_is_not_json_is_reported(): void
+    {
+        $provider = $this->providerFor(['verify_jwt' => false]);
+
+        $this->expectExceptionMessage('JWT: Failed to parse.');
+
+        $provider->callDecodeJWT(
+            $this->segment(['alg' => 'RS256']).'.'.$this->base64UrlEncode('this is not json').'.sig'
+        );
+    }
+
+    #[Test]
+    public function a_payload_that_is_not_an_object_is_reported(): void
+    {
+        $provider = $this->providerFor(['verify_jwt' => false]);
+
+        $this->expectExceptionMessage('JWT: Failed to parse.');
+
+        $provider->callDecodeJWT(
+            $this->segment(['alg' => 'RS256']).'.'.$this->base64UrlEncode('[1,2,3]').'.sig'
+        );
+    }
+
+    #[Test]
+    public function a_valid_token_is_unaffected(): void
+    {
+        $this->seedJwks();
+
+        $payload = $this->providerFor()->callDecodeJWT($this->idToken(['nonce' => self::NONCE]));
+
+        $this->assertSame('user-1', $payload->sub);
+    }
+
+    #[Test]
+    public function unpadded_segments_of_every_length_class_still_decode(): void
+    {
+        // The padding fix and strict mode have to agree for all three valid
+        // base64 length classes (len % 4 of 0, 2 and 3).
+        $this->seedJwks();
+
+        foreach (['a', 'ab', 'abc', 'abcd', 'abcde'] as $filler) {
+            $payload = $this->providerFor()->callDecodeJWT(
+                $this->idToken(['nonce' => self::NONCE, 'name' => $filler])
+            );
+
+            $this->assertSame($filler, $payload->name);
+        }
+    }
+}

--- a/tests/OpenIDConnect/MalformedTokenTest.php
+++ b/tests/OpenIDConnect/MalformedTokenTest.php
@@ -18,7 +18,7 @@ class MalformedTokenTest extends TestCase
     {
         return $this->oidcProvider(
             $config,
-            $request ?? $this->request(session: ['nonce' => self::NONCE]),
+            $request ?? $this->request(session: ['openidconnect_nonce' => self::NONCE]),
             $discovery
         );
     }

--- a/tests/OpenIDConnect/PkceTest.php
+++ b/tests/OpenIDConnect/PkceTest.php
@@ -58,8 +58,8 @@ class PkceTest extends TestCase
         $url = $provider->redirect()->getTargetUrl();
         parse_str(parse_url($url, PHP_URL_QUERY) ?: '', $query);
 
-        $this->assertNotEmpty($request->session()->get('nonce'));
-        $this->assertSame($request->session()->get('nonce'), $query['nonce'] ?? null);
+        $this->assertNotEmpty($request->session()->get('openidconnect_nonce'));
+        $this->assertSame($request->session()->get('openidconnect_nonce'), $query['nonce'] ?? null);
         $this->assertSame($request->session()->get('state'), $query['state'] ?? null);
     }
 }

--- a/tests/OpenIDConnect/PkceTest.php
+++ b/tests/OpenIDConnect/PkceTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect;
+
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Regression cover for the provider declaring its PKCE flag under a property
+ * name Socialite does not read, which silently downgraded the flow to a plain
+ * authorization code exchange.
+ */
+class PkceTest extends TestCase
+{
+    #[Test]
+    public function pkce_is_enabled(): void
+    {
+        $this->assertTrue($this->oidcProvider()->callUsesPKCE());
+    }
+
+    #[Test]
+    public function authorize_request_carries_a_code_challenge(): void
+    {
+        $request = $this->request();
+        $provider = $this->oidcProvider(request: $request);
+
+        $url = $provider->redirect()->getTargetUrl();
+        parse_str(parse_url($url, PHP_URL_QUERY) ?: '', $query);
+
+        $this->assertArrayHasKey('code_challenge', $query);
+        $this->assertSame('S256', $query['code_challenge_method'] ?? null);
+        $this->assertNotEmpty($query['code_challenge']);
+    }
+
+    #[Test]
+    public function code_verifier_is_stored_in_the_session_and_matches_the_challenge(): void
+    {
+        $request = $this->request();
+        $provider = $this->oidcProvider(request: $request);
+
+        $url = $provider->redirect()->getTargetUrl();
+        parse_str(parse_url($url, PHP_URL_QUERY) ?: '', $query);
+
+        $verifier = $request->session()->get('code_verifier');
+
+        $this->assertNotEmpty($verifier);
+        $this->assertSame(
+            $this->base64UrlEncode(hash('sha256', $verifier, true)),
+            $query['code_challenge']
+        );
+    }
+
+    #[Test]
+    public function nonce_and_state_are_also_issued(): void
+    {
+        $request = $this->request();
+        $provider = $this->oidcProvider(request: $request);
+
+        $url = $provider->redirect()->getTargetUrl();
+        parse_str(parse_url($url, PHP_URL_QUERY) ?: '', $query);
+
+        $this->assertNotEmpty($request->session()->get('nonce'));
+        $this->assertSame($request->session()->get('nonce'), $query['nonce'] ?? null);
+        $this->assertSame($request->session()->get('state'), $query['state'] ?? null);
+    }
+}

--- a/tests/OpenIDConnect/ProviderStub.php
+++ b/tests/OpenIDConnect/ProviderStub.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect;
+
+use GuzzleHttp\Client;
+use SocialiteProviders\OpenIDConnect\Provider;
+
+/**
+ * Exposes the provider's protected surface so behaviour can be asserted
+ * without driving a full HTTP round trip.
+ */
+class ProviderStub extends Provider
+{
+    public function callUsesPKCE(): bool
+    {
+        return $this->usesPKCE();
+    }
+
+    public function callGetCodeFields($state = null): array
+    {
+        return $this->getCodeFields($state);
+    }
+
+    /**
+     * Mirrors how decodeJWT() sources the algorithm: straight off the token
+     * header, exactly as an attacker would supply it.
+     */
+    public function callVerifyFromToken(string $jwt)
+    {
+        $alg = $this->decodeJwtHeader($jwt)->alg ?? null;
+
+        return $this->verifyAndDecodeJWT($jwt, $alg);
+    }
+
+    public function callDecodeJWT(string $jwt, ?string $accessToken = null)
+    {
+        return $this->decodeJWT($jwt, $accessToken);
+    }
+
+    public function callAllowedSigningAlgorithms(): array
+    {
+        return $this->getAllowedSigningAlgorithms();
+    }
+
+    public function callResolveTokenAuthMethod(): string
+    {
+        return $this->resolveTokenAuthMethod();
+    }
+
+    public function callGetBaseUrl(): string
+    {
+        return $this->getBaseUrl();
+    }
+
+    public function callUsesNonce(): bool
+    {
+        return $this->usesNonce();
+    }
+
+    /**
+     * getHttpClient() builds its own client, so tests inject one here.
+     */
+    public function useHttpClient(Client $client): static
+    {
+        $this->httpClient = $client;
+
+        return $this;
+    }
+
+    public function callShouldVerifyJwt(): bool
+    {
+        return $this->shouldVerifyJwt();
+    }
+
+    public function callTokenRequestOptions(array $fields): array
+    {
+        return $this->tokenRequestOptions($fields);
+    }
+}

--- a/tests/OpenIDConnect/ProviderStub.php
+++ b/tests/OpenIDConnect/ProviderStub.php
@@ -76,4 +76,14 @@ class ProviderStub extends Provider
     {
         return $this->tokenRequestOptions($fields);
     }
+
+    public function callGetCacheTtl(): int
+    {
+        return $this->getCacheTtl();
+    }
+
+    public function callLogoutTokenReplayTtl($expiresAt = null): int
+    {
+        return $this->logoutTokenReplayTtl($expiresAt);
+    }
 }

--- a/tests/OpenIDConnect/RevokeTest.php
+++ b/tests/OpenIDConnect/RevokeTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Request as PsrRequest;
+use GuzzleHttp\Psr7\Response;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+
+class RevokeTest extends TestCase
+{
+    /**
+     * @param  array<int, Response|\Throwable>  $responses
+     */
+    private function providerReturning(array $responses, array $discovery = []): ProviderStub
+    {
+        $provider = $this->oidcProvider(discovery: $this->discoveryDocument($discovery));
+
+        $stack = HandlerStack::create(new MockHandler($responses));
+
+        return $provider->useHttpClient(new Client(['handler' => $stack]));
+    }
+
+    #[Test]
+    public function a_200_is_a_successful_revocation(): void
+    {
+        $this->assertTrue($this->providerReturning([new Response(200)])->revoke('a-token'));
+    }
+
+    #[Test]
+    public function a_204_is_a_successful_revocation(): void
+    {
+        $this->assertTrue($this->providerReturning([new Response(204)])->revoke('a-token'));
+    }
+
+    #[Test]
+    public function a_400_returns_false_rather_than_throwing(): void
+    {
+        // The already-revoked case on a non-conforming IdP. Previously this
+        // threw a ClientException straight out of the logout controller.
+        $response = new Response(400, [], json_encode(['error' => 'invalid_token']));
+
+        $this->assertFalse($this->providerReturning([$response])->revoke('a-token'));
+    }
+
+    #[Test]
+    public function a_401_returns_false_rather_than_throwing(): void
+    {
+        $this->assertFalse($this->providerReturning([new Response(401)])->revoke('a-token'));
+    }
+
+    #[Test]
+    public function a_500_returns_false_rather_than_throwing(): void
+    {
+        $this->assertFalse($this->providerReturning([new Response(500)])->revoke('a-token'));
+    }
+
+    #[Test]
+    public function a_transport_failure_still_throws(): void
+    {
+        // Deliberately not swallowed: an unreachable IdP is a real failure,
+        // and the README shows callers wrapping this.
+        $provider = $this->providerReturning([
+            new ConnectException('Connection refused', new PsrRequest('POST', '/revoke')),
+        ]);
+
+        $this->expectException(ConnectException::class);
+
+        $provider->revoke('a-token');
+    }
+
+    #[Test]
+    public function a_provider_without_a_revocation_endpoint_is_reported(): void
+    {
+        $provider = $this->oidcProvider(discovery: array_diff_key(
+            $this->discoveryDocument(),
+            ['revocation_endpoint' => null]
+        ));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('does not advertise a revocation_endpoint');
+
+        $provider->revoke('a-token');
+    }
+
+    #[Test]
+    public function the_token_and_hint_are_sent_in_the_request_body(): void
+    {
+        $sent = [];
+        $stack = HandlerStack::create(new MockHandler([new Response(200)]));
+        $stack->push(Middleware::history($sent));
+
+        $provider = $this->oidcProvider()->useHttpClient(new Client(['handler' => $stack]));
+
+        $provider->revoke('the-refresh-token', 'refresh_token');
+
+        parse_str((string) $sent[0]['request']->getBody(), $body);
+
+        $this->assertSame('the-refresh-token', $body['token']);
+        $this->assertSame('refresh_token', $body['token_type_hint']);
+    }
+
+    #[Test]
+    public function the_hint_defaults_to_refresh_token(): void
+    {
+        $sent = [];
+        $stack = HandlerStack::create(new MockHandler([new Response(200)]));
+        $stack->push(Middleware::history($sent));
+
+        $provider = $this->oidcProvider()->useHttpClient(new Client(['handler' => $stack]));
+
+        $provider->revoke('a-token');
+
+        parse_str((string) $sent[0]['request']->getBody(), $body);
+
+        $this->assertSame('refresh_token', $body['token_type_hint']);
+    }
+}

--- a/tests/OpenIDConnect/ScopesTest.php
+++ b/tests/OpenIDConnect/ScopesTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect;
+
+use PHPUnit\Framework\Attributes\Test;
+
+class ScopesTest extends TestCase
+{
+    #[Test]
+    public function the_defaults_are_used_when_nothing_is_configured(): void
+    {
+        $this->assertSame(['openid', 'email', 'profile'], $this->oidcProvider()->getScopes());
+    }
+
+    #[Test]
+    public function a_configured_scope_is_never_repeated(): void
+    {
+        // Previously produced "openid email profile openid email offline_access",
+        // which Azure AD B2C rejects and which is malformed regardless.
+        $scopes = $this->oidcProvider(['scopes' => 'openid email offline_access'])->getScopes();
+
+        $this->assertSame(['openid', 'email', 'offline_access'], $scopes);
+        $this->assertSame(array_unique($scopes), $scopes);
+    }
+
+    #[Test]
+    public function a_configured_list_replaces_the_defaults(): void
+    {
+        // The narrowing case: an OP that does not support `profile`.
+        $this->assertSame(['openid', 'email'], $this->oidcProvider(['scopes' => 'email'])->getScopes());
+    }
+
+    #[Test]
+    public function openid_is_always_present(): void
+    {
+        $this->assertContains('openid', $this->oidcProvider(['scopes' => 'email'])->getScopes());
+        $this->assertSame('openid', $this->oidcProvider(['scopes' => 'groups'])->getScopes()[0]);
+    }
+
+    #[Test]
+    public function a_scope_string_may_be_separated_by_commas_or_extra_whitespace(): void
+    {
+        $expected = ['openid', 'email', 'offline_access'];
+
+        $this->assertSame($expected, $this->oidcProvider(['scopes' => 'email,offline_access'])->getScopes());
+        $this->assertSame($expected, $this->oidcProvider(['scopes' => "email,  offline_access\n"])->getScopes());
+        $this->assertSame($expected, $this->oidcProvider(['scopes' => ' email   offline_access '])->getScopes());
+    }
+
+    #[Test]
+    public function a_scope_array_is_accepted(): void
+    {
+        $this->assertSame(
+            ['openid', 'email', 'offline_access'],
+            $this->oidcProvider(['scopes' => ['email', 'offline_access']])->getScopes()
+        );
+    }
+
+    #[Test]
+    public function fluent_scopes_are_preserved_alongside_a_configured_list(): void
+    {
+        $provider = $this->oidcProvider(['scopes' => 'email']);
+        $provider->scopes(['groups']);
+
+        $this->assertSame(['openid', 'email', 'groups'], $provider->getScopes());
+    }
+
+    #[Test]
+    public function fluent_scopes_work_without_any_configured_list(): void
+    {
+        $provider = $this->oidcProvider();
+        $provider->scopes(['groups']);
+
+        $this->assertSame(['openid', 'email', 'profile', 'groups'], $provider->getScopes());
+    }
+
+    #[Test]
+    public function the_authorize_request_carries_the_resolved_scope_string(): void
+    {
+        $request = $this->request();
+        $provider = $this->oidcProvider(['scopes' => 'openid email offline_access'], $request);
+
+        $url = $provider->redirect()->getTargetUrl();
+        parse_str(parse_url($url, PHP_URL_QUERY) ?: '', $query);
+
+        $this->assertSame('openid email offline_access', $query['scope']);
+    }
+}

--- a/tests/OpenIDConnect/StatelessTest.php
+++ b/tests/OpenIDConnect/StatelessTest.php
@@ -39,7 +39,7 @@ class StatelessTest extends TestCase
         $url = $provider->redirect()->getTargetUrl();
         parse_str(parse_url($url, PHP_URL_QUERY) ?: '', $query);
 
-        $this->assertNull($request->session()->get('nonce'));
+        $this->assertNull($request->session()->get('openidconnect_nonce'));
         $this->assertArrayNotHasKey('nonce', $query);
         $this->assertArrayNotHasKey('state', $query);
     }

--- a/tests/OpenIDConnect/StatelessTest.php
+++ b/tests/OpenIDConnect/StatelessTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect;
+
+use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * A nonce is carried in the session between the redirect and the callback, so
+ * it cannot survive a stateless (API/SPA) flow.
+ */
+class StatelessTest extends TestCase
+{
+    #[Test]
+    public function the_nonce_is_disabled_in_stateless_mode(): void
+    {
+        $provider = $this->oidcProvider();
+        $provider->stateless();
+
+        $this->assertFalse($provider->callUsesNonce());
+    }
+
+    #[Test]
+    public function the_authorize_request_omits_the_nonce_in_stateless_mode(): void
+    {
+        $provider = $this->oidcProvider();
+        $provider->stateless();
+
+        $this->assertArrayNotHasKey('nonce', $provider->callGetCodeFields('state'));
+    }
+
+    #[Test]
+    public function the_redirect_writes_no_nonce_to_the_session_in_stateless_mode(): void
+    {
+        $request = $this->request();
+        $provider = $this->oidcProvider(request: $request);
+        $provider->stateless();
+
+        $url = $provider->redirect()->getTargetUrl();
+        parse_str(parse_url($url, PHP_URL_QUERY) ?: '', $query);
+
+        $this->assertNull($request->session()->get('nonce'));
+        $this->assertArrayNotHasKey('nonce', $query);
+        $this->assertArrayNotHasKey('state', $query);
+    }
+
+    #[Test]
+    public function a_token_without_a_nonce_is_accepted_in_stateless_mode(): void
+    {
+        $this->seedJwks();
+
+        $provider = $this->oidcProvider();
+        $provider->stateless();
+
+        // No session nonce exists to compare against, so requiring one would
+        // make every stateless login fail.
+        $payload = $provider->callDecodeJWT($this->idToken(['sub' => 'alice']));
+
+        $this->assertSame('alice', $payload->sub);
+    }
+
+    #[Test]
+    public function the_nonce_still_applies_to_the_normal_session_flow(): void
+    {
+        $provider = $this->oidcProvider();
+
+        $this->assertTrue($provider->callUsesNonce());
+        $this->assertArrayHasKey('nonce', $provider->callGetCodeFields('state'));
+    }
+
+    #[Test]
+    public function the_nonce_can_be_disabled_explicitly(): void
+    {
+        $this->assertFalse($this->oidcProvider(['use_nonce' => false])->callUsesNonce());
+        $this->assertFalse($this->oidcProvider(['use_nonce' => 'false'])->callUsesNonce());
+        $this->assertTrue($this->oidcProvider(['use_nonce' => true])->callUsesNonce());
+    }
+
+    #[Test]
+    public function the_nonce_can_be_disabled_via_the_fluent_setter(): void
+    {
+        $provider = $this->oidcProvider();
+
+        $this->assertSame($provider, $provider->withoutNonce());
+        $this->assertFalse($provider->callUsesNonce());
+    }
+
+    #[Test]
+    public function a_session_less_redirect_reports_the_pkce_requirement_clearly(): void
+    {
+        // Request::create() leaves no session store on the request at all.
+        // Socialite's PKCE support needs one, so the useful behaviour is a
+        // clear error rather than an opaque "Session store not set on request."
+        $provider = $this->oidcProvider(request: Request::create(self::REDIRECT, 'GET'));
+        $provider->stateless();
+
+        $this->expectExceptionMessage('PKCE requires a session');
+
+        $provider->redirect();
+    }
+
+    #[Test]
+    public function a_stateless_redirect_works_without_a_session_once_pkce_is_disabled(): void
+    {
+        $provider = $this->oidcProvider(request: Request::create(self::REDIRECT, 'GET'));
+        $provider->stateless()->withoutPKCE();
+
+        $url = $provider->redirect()->getTargetUrl();
+        parse_str(parse_url($url, PHP_URL_QUERY) ?: '', $query);
+
+        $this->assertStringStartsWith(self::BASE_URL.'/authorize', $url);
+        $this->assertArrayNotHasKey('nonce', $query);
+        $this->assertArrayNotHasKey('state', $query);
+        $this->assertArrayNotHasKey('code_challenge', $query);
+    }
+
+    #[Test]
+    public function a_stateful_flow_without_a_session_still_fails_on_the_state(): void
+    {
+        // Not stateless, so the `state` write comes first and Socialite's own
+        // error stands: a stateful flow genuinely cannot work without a
+        // session, and the PKCE guard is not what should be reported.
+        $provider = $this->oidcProvider(request: Request::create(self::REDIRECT, 'GET'));
+
+        $this->expectExceptionMessage('Session store not set on request.');
+
+        $provider->redirect();
+    }
+}

--- a/tests/OpenIDConnect/TestCase.php
+++ b/tests/OpenIDConnect/TestCase.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect;
+
+use ArrayAccess;
+use Firebase\JWT\JWT;
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Repository;
+use Illuminate\Http\Request;
+use Illuminate\Session\ArraySessionHandler;
+use Illuminate\Session\Store;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Facade;
+use SocialiteProviders\Manager\Config;
+use SocialiteProviders\Tests\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    protected const BASE_URL = 'https://idp.test';
+
+    protected const CLIENT_ID = 'client-id';
+
+    protected const CLIENT_SECRET = 'client-secret';
+
+    protected const REDIRECT = 'https://app.test/callback';
+
+    protected const KID = 'test-key-1';
+
+    /**
+     * Generating an RSA keypair is expensive, so share one across the suite.
+     *
+     * @var array{private: string, public: string}|null
+     */
+    private static ?array $keypair = null;
+
+    protected string $privateKey;
+
+    protected string $publicKey;
+
+    protected function provider(): string
+    {
+        return ProviderStub::class;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->bootCacheFacade();
+
+        if (self::$keypair === null) {
+            $resource = openssl_pkey_new([
+                'private_key_bits' => 2048,
+                'private_key_type' => OPENSSL_KEYTYPE_RSA,
+            ]);
+
+            openssl_pkey_export($resource, $private);
+
+            self::$keypair = [
+                'private' => $private,
+                'public'  => openssl_pkey_get_details($resource)['key'],
+            ];
+        }
+
+        $this->privateKey = self::$keypair['private'];
+        $this->publicKey = self::$keypair['public'];
+    }
+
+    protected function tearDown(): void
+    {
+        Facade::clearResolvedInstances();
+        Facade::setFacadeApplication(null);
+
+        parent::tearDown();
+    }
+
+    /**
+     * The provider reaches for the Cache facade (discovery, JWKS, logout token
+     * replay). Rather than boot a framework for it, back the facade with an
+     * array store held in a throwaway container, fresh for every test.
+     */
+    private function bootCacheFacade(): void
+    {
+        $container = new class(['cache' => new Repository(new ArrayStore)]) implements ArrayAccess
+        {
+            public function __construct(private array $bindings) {}
+
+            public function offsetExists(mixed $offset): bool
+            {
+                return isset($this->bindings[$offset]);
+            }
+
+            public function offsetGet(mixed $offset): mixed
+            {
+                return $this->bindings[$offset] ?? null;
+            }
+
+            public function offsetSet(mixed $offset, mixed $value): void
+            {
+                $this->bindings[$offset] = $value;
+            }
+
+            public function offsetUnset(mixed $offset): void
+            {
+                unset($this->bindings[$offset]);
+            }
+        };
+
+        Facade::clearResolvedInstances();
+        Facade::setFacadeApplication($container);
+    }
+
+    /**
+     * A minimal discovery document. `configurations` is public on the provider,
+     * so seeding it avoids any HTTP round trip.
+     */
+    protected function discoveryDocument(array $overrides = []): array
+    {
+        return array_merge([
+            'issuer'                                => self::BASE_URL,
+            'authorization_endpoint'                => self::BASE_URL.'/authorize',
+            'token_endpoint'                        => self::BASE_URL.'/token',
+            'userinfo_endpoint'                     => self::BASE_URL.'/userinfo',
+            'jwks_uri'                              => self::BASE_URL.'/jwks',
+            'end_session_endpoint'                  => self::BASE_URL.'/logout',
+            'revocation_endpoint'                   => self::BASE_URL.'/revoke',
+            'id_token_signing_alg_values_supported' => ['RS256'],
+        ], $overrides);
+    }
+
+    protected function request(array $query = [], array $session = []): Request
+    {
+        $request = Request::create(self::REDIRECT, 'GET', $query);
+
+        $store = new Store('test-session', new ArraySessionHandler(60));
+        foreach ($session as $key => $value) {
+            $store->put($key, $value);
+        }
+
+        $request->setLaravelSession($store);
+
+        return $request;
+    }
+
+    protected function oidcProvider(array $config = [], ?Request $request = null, ?array $discovery = null): ProviderStub
+    {
+        $config = array_merge([
+            'base_url'   => self::BASE_URL,
+            'verify_jwt' => true,
+        ], $config);
+
+        $class = $this->provider();
+
+        $provider = new $class(
+            $request ?? $this->request(),
+            self::CLIENT_ID,
+            self::CLIENT_SECRET,
+            self::REDIRECT
+        );
+
+        $provider->setConfig(new Config(self::CLIENT_ID, self::CLIENT_SECRET, self::REDIRECT, $config));
+        $provider->configurations = $discovery ?? $this->discoveryDocument();
+
+        return $provider;
+    }
+
+    /**
+     * Seed the JWKS cache so the JWKS verification path needs no HTTP.
+     */
+    protected function seedJwks(?array $jwks = null): void
+    {
+        Cache::put('openidconnect_jwks_'.md5(self::BASE_URL), $jwks ?? $this->jwks(), 3600);
+    }
+
+    protected function jwks(): array
+    {
+        $details = openssl_pkey_get_details(openssl_pkey_get_public($this->publicKey));
+
+        return [
+            'keys' => [
+                [
+                    'kty' => 'RSA',
+                    'alg' => 'RS256',
+                    'use' => 'sig',
+                    'kid' => self::KID,
+                    'n'   => $this->base64UrlEncode($details['rsa']['n']),
+                    'e'   => $this->base64UrlEncode($details['rsa']['e']),
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Mint a legitimately signed id_token.
+     */
+    protected function idToken(array $claims = [], string $alg = 'RS256', mixed $key = null): string
+    {
+        return JWT::encode(
+            $this->claims($claims),
+            $key ?? $this->privateKey,
+            $alg,
+            self::KID
+        );
+    }
+
+    protected function claims(array $overrides = []): array
+    {
+        return array_merge([
+            'iss'   => self::BASE_URL,
+            'aud'   => self::CLIENT_ID,
+            'sub'   => 'user-1',
+            'email' => 'user@example.test',
+            'iat'   => time(),
+            'exp'   => time() + 3600,
+        ], $overrides);
+    }
+
+    protected function base64UrlEncode(string $data): string
+    {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+}

--- a/tests/OpenIDConnect/TimeClaimsTest.php
+++ b/tests/OpenIDConnect/TimeClaimsTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect;
+
+use Firebase\JWT\JWT;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * exp is required, not optional. php-jwt gates its own exp check on isset(),
+ * so a token that omits the claim is otherwise valid forever on both the
+ * verified and unverified paths.
+ */
+class TimeClaimsTest extends TestCase
+{
+    private const NONCE = 'test-nonce-value';
+
+    /**
+     * claims() always supplies exp/iat, so build the payload by hand here.
+     */
+    private function tokenWithout(array $drop, array $extra = []): string
+    {
+        $claims = array_merge([
+            'iss'   => self::BASE_URL,
+            'aud'   => self::CLIENT_ID,
+            'sub'   => 'user-1',
+            'email' => 'user@example.test',
+            'nonce' => self::NONCE,
+            'iat'   => time(),
+            'exp'   => time() + 3600,
+        ], $extra);
+
+        foreach ($drop as $claim) {
+            unset($claims[$claim]);
+        }
+
+        return JWT::encode($claims, $this->privateKey, 'RS256', self::KID);
+    }
+
+    #[Test]
+    public function an_id_token_without_exp_is_rejected_on_the_verified_path(): void
+    {
+        $this->seedJwks();
+
+        $provider = $this->oidcProvider([], $this->request(session: ['nonce' => self::NONCE]));
+
+        $this->expectExceptionMessage('Missing required exp');
+
+        $provider->callDecodeJWT($this->tokenWithout(['exp']));
+    }
+
+    #[Test]
+    public function an_id_token_without_exp_is_rejected_on_the_unverified_path(): void
+    {
+        // The replay case: with verification off there is nothing else
+        // bounding the token's lifetime.
+        $provider = $this->oidcProvider(
+            ['verify_jwt' => false],
+            $this->request(session: ['nonce' => self::NONCE])
+        );
+
+        $this->expectExceptionMessage('Missing required exp');
+
+        $provider->callDecodeJWT($this->tokenWithout(['exp']));
+    }
+
+    #[Test]
+    public function a_non_numeric_exp_is_rejected(): void
+    {
+        $provider = $this->oidcProvider(
+            ['verify_jwt' => false],
+            $this->request(session: ['nonce' => self::NONCE])
+        );
+
+        // JWT::encode() rejects a non-numeric exp itself, so this token has to
+        // be assembled by hand -- which is exactly what an attacker would do.
+        $header = $this->base64UrlEncode(json_encode(['alg' => 'RS256', 'typ' => 'JWT']));
+        $body = $this->base64UrlEncode(json_encode([
+            'iss'   => self::BASE_URL,
+            'aud'   => self::CLIENT_ID,
+            'sub'   => 'user-1',
+            'email' => 'user@example.test',
+            'nonce' => self::NONCE,
+            'exp'   => 'not-a-timestamp',
+        ]));
+
+        $this->expectExceptionMessage('Missing required exp');
+
+        $provider->callDecodeJWT($header.'.'.$body.'.unchecked');
+    }
+
+    #[Test]
+    public function an_id_token_with_exp_is_still_accepted(): void
+    {
+        $this->seedJwks();
+
+        $provider = $this->oidcProvider([], $this->request(session: ['nonce' => self::NONCE]));
+
+        $this->assertSame('user-1', $provider->callDecodeJWT($this->tokenWithout([]))->sub);
+    }
+
+    #[Test]
+    public function an_id_token_without_iat_is_still_accepted(): void
+    {
+        // Only the logout token requires iat; leaving the id_token unchanged
+        // here keeps this fix to what the spec actually mandates.
+        $this->seedJwks();
+
+        $provider = $this->oidcProvider([], $this->request(session: ['nonce' => self::NONCE]));
+
+        $this->assertSame('user-1', $provider->callDecodeJWT($this->tokenWithout(['iat']))->sub);
+    }
+
+    #[Test]
+    public function a_logout_token_without_exp_is_rejected(): void
+    {
+        $this->seedJwks();
+
+        $this->expectExceptionMessage('Missing required exp');
+
+        $this->oidcProvider()->verifyLogoutToken($this->logoutTokenWithout(['exp']));
+    }
+
+    #[Test]
+    public function a_logout_token_without_iat_is_rejected(): void
+    {
+        $this->seedJwks();
+
+        $this->expectExceptionMessage('Missing required iat');
+
+        $this->oidcProvider()->verifyLogoutToken($this->logoutTokenWithout(['iat']));
+    }
+
+    #[Test]
+    public function a_complete_logout_token_is_still_accepted(): void
+    {
+        $this->seedJwks();
+
+        $payload = $this->oidcProvider()->verifyLogoutToken($this->logoutTokenWithout([]));
+
+        $this->assertSame('user-1', $payload['sub']);
+    }
+
+    private function logoutTokenWithout(array $drop): string
+    {
+        $claims = [
+            'iss'    => self::BASE_URL,
+            'aud'    => self::CLIENT_ID,
+            'sub'    => 'user-1',
+            'sid'    => 'session-1',
+            'iat'    => time(),
+            'exp'    => time() + 300,
+            'jti'    => 'unique-token-id',
+            'events' => ['http://schemas.openid.net/event/backchannel-logout' => new \stdClass],
+        ];
+
+        foreach ($drop as $claim) {
+            unset($claims[$claim]);
+        }
+
+        return JWT::encode($claims, $this->privateKey, 'RS256', self::KID);
+    }
+}

--- a/tests/OpenIDConnect/TimeClaimsTest.php
+++ b/tests/OpenIDConnect/TimeClaimsTest.php
@@ -41,7 +41,7 @@ class TimeClaimsTest extends TestCase
     {
         $this->seedJwks();
 
-        $provider = $this->oidcProvider([], $this->request(session: ['nonce' => self::NONCE]));
+        $provider = $this->oidcProvider([], $this->request(session: ['openidconnect_nonce' => self::NONCE]));
 
         $this->expectExceptionMessage('Missing required exp');
 
@@ -55,7 +55,7 @@ class TimeClaimsTest extends TestCase
         // bounding the token's lifetime.
         $provider = $this->oidcProvider(
             ['verify_jwt' => false],
-            $this->request(session: ['nonce' => self::NONCE])
+            $this->request(session: ['openidconnect_nonce' => self::NONCE])
         );
 
         $this->expectExceptionMessage('Missing required exp');
@@ -68,7 +68,7 @@ class TimeClaimsTest extends TestCase
     {
         $provider = $this->oidcProvider(
             ['verify_jwt' => false],
-            $this->request(session: ['nonce' => self::NONCE])
+            $this->request(session: ['openidconnect_nonce' => self::NONCE])
         );
 
         // JWT::encode() rejects a non-numeric exp itself, so this token has to
@@ -93,7 +93,7 @@ class TimeClaimsTest extends TestCase
     {
         $this->seedJwks();
 
-        $provider = $this->oidcProvider([], $this->request(session: ['nonce' => self::NONCE]));
+        $provider = $this->oidcProvider([], $this->request(session: ['openidconnect_nonce' => self::NONCE]));
 
         $this->assertSame('user-1', $provider->callDecodeJWT($this->tokenWithout([]))->sub);
     }
@@ -105,7 +105,7 @@ class TimeClaimsTest extends TestCase
         // here keeps this fix to what the spec actually mandates.
         $this->seedJwks();
 
-        $provider = $this->oidcProvider([], $this->request(session: ['nonce' => self::NONCE]));
+        $provider = $this->oidcProvider([], $this->request(session: ['openidconnect_nonce' => self::NONCE]));
 
         $this->assertSame('user-1', $provider->callDecodeJWT($this->tokenWithout(['iat']))->sub);
     }

--- a/tests/OpenIDConnect/TokenAuthMethodTest.php
+++ b/tests/OpenIDConnect/TokenAuthMethodTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect;
+
+use GuzzleHttp\RequestOptions;
+use PHPUnit\Framework\Attributes\Test;
+
+class TokenAuthMethodTest extends TestCase
+{
+    #[Test]
+    public function an_explicitly_configured_method_wins(): void
+    {
+        $provider = $this->oidcProvider(
+            ['token_auth_method' => 'client_secret_post'],
+            discovery: $this->discoveryDocument([
+                'token_endpoint_auth_methods_supported' => ['client_secret_basic'],
+            ])
+        );
+
+        $this->assertSame('client_secret_post', $provider->callResolveTokenAuthMethod());
+    }
+
+    #[Test]
+    public function basic_is_preferred_when_the_op_advertises_it(): void
+    {
+        $provider = $this->oidcProvider(discovery: $this->discoveryDocument([
+            'token_endpoint_auth_methods_supported' => ['client_secret_post', 'client_secret_basic'],
+        ]));
+
+        $this->assertSame('client_secret_basic', $provider->callResolveTokenAuthMethod());
+    }
+
+    #[Test]
+    public function post_is_used_when_basic_is_not_advertised(): void
+    {
+        $provider = $this->oidcProvider(discovery: $this->discoveryDocument([
+            'token_endpoint_auth_methods_supported' => ['client_secret_post'],
+        ]));
+
+        $this->assertSame('client_secret_post', $provider->callResolveTokenAuthMethod());
+    }
+
+    #[Test]
+    public function post_is_the_fallback_when_discovery_says_nothing(): void
+    {
+        $this->assertSame('client_secret_post', $this->oidcProvider()->callResolveTokenAuthMethod());
+    }
+
+    #[Test]
+    public function basic_moves_the_credentials_out_of_the_form_body(): void
+    {
+        $provider = $this->oidcProvider(['token_auth_method' => 'client_secret_basic']);
+
+        $options = $provider->callTokenRequestOptions([
+            'client_id'     => self::CLIENT_ID,
+            'client_secret' => self::CLIENT_SECRET,
+            'code'          => 'the-code',
+        ]);
+
+        // Sent as a hand-built header rather than Guzzle's `auth` option; the
+        // encoding itself is covered by ClientSecretBasicTest.
+        $this->assertSame(
+            'Basic '.base64_encode(urlencode(self::CLIENT_ID).':'.urlencode(self::CLIENT_SECRET)),
+            $options[RequestOptions::HEADERS]['Authorization']
+        );
+        $this->assertArrayNotHasKey('client_id', $options[RequestOptions::FORM_PARAMS]);
+        $this->assertArrayNotHasKey('client_secret', $options[RequestOptions::FORM_PARAMS]);
+        $this->assertSame('the-code', $options[RequestOptions::FORM_PARAMS]['code']);
+    }
+
+    #[Test]
+    public function post_keeps_the_credentials_in_the_form_body(): void
+    {
+        $provider = $this->oidcProvider(['token_auth_method' => 'client_secret_post']);
+
+        $options = $provider->callTokenRequestOptions([
+            'client_id'     => self::CLIENT_ID,
+            'client_secret' => self::CLIENT_SECRET,
+            'code'          => 'the-code',
+        ]);
+
+        $this->assertArrayNotHasKey(RequestOptions::AUTH, $options);
+        $this->assertSame(self::CLIENT_ID, $options[RequestOptions::FORM_PARAMS]['client_id']);
+        $this->assertSame(self::CLIENT_SECRET, $options[RequestOptions::FORM_PARAMS]['client_secret']);
+    }
+}

--- a/tests/OpenIDConnect/UserRetrievalTest.php
+++ b/tests/OpenIDConnect/UserRetrievalTest.php
@@ -1,0 +1,289 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The token endpoint response is only loosely specified: expires_in is
+ * optional (RFC 6749 4.2.2), access_token need not accompany an id_token, and
+ * some IdPs report failure with a 200 and an error body.
+ */
+class UserRetrievalTest extends TestCase
+{
+    /**
+     * @param  array<int, Response>  $responses
+     */
+    private function providerReturning(array $responses, array $config = []): ProviderStub
+    {
+        $this->seedJwks();
+
+        $provider = $this->oidcProvider(
+            $config,
+            $this->request(['code' => 'the-auth-code', 'state' => 's'])
+        );
+
+        // Stateless keeps the callback focused on the token response rather
+        // than on state/nonce plumbing.
+        $provider->stateless();
+
+        $stack = HandlerStack::create(new MockHandler($responses));
+
+        return $provider->useHttpClient(new Client(['handler' => $stack]));
+    }
+
+    private function tokenResponse(array $body): Response
+    {
+        return new Response(200, ['Content-Type' => 'application/json'], json_encode($body));
+    }
+
+    #[Test]
+    public function a_response_without_expires_in_is_handled(): void
+    {
+        $provider = $this->providerReturning([
+            $this->tokenResponse([
+                'id_token'     => $this->idToken(),
+                'access_token' => 'the-access-token',
+                // no expires_in
+            ]),
+        ]);
+
+        $user = $provider->user();
+
+        $this->assertSame('user-1', $user->getId());
+        $this->assertSame('the-access-token', $user->token);
+        $this->assertNull($user->expiresIn);
+    }
+
+    #[Test]
+    public function a_response_with_only_an_id_token_is_handled(): void
+    {
+        $provider = $this->providerReturning([
+            $this->tokenResponse(['id_token' => $this->idToken()]),
+        ]);
+
+        $user = $provider->user();
+
+        $this->assertSame('user-1', $user->getId());
+        $this->assertSame('user@example.test', $user->getEmail());
+        $this->assertNull($user->token);
+        $this->assertNull($user->refreshToken);
+    }
+
+    #[Test]
+    public function a_refresh_token_is_captured_when_present(): void
+    {
+        $provider = $this->providerReturning([
+            $this->tokenResponse([
+                'id_token'      => $this->idToken(),
+                'access_token'  => 'at',
+                'refresh_token' => 'rt',
+                'expires_in'    => 3600,
+            ]),
+        ]);
+
+        $user = $provider->user();
+
+        $this->assertSame('rt', $user->refreshToken);
+        $this->assertSame(3600, $user->expiresIn);
+    }
+
+    #[Test]
+    public function an_error_body_returned_with_a_200_is_reported(): void
+    {
+        $provider = $this->providerReturning([
+            $this->tokenResponse([
+                'error'             => 'invalid_grant',
+                'error_description' => 'Authorization code expired',
+            ]),
+        ]);
+
+        $this->expectExceptionMessage('Authorization code expired');
+
+        $provider->user();
+    }
+
+    #[Test]
+    public function an_error_body_without_a_description_still_reports_the_code(): void
+    {
+        $provider = $this->providerReturning([
+            $this->tokenResponse(['error' => 'invalid_client']),
+        ]);
+
+        $this->expectExceptionMessage('invalid_client');
+
+        $provider->user();
+    }
+
+    #[Test]
+    public function a_response_with_no_id_token_reports_that_clearly(): void
+    {
+        // Previously this indexed a missing key and then handed null to a
+        // string-typed parameter, surfacing as a TypeError.
+        $provider = $this->providerReturning([
+            $this->tokenResponse(['access_token' => 'at', 'token_type' => 'Bearer']),
+        ]);
+
+        $this->expectExceptionMessage('contained no id_token');
+
+        $provider->user();
+    }
+
+    #[Test]
+    public function a_non_json_response_body_is_reported(): void
+    {
+        $provider = $this->providerReturning([
+            new Response(200, ['Content-Type' => 'text/html'], '<html>gateway</html>'),
+        ]);
+
+        $this->expectException(\JsonException::class);
+
+        $provider->user();
+    }
+
+    #[Test]
+    public function userinfo_is_consulted_when_the_id_token_carries_no_email(): void
+    {
+        $provider = $this->providerReturning([
+            $this->tokenResponse([
+                'id_token'     => $this->idToken(['email' => null]),
+                'access_token' => 'the-access-token',
+            ]),
+            $this->tokenResponse(['sub' => 'user-1', 'email' => 'from-userinfo@example.test']),
+        ]);
+
+        $this->assertSame('from-userinfo@example.test', $provider->user()->getEmail());
+    }
+
+    #[Test]
+    public function a_user_without_an_email_is_allowed_by_default(): void
+    {
+        // email depends on the `email` scope being granted; OIDC Core 2 makes
+        // sub the only identifier an OP must return.
+        $provider = $this->providerReturning([
+            $this->tokenResponse(['id_token' => $this->idToken(['email' => null])]),
+        ]);
+
+        $user = $provider->user();
+
+        $this->assertSame('user-1', $user->getId());
+        $this->assertNull($user->getEmail());
+    }
+
+    #[Test]
+    public function a_missing_email_can_be_made_fatal(): void
+    {
+        $provider = $this->providerReturning(
+            [$this->tokenResponse(['id_token' => $this->idToken(['email' => null])])],
+            ['require_email' => true]
+        );
+
+        $this->expectExceptionMessage('User has no email');
+
+        $provider->user();
+    }
+
+    #[Test]
+    public function a_token_without_a_sub_is_rejected(): void
+    {
+        $provider = $this->providerReturning([
+            $this->tokenResponse(['id_token' => $this->idToken(['sub' => null])]),
+        ]);
+
+        $this->expectExceptionMessage('Missing required sub');
+
+        $provider->user();
+    }
+
+    #[Test]
+    public function a_userinfo_response_for_a_different_sub_is_rejected(): void
+    {
+        // OIDC Core 5.3.2: the sub must match the id_token exactly, or the
+        // response must not be used.
+        $provider = $this->providerReturning([
+            $this->tokenResponse(['id_token' => $this->idToken(['email' => null]), 'access_token' => 'at']),
+            $this->tokenResponse(['sub' => 'someone-else', 'email' => 'attacker@example.test']),
+        ]);
+
+        $this->expectExceptionMessage('sub does not match');
+
+        $provider->user();
+    }
+
+    #[Test]
+    public function userinfo_claims_are_merged_over_the_id_token_rather_than_replacing_it(): void
+    {
+        $provider = $this->providerReturning([
+            $this->tokenResponse([
+                'id_token'     => $this->idToken(['email' => null, 'groups' => ['admins']]),
+                'access_token' => 'at',
+            ]),
+            $this->tokenResponse(['sub' => 'user-1', 'email' => 'from-userinfo@example.test']),
+        ]);
+
+        $user = $provider->user();
+
+        $this->assertSame('from-userinfo@example.test', $user->getEmail());
+        // Carried by the id_token but absent from userinfo.
+        $this->assertSame(['admins'], $user->getRaw()['groups']);
+    }
+
+    #[Test]
+    public function the_full_token_response_is_exposed_on_the_user(): void
+    {
+        $idToken = $this->idToken();
+
+        $provider = $this->providerReturning([
+            $this->tokenResponse(['id_token' => $idToken, 'access_token' => 'at', 'expires_in' => 60]),
+        ]);
+
+        $body = $provider->user()->accessTokenResponseBody;
+
+        $this->assertSame($idToken, $body['id_token']);
+        $this->assertSame('at', $body['access_token']);
+        $this->assertSame(60, $body['expires_in']);
+    }
+
+    #[Test]
+    public function the_approved_scopes_are_exposed_on_the_user(): void
+    {
+        $provider = $this->providerReturning([
+            $this->tokenResponse([
+                'id_token'     => $this->idToken(),
+                'access_token' => 'at',
+                'scope'        => 'openid email offline_access',
+            ]),
+        ]);
+
+        $this->assertSame(['openid', 'email', 'offline_access'], $provider->user()->approvedScopes);
+    }
+
+    #[Test]
+    public function the_approved_scopes_default_to_empty_when_not_returned(): void
+    {
+        $provider = $this->providerReturning([
+            $this->tokenResponse(['id_token' => $this->idToken(), 'access_token' => 'at']),
+        ]);
+
+        $this->assertSame([], $provider->user()->approvedScopes);
+    }
+
+    #[Test]
+    public function the_raw_user_holds_only_the_claims(): void
+    {
+        // The id_token lives on accessTokenResponseBody, not folded into the
+        // claims, so the same value is not carried in two places.
+        $provider = $this->providerReturning([
+            $this->tokenResponse(['id_token' => $this->idToken(), 'access_token' => 'at']),
+        ]);
+
+        $raw = $provider->user()->getRaw();
+
+        $this->assertArrayNotHasKey('id_token', $raw);
+        $this->assertSame('user-1', $raw['sub']);
+    }
+}

--- a/tests/OpenIDConnect/VerificationDefaultsTest.php
+++ b/tests/OpenIDConnect/VerificationDefaultsTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect;
+
+use Firebase\JWT\JWT;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Signature verification defaults, and the transport precondition that the
+ * OIDC Core 3.1.3.7 step 6 exemption rests on.
+ */
+class VerificationDefaultsTest extends TestCase
+{
+    private function providerWithoutConfigKey(array $config = []): ProviderStub
+    {
+        // Deliberately omits 'verify_jwt' entirely, rather than passing null.
+        return $this->oidcProvider(array_merge(['verify_jwt' => null], $config));
+    }
+
+    #[Test]
+    public function verification_is_on_by_default(): void
+    {
+        $this->seedJwks();
+
+        $provider = $this->providerWithoutConfigKey();
+
+        $forged = JWT::encode($this->claims(['sub' => 'admin']), $this->publicKey, 'HS256', self::KID);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $provider->callVerifyFromToken($forged);
+    }
+
+    #[Test]
+    public function an_unsigned_payload_is_not_trusted_by_default(): void
+    {
+        $this->seedJwks();
+
+        $request = $this->request(session: ['nonce' => 'n']);
+        $provider = $this->oidcProvider(['verify_jwt' => null], $request);
+
+        // A token the IdP never signed, claiming elevated group membership.
+        $header = $this->base64UrlEncode(json_encode(['alg' => 'RS256', 'typ' => 'JWT', 'kid' => self::KID]));
+        $body = $this->base64UrlEncode(json_encode($this->claims([
+            'nonce'  => 'n',
+            'sub'    => 'admin',
+            'groups' => ['administrators'],
+        ])));
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $provider->callDecodeJWT($header.'.'.$body.'.not-a-real-signature');
+    }
+
+    #[Test]
+    public function verification_can_still_be_opted_out_of(): void
+    {
+        // Regression cover for ConfigTrait::getConfig() treating any falsy
+        // value as absent: reading via getConfig() would discard this false
+        // and fall back to the now-true default, stranding these operators.
+        $request = $this->request(session: ['nonce' => 'n']);
+        $provider = $this->oidcProvider(['verify_jwt' => false], $request);
+
+        $header = $this->base64UrlEncode(json_encode(['alg' => 'RS256', 'typ' => 'JWT']));
+        $body = $this->base64UrlEncode(json_encode($this->claims(['nonce' => 'n', 'sub' => 'alice'])));
+
+        $payload = $provider->callDecodeJWT($header.'.'.$body.'.unchecked');
+
+        $this->assertSame('alice', $payload->sub);
+    }
+
+    #[Test]
+    public function string_falsy_values_also_opt_out(): void
+    {
+        $request = $this->request(session: ['nonce' => 'n']);
+        $provider = $this->oidcProvider(['verify_jwt' => 'false'], $request);
+
+        $header = $this->base64UrlEncode(json_encode(['alg' => 'RS256', 'typ' => 'JWT']));
+        $body = $this->base64UrlEncode(json_encode($this->claims(['nonce' => 'n', 'sub' => 'alice'])));
+
+        $this->assertSame('alice', $provider->callDecodeJWT($header.'.'.$body.'.unchecked')->sub);
+    }
+
+    #[Test]
+    public function logout_tokens_are_verified_even_when_verification_is_opted_out_of(): void
+    {
+        $this->seedJwks();
+
+        $provider = $this->oidcProvider(['verify_jwt' => false]);
+
+        $header = $this->base64UrlEncode(json_encode(['alg' => 'RS256', 'typ' => 'JWT']));
+        $body = $this->base64UrlEncode(json_encode([
+            'iss'    => self::BASE_URL,
+            'aud'    => self::CLIENT_ID,
+            'sub'    => 'user-1',
+            'jti'    => 'x',
+            'iat'    => time(),
+            'events' => ['http://schemas.openid.net/event/backchannel-logout' => new \stdClass],
+        ]));
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $provider->verifyLogoutToken($header.'.'.$body.'.unchecked');
+    }
+
+    #[Test]
+    public function a_plaintext_base_url_is_rejected(): void
+    {
+        $provider = $this->oidcProvider(['base_url' => 'http://idp.test'], discovery: null);
+        $provider->configurations = null;
+
+        $this->expectExceptionMessage('must use https');
+
+        $provider->callAllowedSigningAlgorithms();
+    }
+
+    #[Test]
+    public function a_scheme_less_base_url_is_rejected(): void
+    {
+        $provider = $this->oidcProvider(['base_url' => 'idp.test']);
+        $provider->configurations = null;
+
+        $this->expectExceptionMessage('must use https');
+
+        $provider->callAllowedSigningAlgorithms();
+    }
+
+    #[Test]
+    public function loopback_hosts_may_use_plaintext(): void
+    {
+        foreach (['http://localhost:8080', 'http://127.0.0.1', 'http://app.localhost'] as $baseUrl) {
+            $provider = $this->oidcProvider(['base_url' => $baseUrl]);
+
+            $this->assertSame(rtrim($baseUrl, '/'), $provider->callGetBaseUrl());
+        }
+    }
+
+    #[Test]
+    public function an_https_base_url_is_accepted_and_normalised(): void
+    {
+        $provider = $this->oidcProvider(['base_url' => 'https://idp.test/']);
+
+        $this->assertSame('https://idp.test', $provider->callGetBaseUrl());
+    }
+}

--- a/tests/OpenIDConnect/VerificationDefaultsTest.php
+++ b/tests/OpenIDConnect/VerificationDefaultsTest.php
@@ -37,7 +37,7 @@ class VerificationDefaultsTest extends TestCase
     {
         $this->seedJwks();
 
-        $request = $this->request(session: ['nonce' => 'n']);
+        $request = $this->request(session: ['openidconnect_nonce' => 'n']);
         $provider = $this->oidcProvider(['verify_jwt' => null], $request);
 
         // A token the IdP never signed, claiming elevated group membership.
@@ -59,7 +59,7 @@ class VerificationDefaultsTest extends TestCase
         // Regression cover for ConfigTrait::getConfig() treating any falsy
         // value as absent: reading via getConfig() would discard this false
         // and fall back to the now-true default, stranding these operators.
-        $request = $this->request(session: ['nonce' => 'n']);
+        $request = $this->request(session: ['openidconnect_nonce' => 'n']);
         $provider = $this->oidcProvider(['verify_jwt' => false], $request);
 
         $header = $this->base64UrlEncode(json_encode(['alg' => 'RS256', 'typ' => 'JWT']));
@@ -73,7 +73,7 @@ class VerificationDefaultsTest extends TestCase
     #[Test]
     public function string_falsy_values_also_opt_out(): void
     {
-        $request = $this->request(session: ['nonce' => 'n']);
+        $request = $this->request(session: ['openidconnect_nonce' => 'n']);
         $provider = $this->oidcProvider(['verify_jwt' => 'false'], $request);
 
         $header = $this->base64UrlEncode(json_encode(['alg' => 'RS256', 'typ' => 'JWT']));


### PR DESCRIPTION
This adds an [OpenID Connect](https://openid.net/connect/) provider to make it easier to integrate a wide range of supported providers. It implements the [Authorization Code Flow ](https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth) with [PKCE](https://datatracker.ietf.org/doc/html/rfc7636) by default, [auto-discovery](https://openid.net/specs/openid-connect-discovery-1_0.html) via .well-known/openid-configuration (which is cached by default with configurable TTL), JWKS signature verification with kid-miss invalidation for real-time key rotation, configurable signing algorithms, and full spec-level validation of iss, aud, azp, at_hash, nonce, and exp/nbf/iat (with configurable clock-skew leeway) in both verified and unverified paths. 

I also provided convenient ways to handle logout() for [RP-Initiated Logout](https://openid.net/specs/openid-connect-rpinitiated-1_0.html), revoke() for [RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009) token revocation, and verifyLogoutToken() for [Back-Channel Logout 1.0](https://openid.net/specs/openid-connect-backchannel-1_0.html) with complete claim validation. 

The README documents setup, every config key, and working examples for session- and database-backed token storage plus a sid → Laravel session ID mapping table so we can individually clear the correct session.

Completes this stale closed issue: https://github.com/SocialiteProviders/Providers/issues/823