### PR TITLE
test: add per-provider test suite with change detection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
     branches: master
 
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
     name: Lint
 
@@ -29,3 +29,89 @@ jobs:
 
       - name: Lint composer.json
         run: composer validate --strict
+
+  detect:
+    runs-on: ubuntu-latest
+    name: Detect changed providers
+
+    outputs:
+      providers: ${{ steps.detect.outputs.providers }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # Needs history back to the merge base to diff the branch.
+          fetch-depth: 0
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          coverage: none
+          php-version: '8.5'
+          extensions: json, mbstring
+
+      - name: Detect changed providers
+        id: detect
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: |
+          providers=$(php tools/changed-providers.php "$BASE_SHA" "$HEAD_SHA")
+          echo "providers=$providers" >> "$GITHUB_OUTPUT"
+          echo "Testing: $providers"
+
+  test:
+    runs-on: ubuntu-latest
+    needs: detect
+    # An empty matrix fails at expansion time, so skip the job entirely.
+    if: needs.detect.outputs.providers != '[]'
+
+    name: Test ${{ matrix.provider }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        provider: ${{ fromJSON(needs.detect.outputs.providers) }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          coverage: none
+          php-version: '8.5'
+          extensions: json, mbstring
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      # Most providers only need the root install, which autoloads every
+      # src/* class. A handful declare their own third-party dependencies -
+      # install those so they are tested against what users actually get.
+      - name: Install provider dependencies
+        if: matrix.provider != 'all'
+        env:
+          PROVIDER: ${{ matrix.provider }}
+        run: |
+          extra=$(jq -r '.require | keys[]' "src/$PROVIDER/composer.json" \
+            | grep -vE '^(php|ext-.*|socialiteproviders/manager)$' || true)
+
+          if [ -n "$extra" ]; then
+            echo "Installing provider dependencies: $(echo "$extra" | tr '\n' ' ')"
+            composer require --no-interaction --prefer-dist --update-with-dependencies $extra
+          else
+            echo "No extra dependencies."
+          fi
+
+      - name: Run tests
+        env:
+          PROVIDER: ${{ matrix.provider }}
+        run: |
+          if [ "$PROVIDER" = "all" ]; then
+            vendor/bin/phpunit --testsuite Providers
+          else
+            vendor/bin/phpunit --testsuite Providers --filter "SocialiteProviders\\\\Tests\\\\$PROVIDER\\\\"
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,9 @@ jobs:
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: |
-          providers=$(php tools/changed-providers.php "$BASE_SHA" "$HEAD_SHA")
+          # Triple-dot diffs against the merge base, so commits landed on the
+          # base branch since this one forked are not counted as changes.
+          providers=$(php tools/changed-providers.php "$BASE_SHA...$HEAD_SHA")
           echo "providers=$providers" >> "$GITHUB_OUTPUT"
           echo "Testing: $providers"
 
@@ -96,12 +98,17 @@ jobs:
         env:
           PROVIDER: ${{ matrix.provider }}
         run: |
-          extra=$(jq -r '.require | keys[]' "src/$PROVIDER/composer.json" \
-            | grep -vE '^(php|ext-.*|socialiteproviders/manager)$' || true)
+          # Keep the version constraints, so CI resolves what a user installing
+          # this provider would actually get.
+          extra=$(jq -r '.require | to_entries[]
+              | select(.key | test("^(php|ext-|socialiteproviders/manager$)") | not)
+              | "\(.key):\(.value)"' "src/$PROVIDER/composer.json")
 
           if [ -n "$extra" ]; then
-            echo "Installing provider dependencies: $(echo "$extra" | tr '\n' ' ')"
-            composer require --no-interaction --prefer-dist --update-with-dependencies $extra
+            echo "Installing provider dependencies:"
+            echo "$extra"
+            echo "$extra" | tr '\n' '\0' \
+              | xargs -0 composer require --no-interaction --prefer-dist --update-with-dependencies
           else
             echo "No extra dependencies."
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 .idea
 .vscode
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -13,16 +13,24 @@
         "socialiteproviders/manager": "^4.4"
     },
     "require-dev": {
+        "composer/semver": "^3.0",
         "guzzlehttp/guzzle": "^7.9",
         "illuminate/http": "^12.0",
         "laravel/pint": "^1.18",
+        "mockery/mockery": "^1.6",
         "php-parallel-lint/php-console-highlighter": "^1.0",
-        "composer/semver": "^3.0",
-        "php-parallel-lint/php-parallel-lint": "^1.4"
+        "php-parallel-lint/php-parallel-lint": "^1.4",
+        "phpunit/phpunit": "^13.3",
+        "spatie/phpunit-snapshot-assertions": "^5.4"
     },
     "autoload": {
         "psr-4": {
             "SocialiteProviders\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "SocialiteProviders\\Tests\\": "tests/"
         }
     },
     "config": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         failOnWarning="true"
+         failOnRisky="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="Providers">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/tests/Steam/SteamProviderTest.php
+++ b/tests/Steam/SteamProviderTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace SocialiteProviders\Tests\Steam;
+
+use GuzzleHttp\Psr7\Response;
+use SocialiteProviders\Steam\OpenIDValidationException;
+use SocialiteProviders\Steam\Provider;
+use SocialiteProviders\Tests\TestCase;
+use Spatie\Snapshots\MatchesSnapshots;
+
+class SteamProviderTest extends TestCase
+{
+    use MatchesSnapshots;
+
+    private const STEAM_ID = '76561197960287930';
+
+    protected function provider(): string
+    {
+        return Provider::class;
+    }
+
+    public function test_redirect_builds_an_openid_checkid_setup_url(): void
+    {
+        $url = $this->makeProvider()->redirect()->getTargetUrl();
+
+        $this->assertStringStartsWith(Provider::OPENID_URL, $url);
+        $this->assertMatchesJsonSnapshot($this->queryParams($url));
+    }
+
+    public function test_redirect_realm_honours_the_request_scheme(): void
+    {
+        // parse_str() rewrites dots in keys to underscores.
+        $params = $this->queryParams(
+            $this->makeProvider($this->makeRequest())->redirect()->getTargetUrl()
+        );
+
+        $this->assertSame('https://example.com', $params['openid_realm']);
+    }
+
+    public function test_redirect_realm_uses_the_configured_host(): void
+    {
+        $provider = $this->makeProvider(
+            $this->makeRequest([], 'https://game.example.org/auth/callback')
+        );
+
+        $params = $this->queryParams($provider->redirect()->getTargetUrl());
+
+        $this->assertSame('https://game.example.org', $params['openid_realm']);
+    }
+
+    public function test_user_maps_the_steam_player_summary(): void
+    {
+        $provider = $this->makeProvider(
+            $this->makeRequest($this->validOpenidQuery()),
+            [
+                new Response(200, [], 'ns:'.Provider::OPENID_NS."\nis_valid:true\n"),
+                new Response(200, [], $this->fixture('player.json')),
+            ]
+        );
+
+        $user = $provider->user();
+
+        $this->assertSame(self::STEAM_ID, $user->getId());
+        $this->assertMatchesJsonSnapshot([
+            'id'       => $user->getId(),
+            'nickname' => $user->getNickname(),
+            'name'     => $user->getName(),
+            'email'    => $user->getEmail(),
+            'avatar'   => $user->getAvatar(),
+        ]);
+    }
+
+    /**
+     * Steam returns underscore-separated keys on some callbacks (openid_sig rather
+     * than openid.sig). Both spellings must resolve.
+     *
+     * @see https://github.com/socialiteproviders/providers/pull/1469
+     */
+    public function test_user_accepts_underscore_separated_openid_keys(): void
+    {
+        $query = [];
+
+        foreach ($this->validOpenidQuery() as $key => $value) {
+            $query[str_replace('openid.', 'openid_', $key)] = $value;
+        }
+
+        $provider = $this->makeProvider(
+            $this->makeRequest($query),
+            [
+                new Response(200, [], "is_valid:true\n"),
+                new Response(200, [], $this->fixture('player.json')),
+            ]
+        );
+
+        $this->assertSame(self::STEAM_ID, $provider->user()->getId());
+    }
+
+    public function test_user_throws_when_openid_validation_fails(): void
+    {
+        $provider = $this->makeProvider(
+            $this->makeRequest($this->validOpenidQuery()),
+            [new Response(200, [], "is_valid:false\n")]
+        );
+
+        $this->expectException(OpenIDValidationException::class);
+
+        $provider->user();
+    }
+
+    public function test_validate_throws_when_a_required_param_is_missing(): void
+    {
+        $query = $this->validOpenidQuery();
+        unset($query['openid.sig']);
+
+        $provider = $this->makeProvider($this->makeRequest($query));
+
+        $this->expectException(OpenIDValidationException::class);
+        $this->expectExceptionMessage('critical openid parameter is missing');
+
+        $provider->validate();
+    }
+
+    public function test_parse_results_splits_the_key_value_body(): void
+    {
+        $parsed = $this->makeProvider()->parseResults('ns:'.Provider::OPENID_NS."\nis_valid:true\n");
+
+        $this->assertSame('true', $parsed['is_valid']);
+        $this->assertSame(Provider::OPENID_NS, $parsed['ns']);
+    }
+
+    public function test_parse_steam_id_extracts_the_id_from_the_claimed_id(): void
+    {
+        $provider = $this->makeProvider($this->makeRequest($this->validOpenidQuery()));
+        $provider->parseSteamID();
+
+        $this->assertSame(self::STEAM_ID, $provider->steamId);
+    }
+
+    public function test_parse_steam_id_falls_back_to_zero_for_an_unexpected_claimed_id(): void
+    {
+        $query = $this->validOpenidQuery();
+        $query['openid.claimed_id'] = 'https://example.com/not-a-steam-id';
+
+        $provider = $this->makeProvider($this->makeRequest($query));
+        $provider->parseSteamID();
+
+        $this->assertSame(0, $provider->steamId);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function validOpenidQuery(): array
+    {
+        return [
+            'openid.assoc_handle' => '1234567890',
+            'openid.signed'       => 'signed,claimed_id',
+            'openid.sig'          => 'signature',
+            'openid.return_to'    => self::REDIRECT_URI,
+            'openid.claimed_id'   => 'https://steamcommunity.com/openid/id/'.self::STEAM_ID,
+        ];
+    }
+}

--- a/tests/Steam/__snapshots__/SteamProviderTest__test_redirect_builds_an_openid_checkid_setup_url__1.json
+++ b/tests/Steam/__snapshots__/SteamProviderTest__test_redirect_builds_an_openid_checkid_setup_url__1.json
@@ -1,0 +1,8 @@
+{
+    "openid_ns": "http://specs.openid.net/auth/2.0",
+    "openid_mode": "checkid_setup",
+    "openid_return_to": "https://example.com/auth/callback",
+    "openid_realm": "https://example.com",
+    "openid_identity": "http://specs.openid.net/auth/2.0/identifier_select",
+    "openid_claimed_id": "http://specs.openid.net/auth/2.0/identifier_select"
+}

--- a/tests/Steam/__snapshots__/SteamProviderTest__test_user_maps_the_steam_player_summary__1.json
+++ b/tests/Steam/__snapshots__/SteamProviderTest__test_user_maps_the_steam_player_summary__1.json
@@ -1,0 +1,7 @@
+{
+    "id": "76561197960287930",
+    "nickname": "Robin",
+    "name": "Robin Walker",
+    "email": null,
+    "avatar": "https://avatars.steamstatic.com/f1dd60a188883caf82d0cbfccfe6aba0af1732d4_medium.jpg"
+}

--- a/tests/Steam/fixtures/player.json
+++ b/tests/Steam/fixtures/player.json
@@ -1,0 +1,23 @@
+{
+    "response": {
+        "players": [
+            {
+                "steamid": "76561197960287930",
+                "communityvisibilitystate": 3,
+                "profilestate": 1,
+                "personaname": "Robin",
+                "profileurl": "https://steamcommunity.com/id/robinwalker/",
+                "avatar": "https://avatars.steamstatic.com/f1dd60a188883caf82d0cbfccfe6aba0af1732d4.jpg",
+                "avatarmedium": "https://avatars.steamstatic.com/f1dd60a188883caf82d0cbfccfe6aba0af1732d4_medium.jpg",
+                "avatarfull": "https://avatars.steamstatic.com/f1dd60a188883caf82d0cbfccfe6aba0af1732d4_full.jpg",
+                "personastate": 0,
+                "realname": "Robin Walker",
+                "primaryclanid": "103582791429521412",
+                "timecreated": 1063407589,
+                "personastateflags": 0,
+                "loccountrycode": "US",
+                "locstatecode": "WA"
+            }
+        ]
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -77,7 +77,13 @@ abstract class TestCase extends BaseTestCase
             $this->fail("Missing fixture: {$path}");
         }
 
-        return file_get_contents($path);
+        $contents = @file_get_contents($path);
+
+        if ($contents === false) {
+            $this->fail("Unreadable fixture: {$path}");
+        }
+
+        return $contents;
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace SocialiteProviders\Tests;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
+
+abstract class TestCase extends BaseTestCase
+{
+    protected const CLIENT_ID = 'client-id';
+
+    protected const CLIENT_SECRET = 'client-secret';
+
+    protected const REDIRECT_URI = 'https://example.com/auth/callback';
+
+    /**
+     * The provider class under test.
+     */
+    abstract protected function provider(): string;
+
+    /**
+     * Build the provider, optionally with a request and queued HTTP responses.
+     *
+     * @param  array<int, Response>  $responses
+     */
+    protected function makeProvider(?Request $request = null, array $responses = []): AbstractProvider
+    {
+        $class = $this->provider();
+
+        $provider = new $class(
+            $request ?? $this->makeRequest(),
+            static::CLIENT_ID,
+            static::CLIENT_SECRET,
+            static::REDIRECT_URI
+        );
+
+        if ($responses !== []) {
+            $provider->setHttpClient($this->makeHttpClient($responses));
+        }
+
+        return $provider;
+    }
+
+    /**
+     * @param  array<string, mixed>  $query
+     */
+    protected function makeRequest(array $query = [], ?string $uri = null): Request
+    {
+        return Request::create($uri ?? static::REDIRECT_URI, 'GET', $query);
+    }
+
+    /**
+     * A Guzzle client that replays the given responses instead of hitting the network.
+     *
+     * @param  array<int, Response>  $responses
+     */
+    protected function makeHttpClient(array $responses): Client
+    {
+        return new Client([
+            'handler' => HandlerStack::create(new MockHandler($responses)),
+        ]);
+    }
+
+    /**
+     * Read a fixture from the provider's own tests/<Provider>/fixtures directory.
+     */
+    protected function fixture(string $name): string
+    {
+        $path = $this->fixturePath($name);
+
+        if (! is_file($path)) {
+            $this->fail("Missing fixture: {$path}");
+        }
+
+        return file_get_contents($path);
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    protected function fixtureJson(string $name): array
+    {
+        return json_decode($this->fixture($name), true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    protected function fixturePath(string $name): string
+    {
+        return dirname((new \ReflectionClass($this))->getFileName()).'/fixtures/'.$name;
+    }
+
+    /**
+     * Parse a URL's query string into an array.
+     *
+     * @return array<string, string>
+     */
+    protected function queryParams(string $url): array
+    {
+        parse_str((string) parse_url($url, PHP_URL_QUERY), $params);
+
+        return $params;
+    }
+}

--- a/tools/changed-providers.php
+++ b/tools/changed-providers.php
@@ -69,7 +69,14 @@ $output = shell_exec(sprintf('git -C %s diff --name-only %s', escapeshellarg($ro
 $changedFiles = array_filter(explode("\n", trim($output ?? '')));
 
 // Changes to shared files can affect every provider.
-$global = ['composer.json', 'composer.lock', 'phpunit.xml.dist', 'tests/TestCase.php', '.github/workflows/test.yml'];
+$global = [
+    'composer.json',
+    'composer.lock',
+    'phpunit.xml.dist',
+    'tests/TestCase.php',
+    '.github/workflows/test.yml',
+    'tools/changed-providers.php',
+];
 
 foreach ($changedFiles as $file) {
     if (in_array($file, $global, true)) {

--- a/tools/changed-providers.php
+++ b/tools/changed-providers.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Detect which providers need their test suite run for a diff range.
+ *
+ * Mirrors the change detection in release.php, but works across a range (a PR is
+ * many commits) and only emits providers that actually have a suite under tests/.
+ * Outputs a JSON array for use as a GitHub Actions matrix.
+ *
+ * Usage: php tools/changed-providers.php <base_ref> [head_ref]
+ *
+ * Environment overrides (for testing):
+ *   TEST_PACKAGES - Comma-separated list of packages (skip change detection)
+ */
+$base = $argv[1] ?? null;
+$head = $argv[2] ?? 'HEAD';
+
+if (empty($base)) {
+    echo "Usage: changed-providers.php <base_ref> [head_ref]\n";
+    exit(1);
+}
+
+$root = dirname(__DIR__);
+
+/**
+ * Providers are only testable if someone has written tests for them.
+ */
+$hasTests = static fn (string $package): bool => is_dir($root.'/tests/'.$package);
+
+$testable = static function (array $packages) use ($root, $hasTests): array {
+    return array_values(array_filter($packages, static function (string $package) use ($root, $hasTests): bool {
+        // Skip providers deleted in this range - there is nothing left to test.
+        return is_dir($root.'/src/'.$package) && $hasTests($package);
+    }));
+};
+
+$allProviders = static function () use ($root): array {
+    return array_map('basename', glob($root.'/tests/*', GLOB_ONLYDIR));
+};
+
+/**
+ * GitHub caps a matrix at 256 jobs per run. Once that many providers have tests,
+ * a full run has to collapse into a single job rather than fanning out.
+ *
+ * @see https://docs.github.com/en/actions/reference/limits
+ */
+$emit = static function (array $packages): void {
+    if (count($packages) > 256) {
+        echo json_encode(['all'])."\n";
+
+        return;
+    }
+
+    echo json_encode($packages)."\n";
+};
+
+if ($packages = getenv('TEST_PACKAGES')) {
+    $emit($testable(array_map('trim', explode(',', $packages))));
+    exit(0);
+}
+
+// Accept either "base head" or a single "base...head" range.
+$range = str_contains($base, '..')
+    ? escapeshellarg($base)
+    : escapeshellarg($base).' '.escapeshellarg($head);
+
+$output = shell_exec(sprintf('git -C %s diff --name-only %s', escapeshellarg($root), $range));
+
+$changedFiles = array_filter(explode("\n", trim($output ?? '')));
+
+// Changes to shared files can affect every provider.
+$global = ['composer.json', 'composer.lock', 'phpunit.xml.dist', 'tests/TestCase.php', '.github/workflows/test.yml'];
+
+foreach ($changedFiles as $file) {
+    if (in_array($file, $global, true)) {
+        $emit($testable($allProviders()));
+        exit(0);
+    }
+}
+
+$changedPackages = [];
+
+foreach ($changedFiles as $file) {
+    // A change to either the provider or its tests should run that suite.
+    if (str_starts_with($file, 'src/') || str_starts_with($file, 'tests/')) {
+        $parts = explode('/', $file);
+
+        if (isset($parts[1])) {
+            $changedPackages[$parts[1]] = true;
+        }
+    }
+}
+
+$emit($testable(array_keys($changedPackages)));


### PR DESCRIPTION
Adds automated tests to the repo, wired into GitHub Actions so only the providers touched in a PR get their suites run.

## How it works

`tools/changed-providers.php` mirrors the change detection already in `release.php`, with two differences: it works across a diff range (a PR is many commits, not one), and it only emits providers that actually have a suite under `tests/`. The workflow feeds that JSON into a matrix, so a one-provider PR runs one job rather than the full set.

Of the last 100 commits on master, 78 touched exactly one provider — so in practice this is a single job almost every time.

## Where tests live

`tools/split.sh` splits on `--prefix="src/$package"`, so anything under `src/Foo/` ships to the split repo and into the published dist. Tests therefore live in a root-level `tests/<Provider>/`, which never splits. Published packages are byte-identical to before this PR.

Provider detection is `is_dir("tests/$provider")` rather than a `require-dev` entry, so no provider `composer.json` needs to change — none of the 275 has a `require-dev` block today, and adding one would push a dev dependency into every published package.

## Dependencies

The root autoload (`"SocialiteProviders\\": "src/"`) already resolves every provider class, so most providers need only the root install. Four declare their own third-party deps (Apple, Saml2, Ovh, Microsoft); for those the test job installs the package's own requirements, so they're tested against what users actually get rather than the root vendor tree.

## Steam as the first suite

Steam is covered as the worked example — it's OpenID rather than stock OAuth2, so it exercises the harness where it's weakest. Includes a regression test for the underscore-separated openid keys fixed in #1469; reverting that fix fails 4 of the 10 tests.

## Notes

- **Ovh will fail CI.** `ovh/ovh ^2.0` requires `guzzle ^6.0`, which Composer now blocks over security advisories, so `src/Ovh` cannot install standalone. That's a pre-existing packaging bug — surfacing it is the point. It has no tests yet so it won't run today, but it'll need fixing before Ovh can be covered.
- PHPUnit is pinned `^13.3` (latest) rather than matching `manager`'s `^9.0`, which is EOL and predates PHP 8.5.
- Snapshots use `spatie/phpunit-snapshot-assertions`; regenerate with `-d --update-snapshots`.
- The matrix collapses to a single job above 256 providers, since that's GitHub's hard per-run cap.

## Adding tests for another provider

Create `tests/<Provider>/`, extend `SocialiteProviders\Tests\TestCase`, and implement `provider()`. It joins CI automatically — no workflow change.
