### PR TITLE
Microsoft provider: add public getClaims and getGroups function

### DIFF
--- a/src/Microsoft/Provider.php
+++ b/src/Microsoft/Provider.php
@@ -24,6 +24,8 @@ class Provider extends AbstractProvider
 
     private ?array $jwtKeys = null;
 
+    private ?\stdClass $claims = null;
+
     /**
      * The tenant id associated with personal Microsoft accounts (services like Xbox, Teams for Life, or Outlook).
      * Note: only reported in JWT ID_TOKENs and not in call's to Graph Organization endpoint.
@@ -165,6 +167,7 @@ class Provider extends AbstractProvider
         }
 
         $formattedResponse['roles'] = $this->getRoles();
+        $formattedResponse['groups'] = $this->getGroups();
 
         return $formattedResponse;
     }
@@ -205,6 +208,7 @@ class Provider extends AbstractProvider
             'userPrincipalName' => Arr::get($user, 'userPrincipalName'),
             'employeeId'        => Arr::get($user, 'employeeId'),
             'roles'             => Arr::get($user, 'roles'),
+            'groups'            => Arr::get($user, 'groups'),
 
             'tenant' => Arr::get($user, 'tenant'),
         ]);
@@ -234,19 +238,41 @@ class Provider extends AbstractProvider
     }
 
     /**
+     * Get all claims from the ID_TOKEN.
+     */
+    public function getClaims(): ?\stdClass
+    {
+        if ($this->claims !== null) {
+            return $this->claims;
+        }
+
+        if ($idToken = $this->parseIdToken($this->credentialsResponseBody)) {
+            return $this->claims = $this->validate($idToken);
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the optional groups from the ID_TOKEN.
+     * https://learn.microsoft.com/en-us/entra/identity-platform/optional-claims-reference
+     *
+     * @return array<string>
+     */
+    public function getGroups(): array
+    {
+        return $this->getClaims()?->groups ?? [];
+    }
+
+    /**
      * Get user's roles from the ID_TOKEN.
-     * https://learn.microsoft.com/en-us/entra/identity-platform/optional-claims#configure-groups-optional-claims
+     * https://learn.microsoft.com/en-us/entra/identity-platform/howto-add-app-roles-in-microsoft-entra-apps
      *
      * @return array<string>
      */
     public function getRoles(): array
     {
-        if ($idToken = $this->parseIdToken($this->credentialsResponseBody)) {
-
-            $claims = $this->validate($idToken);
-        }
-
-        return $claims?->roles ?? [];
+        return $this->getClaims()?->roles ?? [];
     }
 
     /**
@@ -257,14 +283,7 @@ class Provider extends AbstractProvider
      */
     public function isConsumerTenant(): bool
     {
-        if ($idToken = $this->parseIdToken($this->credentialsResponseBody)) {
-
-            $claims = $this->validate($idToken);
-
-            return ($claims?->tid ?? '') === self::MS_ENTRA_CONSUMER_TENANT_ID;
-        }
-
-        return false;
+        return ($this->getClaims()?->tid ?? '') === self::MS_ENTRA_CONSUMER_TENANT_ID;
     }
 
     /**

--- a/src/Microsoft/README.md
+++ b/src/Microsoft/README.md
@@ -72,6 +72,25 @@ Microsoft (Entra ID / Azure AD) periodically rotates signing keys. During rollov
 
 - ref. [Emit groups as role claims in Entra ID](https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/how-to-connect-fed-group-claims)
 
+### Groups
+
+`Socialite::driver('microsoft')->getGroups()` returns an array of the group IDs the authenticated user belongs to, taken from the `groups` claim of the ID token. The groups are also available on the user object as `$user->groups`.
+
+**Note:** the `groups` claim is not emitted by default. It has to be enabled in the Entra app registration (**Token configuration** → **Add groups claim**, or via `groupMembershipClaims` in the app manifest).
+
+**Note:** when a user is a member of too many groups (more than 200 for a JWT), Entra omits the `groups` claim entirely and emits `_claim_names`/`_claim_sources` claims pointing to a Microsoft Graph endpoint instead. In that case `getGroups()` returns an empty array and you need to query Graph for the user's groups yourself.
+
+- ref. [Configure group claims](https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/how-to-connect-fed-group-claims)
+- ref. [Groups overage claim](https://learn.microsoft.com/en-us/security/zero-trust/develop/configure-tokens-group-claims-app-roles#group-overages)
+
+### Claims
+
+`Socialite::driver('microsoft')->getClaims()` returns all claims from the validated ID token as a `\stdClass`, or `null` when no ID token is present (e.g. the `openid` scope was not requested). This gives access to any [optional claims](https://learn.microsoft.com/en-us/entra/identity-platform/optional-claims-reference) configured for the app registration:
+
+```php
+$user = Socialite::driver('microsoft')->user();
+$ipAddress = Socialite::driver('microsoft')->getClaims()?->ipaddr;
+```
 
 ### Tenant Details
 You can also retrieve Tenant information at the same time as you retrieve users, this can be useful if you need to allow only your tenant/s or filter certain tenants.


### PR DESCRIPTION
I saw that the current microsoft provider already fetches some claims from the id_token (roles and tenant-id)
For a customer of ours we were looking at using the "groups" claim.
Because there are [many more claims](https://learn.microsoft.com/en-us/entra/identity-platform/optional-claims-reference), i think the class would benefit from a public function to access them.