### PR TITLE
feat(saml2): support manual IdP Single Logout via "slo" config key

### DIFF
--- a/src/Saml2/Provider.php
+++ b/src/Saml2/Provider.php
@@ -149,6 +149,7 @@ class Provider extends AbstractProvider implements SocialiteProvider
             'metadata',
             'ttl',
             'acs',
+            'slo',
             'entityid',
             'certificate',
             'sp_acs',
@@ -270,6 +271,7 @@ class Provider extends AbstractProvider implements SocialiteProvider
     protected function getIdentityProviderEntityDescriptorManually(): EntityDescriptor
     {
         $acs = $this->getConfig('acs');
+        $slo = $this->getConfig('slo');
         $entityId = $this->getConfig('entityid');
         $certificate = $this->getConfig('certificate');
 
@@ -281,7 +283,20 @@ class Provider extends AbstractProvider implements SocialiteProvider
 
         $builder = new SimpleEntityDescriptorBuilder($entityId, $acs, $acs, $x509);
 
-        return $builder->get();
+        $entityDescriptor = $builder->get();
+
+        // SimpleEntityDescriptorBuilder only emits a SingleSignOnService, so when an IdP Single Logout location is
+        // configured manually (via "slo"), advertise it here. Without this, logoutResponse() cannot resolve the IdP
+        // logout endpoint unless the IdP is configured through metadata instead.
+        if ($slo) {
+            $idpSsoDescriptor = $entityDescriptor->getFirstIdpSsoDescriptor();
+
+            foreach ([SamlConstants::BINDING_SAML2_HTTP_REDIRECT, SamlConstants::BINDING_SAML2_HTTP_POST] as $binding) {
+                $idpSsoDescriptor->addSingleLogoutService(new SingleLogoutService($slo, $binding));
+            }
+        }
+
+        return $entityDescriptor;
     }
 
     protected function getIdpEntityDescriptorFromXml(string $xml): EntityDescriptor

--- a/src/Saml2/README.md
+++ b/src/Saml2/README.md
@@ -182,6 +182,17 @@ To publish the SingleLogoutService in your service provider metadata, you also h
 ],
 ```
 
+When the Identity Provider is configured through `metadata`, its SingleLogoutService location is read from that metadata automatically. When configuring the Identity Provider manually (using `acs`), there is no metadata to read it from, so provide the IdP's Single Logout URL with the `slo` key:
+```php
+'saml2' => [
+  'acs' => 'https://idp.co/auth/sso', // the IDP's Single Sign-On URL
+  'slo' => 'https://idp.co/auth/slo', // the IDP's Single Logout URL
+  'entityid' => 'http://saml.to/trust',
+  'certificate' => 'MIIC4jCCAcqgAwIBAgIQbDO5YO....',
+],
+```
+Without `slo`, `logoutResponse()` cannot resolve the IdP logout endpoint for a manually configured Identity Provider.
+
 ### Signing and encryption
 
 SAML2 supports the signing and encryption of messages and assertions. Many Identity Providers make one or both mandatory. To enable this feature, you can generate a certificate for your application and provide it in `config/services.php` as:


### PR DESCRIPTION
## Why

Single Logout currently only works when the Identity Provider is configured through `metadata`. When the IdP is configured **manually** with the `acs` key, the descriptor is built by lightsaml's `SimpleEntityDescriptorBuilder`, which only emits a `SingleSignOnService` — it has no concept of a `SingleLogoutService`.

As a result, `logoutResponse()` cannot resolve the IdP's logout endpoint (`getFirstSingleLogoutService()` returns nothing), so IdP-initiated SLO is impossible for manually-configured providers unless you supply full IdP metadata XML.

## What

Adds an optional `slo` config key holding the IdP's Single Logout URL. When present, `getIdentityProviderEntityDescriptorManually()` advertises a `SingleLogoutService` on the IdP descriptor for both HTTP-Redirect and HTTP-POST bindings, so the existing native `logoutResponse()` flow can resolve it.

This mirrors how `acs` already provides the IdP's SSO location for the manual path (`acs` ↔ SSO, `slo` ↔ SLO).

```php
'saml2' => [
  'acs' => 'https://idp.co/auth/sso',
  'slo' => 'https://idp.co/auth/slo', // new
  'entityid' => 'http://saml.to/trust',
  'certificate' => '...',
],
```

## Notes

- **Fully backward compatible** — behaviour is unchanged when `slo` is omitted (no `SingleLogoutService` is added).
- No new imports required: `SingleLogoutService` and `SamlConstants` are already imported in `Provider.php`.
- Both bindings are advertised so `logoutResponse()` resolves the endpoint regardless of the configured `idp_binding_method`.
- README updated to document `slo` in the Single Logout section.