### PR TITLE
fix(soundcloud): migrate to OAuth 2.1 endpoints with PKCE

### DIFF
--- a/src/SoundCloud/Provider.php
+++ b/src/SoundCloud/Provider.php
@@ -12,14 +12,19 @@ class Provider extends AbstractProvider
 
     protected $scopes = ['non-expiring'];
 
+    /**
+     * {@inheritdoc}
+     */
+    protected $usesPKCE = true;
+
     protected function getAuthUrl($state): string
     {
-        return $this->buildAuthUrlFromBase('https://soundcloud.com/connect', $state);
+        return $this->buildAuthUrlFromBase('https://secure.soundcloud.com/authorize', $state);
     }
 
     protected function getTokenUrl(): string
     {
-        return 'https://api.soundcloud.com/oauth2/token';
+        return 'https://secure.soundcloud.com/oauth/token';
     }
 
     /**
@@ -28,9 +33,10 @@ class Provider extends AbstractProvider
     protected function getUserByToken($token)
     {
         $response = $this->getHttpClient()->get(
-            'https://api.soundcloud.com/me.json',
+            'https://api.soundcloud.com/me',
             [
                 RequestOptions::HEADERS => [
+                    'Accept'        => 'application/json; charset=utf-8',
                     'Authorization' => 'OAuth '.$token,
                 ],
             ]


### PR DESCRIPTION
Fixes #1410

SoundCloud moved to OAuth 2.1 and retired the legacy OAuth 2.0 hosts. The provider still pointed at the old `soundcloud.com/connect` and `api.soundcloud.com/oauth2/token` endpoints, so the token exchange fails — surfacing downstream as the reported `A request must contain the Authorization header` error.

Migrates the provider to the current endpoints:

| | Before | After |
|---|---|---|
| Authorize | `soundcloud.com/connect` | `secure.soundcloud.com/authorize` |
| Token | `api.soundcloud.com/oauth2/token` | `secure.soundcloud.com/oauth/token` |
| User | `api.soundcloud.com/me.json` | `api.soundcloud.com/me` |
| PKCE | off | required, now enabled |

PKCE is now mandatory for the authorization code flow; enabling `$usesPKCE` is enough since Socialite's base provider handles the `code_challenge`/`code_verifier` mechanics. The `OAuth {token}` auth header was already correct.

Endpoints verified against SoundCloud's current [API guide](https://developers.soundcloud.com/docs/api/guide).