### PR TITLE
Add Logto provider

### DIFF
--- a/src/Logto/LogtoExtendSocialite.php
+++ b/src/Logto/LogtoExtendSocialite.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SocialiteProviders\Logto;
+
+use SocialiteProviders\Manager\SocialiteWasCalled;
+
+class LogtoExtendSocialite
+{
+    public function handle(SocialiteWasCalled $socialiteWasCalled): void
+    {
+        $socialiteWasCalled->extendSocialite('logto', Provider::class);
+    }
+}

--- a/src/Logto/Provider.php
+++ b/src/Logto/Provider.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace SocialiteProviders\Logto;
+
+use GuzzleHttp\RequestOptions;
+use InvalidArgumentException;
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
+use SocialiteProviders\Manager\OAuth2\User;
+
+class Provider extends AbstractProvider
+{
+    public const IDENTIFIER = 'LOGTO';
+
+    protected $scopeSeparator = ' ';
+
+    protected $scopes = ['openid', 'profile', 'email'];
+
+    public static function additionalConfigKeys(): array
+    {
+        return ['base_url'];
+    }
+
+    /**
+     * The Logto tenant endpoint, e.g. https://auth.example.com or
+     * https://<tenant-id>.logto.app. The OIDC routes live under /oidc.
+     */
+    protected function getBaseUrl(): string
+    {
+        $baseUrl = $this->getConfig('base_url');
+        if ($baseUrl === null) {
+            throw new InvalidArgumentException('Missing base_url');
+        }
+
+        return rtrim($baseUrl, '/');
+    }
+
+    protected function getAuthUrl($state): string
+    {
+        return $this->buildAuthUrlFromBase($this->getBaseUrl().'/oidc/auth', $state);
+    }
+
+    protected function getTokenUrl(): string
+    {
+        return $this->getBaseUrl().'/oidc/token';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByToken($token)
+    {
+        $response = $this->getHttpClient()->get($this->getBaseUrl().'/oidc/me', [
+            RequestOptions::HEADERS => [
+                'Authorization' => 'Bearer '.$token,
+            ],
+        ]);
+
+        return json_decode((string) $response->getBody(), true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function refreshToken($refreshToken)
+    {
+        $response = $this->getHttpClient()->post($this->getTokenUrl(), [
+            RequestOptions::FORM_PARAMS => [
+                'client_id'     => $this->clientId,
+                'client_secret' => $this->clientSecret,
+                'grant_type'    => 'refresh_token',
+                'refresh_token' => $refreshToken,
+            ],
+        ]);
+
+        return json_decode((string) $response->getBody(), true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return (new User)->setRaw($user)->map([
+            'id'                 => $user['sub'],
+            'nickname'           => $user['username'] ?? null,
+            'name'               => $user['name'] ?? null,
+            'email'              => $user['email'] ?? null,
+            'email_verified'     => $user['email_verified'] ?? null,
+            'avatar'             => $user['picture'] ?? null,
+            'given_name'         => $user['given_name'] ?? null,
+            'family_name'        => $user['family_name'] ?? null,
+            'preferred_username' => $user['username'] ?? null,
+        ]);
+    }
+}

--- a/src/Logto/README.md
+++ b/src/Logto/README.md
@@ -1,0 +1,77 @@
+# Logto
+
+```bash
+composer require socialiteproviders/logto
+```
+
+## Installation & Basic Usage
+
+Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
+then follow the provider specific instructions below.
+
+### Prepare OAuth application in Logto
+
+Create a **Traditional Web** application in your Logto Console
+(https://docs.logto.io/integrate-logto/traditional-web) and set its redirect URI
+to your app's callback (e.g. `https://example.com/auth/logto/callback`).
+
+### Add configuration to `config/services.php`
+
+```php
+'logto' => [
+  'base_url' => env('LOGTO_BASE_URL'), // e.g. https://auth.example.com or https://<tenant>.logto.app
+  'client_id' => env('LOGTO_CLIENT_ID'),
+  'client_secret' => env('LOGTO_CLIENT_SECRET'),
+  'redirect' => env('LOGTO_REDIRECT_URI')
+],
+```
+
+### Add provider event listener
+
+#### Laravel 11+
+
+In Laravel 11, the default `EventServiceProvider` provider was removed. Instead, add the listener using the `listen` method on the `Event` facade, in your `AppServiceProvider` `boot` method.
+
+* Note: You do not need to add anything for the built-in socialite providers unless you override them with your own providers.
+
+```php
+Event::listen(function (\SocialiteProviders\Manager\SocialiteWasCalled $event) {
+    $event->extendSocialite('logto', \SocialiteProviders\Logto\Provider::class);
+});
+```
+<details>
+<summary>
+Laravel 10 or below
+</summary>
+Configure the package's listener to listen for `SocialiteWasCalled` events.
+
+Add the event to your `listen[]` array in `app/Providers/EventServiceProvider`. See the [Base Installation Guide](https://socialiteproviders.com/usage/) for detailed instructions.
+
+```php
+protected $listen = [
+    \SocialiteProviders\Manager\SocialiteWasCalled::class => [
+        // ... other providers
+        \SocialiteProviders\Logto\LogtoExtendSocialite::class.'@handle',
+    ],
+];
+```
+</details>
+
+### Usage
+
+You should now be able to use the provider like you would regularly use
+Socialite (assuming you have the facade installed):
+
+```php
+return Socialite::driver('logto')->redirect();
+```
+
+To redirect to the authentication, and then:
+
+```php
+$user = Socialite::driver('logto')->user();
+```
+
+In the return function. The user will contain a `name` and `email` field
+populated from the Logto `/oidc/me` endpoint, along with `id` (`sub`),
+`nickname`/`preferred_username` (`username`) and `avatar` (`picture`).

--- a/src/Logto/composer.json
+++ b/src/Logto/composer.json
@@ -1,0 +1,33 @@
+{
+    "name": "socialiteproviders/logto",
+    "description": "Logto OAuth2/OIDC Provider for Laravel Socialite",
+    "license": "MIT",
+    "keywords": [
+        "logto",
+        "oidc",
+        "laravel",
+        "oauth",
+        "provider",
+        "socialite"
+    ],
+    "authors": [
+        {
+            "name": "Cold Code Labs",
+            "email": "dev@coldcodelabs.com"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/socialiteproviders/providers/issues",
+        "source": "https://github.com/socialiteproviders/providers",
+        "docs": "https://socialiteproviders.com/logto"
+    },
+    "require": {
+        "php": "^8.0",
+        "socialiteproviders/manager": "^4.4"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialiteProviders\\Logto\\": ""
+        }
+    }
+}


### PR DESCRIPTION
Adds a provider for [Logto](https://logto.io), an open-source OIDC identity provider (self-hosted or Logto Cloud).

It targets Logto's standard OIDC endpoints under a configurable `base_url` (mirroring the Authentik/Zitadel providers):

| Purpose   | Endpoint                |
|-----------|-------------------------|
| authorize | `{base_url}/oidc/auth`  |
| token     | `{base_url}/oidc/token` |
| userinfo  | `{base_url}/oidc/me`    |

- Scopes: `openid profile email`
- Maps `sub`→`id`, plus `email`, `email_verified`, `name`, `username`→`nickname`/`preferred_username`, `picture`→`avatar`
- `additionalConfigKeys`: `base_url`

Follows the standard `src/<Name>/` structure (`Provider.php`, `LogtoExtendSocialite.php`, `composer.json`, `README.md`).

Validated end-to-end against a live Logto tenant (authorization code → token → userinfo → mapped user).