### PR TITLE
docs: add category frontmatter to Epic Games and Logto

### DIFF
--- a/src/EpicGames/README.md
+++ b/src/EpicGames/README.md
@@ -1,3 +1,8 @@
+---
+category: Gaming
+name: Epic Games
+---
+
 # Epic Games
 
 ```bash

--- a/src/Logto/README.md
+++ b/src/Logto/README.md
@@ -1,3 +1,7 @@
+---
+category: Social / Platform
+---
+
 # Logto
 
 ```bash


### PR DESCRIPTION
Epic Games (#1458) and Logto (#1456) merged just before the frontmatter convention landed in #1465, so their READMEs have no `category` key and the sync workflow skipped them.

Adds the missing block to both. `Logto` needs no `name` — it falls back to the directory name — while `Epic Games` sets one because the display name differs.

The website entries are being added in SocialiteProviders/website#83; this keeps the source of truth consistent so any future re-run of the sync is a no-op rather than a surprise.
