### PR TITLE
fix: drop redundant HubSpot split override

### DIFF
--- a/split-overrides.json
+++ b/split-overrides.json
@@ -7,7 +7,6 @@
     "FiveHundredPixel": "500px",
     "Google": "Google-Plus",
     "Graph": "Microsoft-Graph",
-    "HubSpot": "Hubspot",
     "HumanApi": "Human-API",
     "LaravelPassport": "Laravel-Passport",
     "Live": "Microsoft-Live",


### PR DESCRIPTION
`"HubSpot": "Hubspot"` mapped the package to a repo name that doesn't exist — the repo is `SocialiteProviders/HubSpot`. Since the corrected value would be identical to the key, the entry isn't an override at all and the `$overrides[$package] ?? $package` fallback already produces the right name.

No behaviour change: GitHub resolves repo names case-insensitively, so the split push, the release API calls, and the website's raw README fetch all worked regardless. This just removes a line that reads as if the repo were named `Hubspot`.

The two remaining case-only entries (`Deviantart` → `deviantART`, `MediaCube` → `Mediacube`) are kept — unlike this one, their values differ from the key and carry the canonical repo casing.
