### PR TITLE
fix(dataporten): use OIDC userinfo endpoint

### DIFF
--- a/src/Dataporten/Provider.php
+++ b/src/Dataporten/Provider.php
@@ -3,6 +3,7 @@
 namespace SocialiteProviders\Dataporten;
 
 use GuzzleHttp\RequestOptions;
+use Illuminate\Support\Arr;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -25,7 +26,7 @@ class Provider extends AbstractProvider
      */
     protected function getUserByToken($token)
     {
-        $response = $this->getHttpClient()->get('https://auth.dataporten.no/userinfo', [
+        $response = $this->getHttpClient()->get('https://auth.dataporten.no/openid/userinfo', [
             RequestOptions::HEADERS => [
                 'Authorization' => 'Bearer '.$token,
             ],
@@ -39,6 +40,11 @@ class Provider extends AbstractProvider
      */
     protected function mapUserToObject(array $user)
     {
-        return (new User)->setRaw($user);
+        return (new User)->setRaw($user)->map([
+            'id'     => Arr::get($user, 'sub'),
+            'name'   => Arr::get($user, 'name'),
+            'email'  => Arr::get($user, 'email'),
+            'avatar' => Arr::get($user, 'picture'),
+        ]);
     }
 }


### PR DESCRIPTION
Feide/Dataporten has deprecated the legacy `/userinfo` endpoint. The OIDC discovery document (`https://auth.dataporten.no/.well-known/openid-configuration`) points to `/openid/userinfo`, so this switches `getUserByToken()` to the OIDC endpoint.

Also maps the standard OIDC claims returned by that endpoint (`sub`, `name`, `email`, `picture`) onto the user object — previously `mapUserToObject()` populated nothing, so `getId()`/`getName()`/`getEmail()`/`getAvatar()` all returned null.

Not a breaking change: the accessors go from null → populated (additive). `getRaw()` reflects the new flat OIDC claim shape, which is an inherent consequence of the endpoint migration.

Closes #1383