### PR TITLE
fix(steam): read literal-dot openid keys via Arr::get

### DIFF
--- a/src/Steam/Provider.php
+++ b/src/Steam/Provider.php
@@ -176,7 +176,7 @@ class Provider extends AbstractProvider
             throw new OpenIDValidationException('A critical openid parameter is missing from the request');
         }
 
-        if (! $this->validateHost($this->request->input(self::OPENID_RETURN_TO))) {
+        if (! $this->validateHost($this->getOrNull(self::OPENID_RETURN_TO))) {
             throw new OpenIDValidationException('Invalid return_to host');
         }
 
@@ -209,7 +209,13 @@ class Provider extends AbstractProvider
     {
         return $this->request->has(self::OPENID_ASSOC_HANDLE)
             && $this->request->has(self::OPENID_SIGNED)
-            && $this->request->has(self::OPENID_SIG);
+            && $this->request->has(self::OPENID_SIG)
+            && $this->request->has(self::OPENID_RETURN_TO);
+    }
+
+    private function getOrNull(string $key): ?string
+    {
+        return Arr::get($this->request->all(), $key);
     }
 
     /**
@@ -254,18 +260,18 @@ class Provider extends AbstractProvider
     public function getParams()
     {
         $params = [
-            'openid.assoc_handle' => $this->request->input(self::OPENID_ASSOC_HANDLE),
-            'openid.signed'       => $this->request->input(self::OPENID_SIGNED),
-            'openid.sig'          => $this->request->input(self::OPENID_SIG),
+            'openid.assoc_handle' => $this->getOrNull(self::OPENID_ASSOC_HANDLE),
+            'openid.signed'       => $this->getOrNull(self::OPENID_SIGNED),
+            'openid.sig'          => $this->getOrNull(self::OPENID_SIG),
             'openid.ns'           => self::OPENID_NS,
             'openid.mode'         => 'check_authentication',
-            'openid.error'        => $this->request->input(self::OPENID_ERROR),
+            'openid.error'        => $this->getOrNull(self::OPENID_ERROR),
         ];
 
-        $signedParams = explode(',', $this->request->input(self::OPENID_SIGNED));
+        $signedParams = explode(',', (string) $this->getOrNull(self::OPENID_SIGNED));
 
         foreach ($signedParams as $item) {
-            $value = $this->request->input('openid.'.str_replace('.', '_', $item));
+            $value = $this->getOrNull('openid.'.str_replace('.', '_', $item));
             $params['openid.'.$item] = $value;
         }
 
@@ -313,7 +319,7 @@ class Provider extends AbstractProvider
     {
         preg_match(
             '#^https?://steamcommunity.com/openid/id/([0-9]{17,25})#',
-            $this->request->input(self::OPENID_CLAIMED_ID),
+            (string) $this->getOrNull(self::OPENID_CLAIMED_ID),
             $matches
         );
 


### PR DESCRIPTION
Fixes #1468. Regression in 4.4.0 from #1462 — every Steam login fatals with `validateHost(): Argument #1 ($url) must be of type string, null given`.

`normalizeOpenidKeys()` produces flat keys containing a literal dot (`openid.return_to`). `Request::input()` routes through `data_get()`, which explodes on `.` and looks for a nested array that doesn't exist, returning null. `Request::get()` read the key literally, which is why 4.3.1 was fine. The `requestIsValid()` guard missed it because `Request::has()` uses `Arr::has()`, which does have a literal-key fast path.

Rather than reverting to the deprecated `get()`, reads now go through a `getOrNull()` helper using `Arr::get($this->request->all(), $key)`, which has the same fast path.

- Converted all 8 dotted-key reads — the issue named four, but `getParams()` and `parseSteamID()` were equally broken.
- Added `OPENID_RETURN_TO` to `requestIsValid()`, so a malformed callback throws `OpenIDValidationException` rather than a `TypeError`.
- Added `(string)` casts for `explode()` and `preg_match()`.

AmoCRM, Shopify and TikTokShop only read dot-free keys, so they're unaffected by the same sweep.
