### PR TITLE
Use www.instagram.com for the Instagram authorize endpoint

### DIFF
--- a/src/Instagram/Provider.php
+++ b/src/Instagram/Provider.php
@@ -35,7 +35,7 @@ class Provider extends AbstractProvider
 
     protected function getAuthUrl($state): string
     {
-        return $this->buildAuthUrlFromBase('https://api.instagram.com/oauth/authorize', $state);
+        return $this->buildAuthUrlFromBase('https://www.instagram.com/oauth/authorize', $state);
     }
 
     protected function getTokenUrl(): string


### PR DESCRIPTION
The Instagram provider builds its authorize URL from `api.instagram.com/oauth/authorize`, which Meta's current Business Login docs no longer list. That host now just 302s to `www.instagram.com/oauth/authorize`, so logins depend on Meta keeping the old redirect alive. This uses the documented URL directly; the token endpoint is unaffected.

Fixes #1459
