### PR TITLE
feat: add Epic Games provider

### DIFF
--- a/src/EpicGames/EpicGamesExtendSocialite.php
+++ b/src/EpicGames/EpicGamesExtendSocialite.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SocialiteProviders\EpicGames;
+
+use SocialiteProviders\Manager\SocialiteWasCalled;
+
+class EpicGamesExtendSocialite
+{
+    public function handle(SocialiteWasCalled $socialiteWasCalled): void
+    {
+        $socialiteWasCalled->extendSocialite('epic-games', Provider::class);
+    }
+}

--- a/src/EpicGames/Provider.php
+++ b/src/EpicGames/Provider.php
@@ -4,8 +4,8 @@ namespace SocialiteProviders\EpicGames;
 
 use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
-use Laravel\Socialite\Two\User;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
+use SocialiteProviders\Manager\OAuth2\User;
 
 class Provider extends AbstractProvider
 {
@@ -92,7 +92,6 @@ class Provider extends AbstractProvider
             'nickname' => Arr::get($user, 'preferred_username'),
             'name' => Arr::get($user, 'name', Arr::get($user, 'preferred_username')),
             'email' => Arr::get($user, 'email'),
-            'avatar' => null,
         ]);
     }
 }

--- a/src/EpicGames/Provider.php
+++ b/src/EpicGames/Provider.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace SocialiteProviders\EpicGames;
+
+use GuzzleHttp\RequestOptions;
+use Illuminate\Support\Arr;
+use Laravel\Socialite\Two\User;
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
+
+class Provider extends AbstractProvider
+{
+    public const IDENTIFIER = 'EPIC_GAMES';
+
+    /**
+     * The scopes being requested.
+     *
+     * @var array
+     */
+    protected $scopes = ['basic_profile'];
+
+    /**
+     * Build the authorization URL.
+     */
+    protected function getAuthUrl($state): string
+    {
+        return $this->buildAuthUrlFromBase('https://www.epicgames.com/id/authorize', $state);
+    }
+
+    /**
+     * Build the token URL.
+     */
+    protected function getTokenUrl(): string
+    {
+        return 'https://api.epicgames.dev/epic/oauth/v2/token';
+    }
+
+    /**
+     * Get the POST fields for the token request.
+     *
+     * @param  string  $code
+     * @return array
+     */
+    protected function getTokenFields($code)
+    {
+        return [
+            'grant_type' => 'authorization_code',
+            'code' => $code,
+            'redirect_uri' => $this->redirectUrl,
+        ];
+    }
+
+    /**
+     * Get the headers for the token request.
+     *
+     * @param  string  $code
+     * @return array
+     */
+    protected function getTokenHeaders($code)
+    {
+        return [
+            'Authorization' => 'Basic '.base64_encode($this->clientId.':'.$this->clientSecret),
+            'Content-Type' => 'application/x-www-form-urlencoded',
+        ];
+    }
+
+    /**
+     * Retrieve the logged in user data from Epic Games.
+     *
+     * @param  string  $token
+     * @return array<string, mixed>
+     */
+    protected function getUserByToken($token)
+    {
+        $response = $this->getHttpClient()->get('https://api.epicgames.dev/epic/oauth/v2/userInfo', [
+            RequestOptions::HEADERS => [
+                'Authorization' => 'Bearer '.$token,
+            ],
+        ]);
+
+        return json_decode((string) $response->getBody(), true);
+    }
+
+    /**
+     * Map the raw payload to a Socialite user object.
+     *
+     * @param  array<string, mixed>  $user
+     */
+    protected function mapUserToObject(array $user): User
+    {
+        return (new User())->setRaw($user)->map([
+            'id' => Arr::get($user, 'sub'),
+            'nickname' => Arr::get($user, 'preferred_username'),
+            'name' => Arr::get($user, 'name', Arr::get($user, 'preferred_username')),
+            'email' => Arr::get($user, 'email'),
+            'avatar' => null,
+        ]);
+    }
+}

--- a/src/EpicGames/README.md
+++ b/src/EpicGames/README.md
@@ -1,0 +1,49 @@
+# Epic Games
+
+```bash
+composer require socialiteproviders/epic-games
+```
+
+## Installation & Basic Usage
+
+Please see the [Base Installation Guide](https://socialiteproviders.com/usage/), then follow the provider specific instructions below.
+
+### Add configuration to `config/services.php`
+
+```php
+'epic_games' => [    
+  'client_id' => env('EPIC_GAMES_CLIENT_ID'),  
+  'client_secret' => env('EPIC_GAMES_CLIENT_SECRET'),  
+  'redirect' => env('EPIC_GAMES_REDIRECT_URI') 
+],
+```
+
+### Add provider event listener
+
+Configure the package's listener to listen for `SocialiteWasCalled` events.
+
+Add the event to your `listen[]` array in `app/Providers/EventServiceProvider.php`. See the [Base Installation Guide](https://socialiteproviders.com/usage/) for detailed instructions.
+
+```php
+protected $listen = [
+    \SocialiteProviders\Manager\SocialiteWasCalled::class => [
+        // ... other providers
+        \SocialiteProviders\EpicGames\EpicGamesExtendSocialite::class.'@handle',
+    ],
+];
+```
+
+### Usage
+
+You should now be able to use the provider like you would regularly use Socialite (assuming you have the facade installed):
+
+```php
+return Socialite::driver('epic-games')->redirect();
+```
+
+### Returned User fields
+
+- ``id``
+- ``nickname``
+- ``name``
+- ``email``

--- a/src/EpicGames/README.md
+++ b/src/EpicGames/README.md
@@ -11,7 +11,7 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
 ### Add configuration to `config/services.php`
 
 ```php
-'epic_games' => [    
+'epic-games' => [    
   'client_id' => env('EPIC_GAMES_CLIENT_ID'),  
   'client_secret' => env('EPIC_GAMES_CLIENT_SECRET'),  
   'redirect' => env('EPIC_GAMES_REDIRECT_URI') 

--- a/src/EpicGames/composer.json
+++ b/src/EpicGames/composer.json
@@ -1,0 +1,32 @@
+{
+    "name": "socialiteproviders/epic-games",
+    "description": "Epic Games OAuth2 Provider for Laravel Socialite",
+    "license": "MIT",
+    "keywords": [
+        "epic-games",
+        "epicgames",
+        "laravel",
+        "oauth",
+        "provider",
+        "socialite"
+    ],
+    "authors": [
+        {
+            "name": "Bruno Rosa"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/socialiteproviders/providers/issues",
+        "source": "https://github.com/socialiteproviders/providers",
+        "docs": "https://socialiteproviders.com/epic-games"
+    },
+    "require": {
+        "php": "^8.0",
+        "socialiteproviders/manager": "^4.4"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialiteProviders\\EpicGames\\": ""
+        }
+    }
+}


### PR DESCRIPTION
### What does this PR do?
This PR introduces a new OAuth2 provider for **Epic Games**, allowing developers to easily integrate Epic
Games authentication into their Laravel applications using Socialite.

### Implementation Details:
- **Provider ID:** `EPIC_GAMES`
- **Auth URL:** `https://www.epicgames.com/id/authorize`
- **Token URL:** `https://api.epicgames.dev/epic/oauth/v2/token`
- **User Info URL:** `https://api.epicgames.dev/epic/oauth/v2/userInfo`
- Handled the Epic Games requirement to send credentials via `Basic Auth` in the token exchange request
header instead of passing them in the POST body.
- Mapped standard User fields (`id`, `nickname`, `name`, `email`) corresponding to the Epic Games user info
endpoint schema.

### Checklist:
- [x] Provider class created.
- [x] Listener (`EpicGamesExtendSocialite`) created.
- [x] `composer.json` configured appropriately.
- [x] `README.md` created with usage and installation instructions.
