### PR TITLE
fix: replace deprecated Request::get() with input()

### DIFF
--- a/src/AmoCRM/Provider.php
+++ b/src/AmoCRM/Provider.php
@@ -31,7 +31,7 @@ class Provider extends AbstractProvider
      *
      * @return string
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function getTld()
     {
@@ -51,7 +51,7 @@ class Provider extends AbstractProvider
 
     protected function getTokenUrl(): string
     {
-        $domain = $this->request->get('referer');
+        $domain = $this->request->input('referer');
 
         return "https://{$domain}/oauth2/access_token";
     }
@@ -61,7 +61,7 @@ class Provider extends AbstractProvider
      */
     protected function getUserByToken($token)
     {
-        $domain = $this->request->get('referer');
+        $domain = $this->request->input('referer');
 
         $response = $this->getHttpClient()->get("https://$domain/api/v4/account", [
             RequestOptions::HEADERS => [

--- a/src/Shopify/Provider.php
+++ b/src/Shopify/Provider.php
@@ -40,8 +40,8 @@ class Provider extends AbstractProvider
                         myshopifyDomain
                         shopOwnerName
                     }
-                }'
-            ]
+                }',
+            ],
         ]);
 
         return json_decode($response->getBody(), true)['data']['shop'];
@@ -82,6 +82,6 @@ class Provider extends AbstractProvider
             return "https://{$this->getConfig('subdomain')}.myshopify.com".$uri;
         }
 
-        return 'https://'.$this->request->get('shop').$uri;
+        return 'https://'.$this->request->input('shop').$uri;
     }
 }

--- a/src/Steam/Provider.php
+++ b/src/Steam/Provider.php
@@ -166,7 +166,7 @@ class Provider extends AbstractProvider
      *
      * @return bool
      *
-     * @throws \SocialiteProviders\Steam\OpenIDValidationException
+     * @throws OpenIDValidationException
      */
     public function validate()
     {
@@ -176,7 +176,7 @@ class Provider extends AbstractProvider
             throw new OpenIDValidationException('A critical openid parameter is missing from the request');
         }
 
-        if (! $this->validateHost($this->request->get(self::OPENID_RETURN_TO))) {
+        if (! $this->validateHost($this->request->input(self::OPENID_RETURN_TO))) {
             throw new OpenIDValidationException('Invalid return_to host');
         }
 
@@ -254,18 +254,18 @@ class Provider extends AbstractProvider
     public function getParams()
     {
         $params = [
-            'openid.assoc_handle' => $this->request->get(self::OPENID_ASSOC_HANDLE),
-            'openid.signed'       => $this->request->get(self::OPENID_SIGNED),
-            'openid.sig'          => $this->request->get(self::OPENID_SIG),
+            'openid.assoc_handle' => $this->request->input(self::OPENID_ASSOC_HANDLE),
+            'openid.signed'       => $this->request->input(self::OPENID_SIGNED),
+            'openid.sig'          => $this->request->input(self::OPENID_SIG),
             'openid.ns'           => self::OPENID_NS,
             'openid.mode'         => 'check_authentication',
-            'openid.error'        => $this->request->get(self::OPENID_ERROR),
+            'openid.error'        => $this->request->input(self::OPENID_ERROR),
         ];
 
-        $signedParams = explode(',', $this->request->get(self::OPENID_SIGNED));
+        $signedParams = explode(',', $this->request->input(self::OPENID_SIGNED));
 
         foreach ($signedParams as $item) {
-            $value = $this->request->get('openid.'.str_replace('.', '_', $item));
+            $value = $this->request->input('openid.'.str_replace('.', '_', $item));
             $params['openid.'.$item] = $value;
         }
 
@@ -313,7 +313,7 @@ class Provider extends AbstractProvider
     {
         preg_match(
             '#^https?://steamcommunity.com/openid/id/([0-9]{17,25})#',
-            $this->request->get(self::OPENID_CLAIMED_ID),
+            $this->request->input(self::OPENID_CLAIMED_ID),
             $matches
         );
 

--- a/src/TikTokShop/Provider.php
+++ b/src/TikTokShop/Provider.php
@@ -11,6 +11,7 @@ use SocialiteProviders\Manager\OAuth2\User;
 class Provider extends AbstractProvider implements ProviderInterface
 {
     public const IDENTIFIER = 'TIKTOKSHOP';
+
     protected $scopes = [];
 
     protected function getAuthUrl($state)
@@ -35,10 +36,10 @@ class Provider extends AbstractProvider implements ProviderInterface
     public function user()
     {
         $response = $this->getHttpClient()->get($this->getTokenUrl(), [
-            'query' => $this->getTokenFields($this->request->get('code')),
+            'query' => $this->getTokenFields($this->request->input('code')),
         ]);
 
-        $json = json_decode((string)$response->getBody(), true);
+        $json = json_decode((string) $response->getBody(), true);
         $tokenData = $json['data'] ?? $json;
 
         $user = $this->mapUserToObject($tokenData);
@@ -56,9 +57,9 @@ class Provider extends AbstractProvider implements ProviderInterface
     protected function getTokenFields($code)
     {
         return [
-            'app_key' => $this->clientId,
+            'app_key'    => $this->clientId,
             'app_secret' => $this->clientSecret,
-            'auth_code' => $code,
+            'auth_code'  => $code,
             'grant_type' => 'authorized_code',
         ];
     }
@@ -69,11 +70,11 @@ class Provider extends AbstractProvider implements ProviderInterface
     protected function mapUserToObject(array $user)
     {
         return (new User)->setRaw($user)->map([
-            'id' => $user['open_id'] ?? null,
+            'id'       => $user['open_id'] ?? null,
             'nickname' => $user['seller_name'] ?? null,
-            'name' => $user['seller_name'] ?? null,
-            'email' => null,
-            'avatar' => null,
+            'name'     => $user['seller_name'] ?? null,
+            'email'    => null,
+            'avatar'   => null,
         ]);
     }
 }


### PR DESCRIPTION
Fixes #1461

`Request::get()` was deprecated in symfony/http-foundation 7.4:

> Request::get() is deprecated, use properties ->attributes, query or request directly instead

The Steam provider (reported in #1461) triggers this on every OpenID callback. Swapping to Laravel's `Request::input()` reads from the query and request bags without the deprecation, keeping the same behaviour.

While fixing Steam I swept the rest of the providers for the same pattern and fixed the other occurrences too.

### Changed
- **Steam** — 8 calls in `validate()`, `getParams()`, `parseSteamID()` (covers the reported lines 90/197/316)
- **Shopify** — `->get('shop')`
- **TikTokShop** — `->get('code')`
- **AmoCRM** — two `->get('referer')`

All are OAuth callback query/request params, so `input()` is a semantic no-op replacement.
