### PR TITLE
feat: add Frappe provider

### DIFF
--- a/src/Frappe/FrappeExtendSocialite.php
+++ b/src/Frappe/FrappeExtendSocialite.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SocialiteProviders\Frappe;
+
+use SocialiteProviders\Manager\SocialiteWasCalled;
+
+class FrappeExtendSocialite
+{
+    public function handle(SocialiteWasCalled $socialiteWasCalled): void
+    {
+        $socialiteWasCalled->extendSocialite('frappe', Provider::class);
+    }
+}

--- a/src/Frappe/Provider.php
+++ b/src/Frappe/Provider.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace SocialiteProviders\Frappe;
+
+use GuzzleHttp\RequestOptions;
+use Illuminate\Support\Arr;
+use InvalidArgumentException;
+use Psr\Http\Message\ResponseInterface;
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
+use SocialiteProviders\Manager\OAuth2\User;
+
+class Provider extends AbstractProvider
+{
+    public const string IDENTIFIER = 'FRAPPE';
+
+    protected $scopeSeparator = ' ';
+
+    protected $scopes = ['openid'];
+
+    public static function additionalConfigKeys(): array
+    {
+        return ['base_url', 'fields'];
+    }
+
+    /** {@inheritDoc} */
+    public function getScopes()
+    {
+        return array_values(array_unique(array_merge(
+            $this->scopes,
+            $this->getConfig('fields', []) ? ['all'] : []
+        )));
+    }
+
+    public function getLogoutUrl(): string
+    {
+        return $this->getBaseUrl().'/api/method/logout';
+    }
+
+    public function revokeToken(string $token): ResponseInterface
+    {
+        return $this->getHttpClient()->post(
+            $this->getBaseUrl().'/api/method/frappe.integrations.oauth2.revoke_token',
+            [RequestOptions::FORM_PARAMS => ['token' => $token]]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function refreshToken($refreshToken)
+    {
+        $response = $this->getHttpClient()->post($this->getTokenUrl(), [
+            RequestOptions::FORM_PARAMS => [
+                'grant_type'    => 'refresh_token',
+                'refresh_token' => $refreshToken,
+                'client_id'     => $this->clientId,
+                'client_secret' => $this->clientSecret,
+            ],
+        ]);
+
+        return json_decode((string) $response->getBody(), true);
+    }
+
+    protected function getTokenUrl(): string
+    {
+        return $this->getBaseUrl().'/api/method/frappe.integrations.oauth2.get_token';
+    }
+
+    protected function getAuthUrl($state): string
+    {
+        return $this->buildAuthUrlFromBase(
+            $this->getBaseUrl().'/api/method/frappe.integrations.oauth2.authorize',
+            $state
+        );
+    }
+
+    /**
+     * The root URL of the Frappe / ERPNext site, e.g. https://erp.example.com.
+     */
+    protected function getBaseUrl(): string
+    {
+        $baseUrl = $this->getConfig('base_url');
+
+        if ($baseUrl === null) {
+            throw new InvalidArgumentException('Missing Frappe "base_url" configuration.');
+        }
+
+        return rtrim($baseUrl, '/');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByToken($token)
+    {
+        $response = $this->getHttpClient()->get(
+            $this->getBaseUrl().'/api/method/frappe.integrations.oauth2.openid_profile',
+            [
+                RequestOptions::HEADERS => [
+                    'Authorization' => 'Bearer '.$token,
+                ],
+            ]
+        );
+
+        $user = json_decode((string) $response->getBody(), true);
+        $fields = $this->getConfig('fields', []);
+
+        if ($fields === []) {
+            return $user;
+        }
+
+        $response = $this->getHttpClient()->get($this->getBaseUrl().'/api/resource/User', [
+            RequestOptions::HEADERS => [
+                'Accept'        => 'application/json',
+                'Authorization' => 'Bearer '.$token,
+            ],
+            RequestOptions::QUERY => [
+                'fields'            => json_encode($fields),
+                'filters'           => json_encode([['name', '=', Arr::get($user, 'email')]]),
+                'limit_page_length' => 1,
+            ],
+        ]);
+
+        $fields = json_decode((string) $response->getBody(), true)['data'][0] ?? [];
+
+        return array_merge($fields, $user);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return (new User)->setRaw($user)->map([
+            'id'          => Arr::get($user, 'sub') ?? Arr::get($user, 'email'),
+            'nickname'    => null,
+            'name'        => Arr::get($user, 'name'),
+            'email'       => Arr::get($user, 'email'),
+            'avatar'      => Arr::get($user, 'picture'),
+            'given_name'  => Arr::get($user, 'given_name'),
+            'family_name' => Arr::get($user, 'family_name'),
+            'roles'       => Arr::get($user, 'roles'),
+        ]);
+    }
+}

--- a/src/Frappe/Provider.php
+++ b/src/Frappe/Provider.php
@@ -22,7 +22,6 @@ class Provider extends AbstractProvider
         return ['base_url', 'fields'];
     }
 
-    /** {@inheritDoc} */
     public function getScopes()
     {
         return array_values(array_unique(array_merge(
@@ -44,9 +43,6 @@ class Provider extends AbstractProvider
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function refreshToken($refreshToken)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
@@ -88,9 +84,6 @@ class Provider extends AbstractProvider
         return rtrim($baseUrl, '/');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getUserByToken($token)
     {
         $response = $this->getHttpClient()->get(
@@ -121,14 +114,11 @@ class Provider extends AbstractProvider
             ],
         ]);
 
-        $fields = json_decode((string) $response->getBody(), true)['data'][0] ?? [];
+        $extra = json_decode((string) $response->getBody(), true)['data'][0] ?? [];
 
-        return array_merge($fields, $user);
+        return array_merge($extra, $user);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function mapUserToObject(array $user)
     {
         return (new User)->setRaw($user)->map([

--- a/src/Frappe/README.md
+++ b/src/Frappe/README.md
@@ -1,0 +1,145 @@
+---
+category: Business
+name: Frappe / ERPNext
+---
+
+# Frappe / ERPNext
+
+Use any Frappe-based site, including ERPNext, Frappe HR, LMS, Helpdesk, Books,
+and custom apps, as an OAuth2 / OpenID Connect provider.
+
+```bash
+composer require socialiteproviders/frappe
+```
+
+## Installation & Basic Usage
+
+Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
+then follow the provider-specific instructions below.
+
+### Create an OAuth Client in Frappe / ERPNext
+
+See Frappe's official [How to setup OAuth Client](https://docs.frappe.io/framework/user/en/guides/integration/how_to_set_up_oauth#add-a-client-app)
+guide, then set the redirect URI to your callback (e.g.
+`https://your-app.test/auth/frappe/callback`) and the scopes to `openid`.
+Use `openid all` when requesting additional User fields or REST API access.
+After saving, use the generated App Client ID and App Client Secret below.
+
+### Add configuration to `config/services.php`
+
+```php
+'frappe' => [
+  'client_id' => env('FRAPPE_CLIENT_ID'),
+  'client_secret' => env('FRAPPE_CLIENT_SECRET'),
+  'redirect' => env('FRAPPE_REDIRECT_URI'),
+  'base_url' => env('FRAPPE_BASE_URL'), // Also used for logout and token revocation
+],
+```
+
+Set the site root, without an API path, in `.env`:
+
+```dotenv
+FRAPPE_CLIENT_ID=your-client-id
+FRAPPE_CLIENT_SECRET=your-client-secret
+FRAPPE_REDIRECT_URI=https://your-app.test/auth/frappe/callback
+FRAPPE_BASE_URL=https://erp.example.com
+```
+
+### Add provider event listener
+
+#### Laravel 11+
+
+Add the listener in your `AppServiceProvider` `boot` method:
+
+```php
+use Illuminate\Support\Facades\Event;
+
+Event::listen(function (\SocialiteProviders\Manager\SocialiteWasCalled $event) {
+    $event->extendSocialite('frappe', \SocialiteProviders\Frappe\Provider::class);
+});
+```
+
+<details>
+<summary>Laravel 10 or below</summary>
+
+Add the listener to the `listen` array in `app/Providers/EventServiceProvider.php`:
+
+```php
+protected $listen = [
+    \SocialiteProviders\Manager\SocialiteWasCalled::class => [
+        \SocialiteProviders\Frappe\FrappeExtendSocialite::class.'@handle',
+    ],
+];
+```
+</details>
+
+### Usage
+
+```php
+return Socialite::driver('frappe')->redirect();
+```
+
+The default `openid` scope is enough for login and profile data. To access the
+Frappe REST API too:
+
+```php
+return Socialite::driver('frappe')
+    ->scopes(['openid', 'all'])
+    ->redirect();
+```
+
+### Additional User fields
+
+Add the field names to the provider's configuration:
+
+```php
+'frappe' => [
+  // ...
+  'fields' => [
+    'custom_department',
+    'custom_employee_number',
+  ],
+],
+```
+
+When configured, the provider automatically requests the `all` scope and
+fetches those fields from the authenticated Frappe User record. The OAuth
+Client in Frappe must allow the `all` scope.
+
+Additional fields are available in Socialite's raw user array:
+
+```php
+$user = Socialite::driver('frappe')->user();
+
+$department = $user->getRaw()['custom_department'] ?? null;
+```
+
+### Logout
+
+No extra configuration is required; the logout and revocation endpoints are
+derived from `base_url`.
+
+Revoke the OAuth access token and log out of your Laravel app:
+
+```php
+Socialite::driver('frappe')->revokeToken($user->token);
+Auth::logout();
+```
+
+To also end the user's Frappe browser session, submit a `POST` form to
+`Socialite::driver('frappe')->getLogoutUrl()`. Do not redirect to this URL;
+current Frappe versions require `POST`. See Frappe's official
+[logout](https://docs.frappe.io/framework/user/en/guides/integration/rest_api/simple_authentication#get-api-method-logout)
+and [token revocation](https://docs.frappe.io/framework/user/en/guides/integration/rest_api/oauth-2#revoke-token-endpoint)
+documentation.
+
+### Returned User fields
+
+- `id` (OpenID `sub`, falling back to `email`)
+- `name`
+- `email`
+- `avatar`
+- `given_name`
+- `family_name`
+- `roles`
+- Any configured `fields`, via `getRaw()`

--- a/src/Frappe/README.md
+++ b/src/Frappe/README.md
@@ -126,9 +126,15 @@ Socialite::driver('frappe')->revokeToken($user->token);
 Auth::logout();
 ```
 
-To also end the user's Frappe browser session, submit a `POST` form to
-`Socialite::driver('frappe')->getLogoutUrl()`. Do not redirect to this URL;
-current Frappe versions require `POST`. See Frappe's official
+To also end the user's Frappe browser session, send the user to
+`Socialite::driver('frappe')->getLogoutUrl()`.
+
+Frappe v15 and earlier accept a `GET`, so a redirect works. Frappe v16
+[restricted this endpoint to `POST`](https://github.com/frappe/frappe/commit/9c6594b47c04fd17095dd9058d2b2792dce8de26),
+and `POST` is CSRF-checked; submit a form carrying the session's `csrf_token`,
+or list your app's origin in the site's `allowed_referrers`.
+
+See Frappe's official
 [logout](https://docs.frappe.io/framework/user/en/guides/integration/rest_api/simple_authentication#get-api-method-logout)
 and [token revocation](https://docs.frappe.io/framework/user/en/guides/integration/rest_api/oauth-2#revoke-token-endpoint)
 documentation.

--- a/src/Frappe/composer.json
+++ b/src/Frappe/composer.json
@@ -23,7 +23,7 @@
         "docs": "https://socialiteproviders.com/frappe"
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.3",
         "socialiteproviders/manager": "^4.4"
     },
     "autoload": {

--- a/src/Frappe/composer.json
+++ b/src/Frappe/composer.json
@@ -1,0 +1,34 @@
+{
+    "name": "socialiteproviders/frappe",
+    "description": "Frappe / ERPNext OAuth2 Provider for Laravel Socialite",
+    "license": "MIT",
+    "keywords": [
+        "frappe",
+        "erpnext",
+        "oidc",
+        "laravel",
+        "oauth",
+        "provider",
+        "socialite"
+    ],
+    "authors": [
+        {
+            "name": "Ali Youssef Kayed",
+            "email": "3likayed@gmail.com"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/socialiteproviders/providers/issues",
+        "source": "https://github.com/socialiteproviders/providers",
+        "docs": "https://socialiteproviders.com/frappe"
+    },
+    "require": {
+        "php": "^8.0",
+        "socialiteproviders/manager": "^4.4"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialiteProviders\\Frappe\\": ""
+        }
+    }
+}

--- a/tests/Frappe/FrappeProviderTest.php
+++ b/tests/Frappe/FrappeProviderTest.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace SocialiteProviders\Tests\Frappe;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Http\Request;
+use SocialiteProviders\Frappe\Provider;
+use SocialiteProviders\Manager\Config;
+use SocialiteProviders\Tests\TestCase;
+
+class FrappeProviderTest extends TestCase
+{
+    private const BASE_URL = 'https://erp.example.com';
+
+    protected function provider(): string
+    {
+        return Provider::class;
+    }
+
+    /**
+     * @param  array<int, Response>  $responses
+     */
+    private function configured(?Request $request = null, array $responses = [], array $fields = []): Provider
+    {
+        /** @var Provider $provider */
+        $provider = $this->makeProvider($request, $responses);
+
+        $provider->setConfig(new Config(
+            static::CLIENT_ID,
+            static::CLIENT_SECRET,
+            static::REDIRECT_URI,
+            [
+                'base_url' => self::BASE_URL,
+                'fields'   => $fields,
+            ]
+        ));
+
+        return $provider;
+    }
+
+    public function test_redirect_targets_the_frappe_authorize_endpoint(): void
+    {
+        $url = $this->configured()->stateless()->redirect()->getTargetUrl();
+
+        $this->assertStringStartsWith(
+            self::BASE_URL.'/api/method/frappe.integrations.oauth2.authorize',
+            $url
+        );
+
+        $params = $this->queryParams($url);
+
+        $this->assertSame(static::CLIENT_ID, $params['client_id']);
+        $this->assertSame(static::REDIRECT_URI, $params['redirect_uri']);
+        $this->assertSame('code', $params['response_type']);
+        $this->assertSame('openid', $params['scope']);
+    }
+
+    public function test_user_maps_the_openid_profile(): void
+    {
+        $provider = $this->configured(
+            $this->makeRequest(['code' => 'auth-code', 'state' => 'state']),
+            [
+                new Response(200, ['Content-Type' => 'application/json'], (string) json_encode([
+                    'access_token'  => 'access-token',
+                    'refresh_token' => 'refresh-token',
+                    'expires_in'    => 3600,
+                    'token_type'    => 'Bearer',
+                ])),
+                new Response(200, ['Content-Type' => 'application/json'], $this->fixture('user.json')),
+            ]
+        );
+
+        $user = $provider->stateless()->user();
+
+        $this->assertSame('e1b9c2d3f4a5b6c7', $user->getId());
+        $this->assertSame('Ada Lovelace', $user->getName());
+        $this->assertSame('ada@example.com', $user->getEmail());
+        $this->assertSame(self::BASE_URL.'/files/ada.png', $user->getAvatar());
+        $this->assertSame('access-token', $user->token);
+        $this->assertSame(['System Manager', 'Sales User'], $user->getRaw()['roles']);
+    }
+
+    public function test_configured_fields_are_requested_and_added_to_the_raw_user(): void
+    {
+        $fields = ['custom_department', 'custom_employee_number'];
+        $redirect = $this->configured(null, [], $fields)->stateless()->redirect()->getTargetUrl();
+
+        $this->assertSame('openid all', $this->queryParams($redirect)['scope']);
+
+        $provider = $this->configured(
+            $this->makeRequest(['code' => 'auth-code', 'state' => 'state']),
+            [
+                new Response(200, ['Content-Type' => 'application/json'], (string) json_encode([
+                    'access_token' => 'access-token',
+                ])),
+                new Response(200, ['Content-Type' => 'application/json'], $this->fixture('user.json')),
+                new Response(200, ['Content-Type' => 'application/json'], (string) json_encode([
+                    'data' => [[
+                        'custom_department'      => 'Research',
+                        'custom_employee_number' => 'EMP-001',
+                    ]],
+                ])),
+            ],
+            $fields
+        );
+
+        $raw = $provider->stateless()->user()->getRaw();
+
+        $this->assertSame('Research', $raw['custom_department']);
+        $this->assertSame('EMP-001', $raw['custom_employee_number']);
+    }
+
+    public function test_id_falls_back_to_email_when_sub_is_missing(): void
+    {
+        $provider = $this->configured(
+            $this->makeRequest(['code' => 'auth-code', 'state' => 'state']),
+            [
+                new Response(200, ['Content-Type' => 'application/json'], (string) json_encode([
+                    'access_token' => 'access-token',
+                ])),
+                new Response(200, ['Content-Type' => 'application/json'], (string) json_encode([
+                    'name'  => 'No Sub',
+                    'email' => 'nosub@example.com',
+                ])),
+            ]
+        );
+
+        $this->assertSame('nosub@example.com', $provider->stateless()->user()->getId());
+    }
+
+    public function test_user_can_be_fetched_from_an_access_token(): void
+    {
+        $provider = $this->configured(null, [
+            new Response(200, ['Content-Type' => 'application/json'], $this->fixture('user.json')),
+        ]);
+
+        $user = $provider->userFromToken('access-token');
+
+        $this->assertSame('e1b9c2d3f4a5b6c7', $user->getId());
+        $this->assertSame('access-token', $user->token);
+    }
+
+    public function test_refresh_token_uses_the_frappe_token_endpoint(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json'], (string) json_encode([
+                'access_token' => 'refreshed-access-token',
+            ])),
+        ]);
+        $provider = $this->configured();
+        $provider->setHttpClient(new Client(['handler' => HandlerStack::create($mock)]));
+
+        $response = $provider->refreshToken('refresh-token');
+        $request = $mock->getLastRequest();
+
+        $this->assertSame('refreshed-access-token', $response['access_token']);
+        $this->assertSame(self::BASE_URL.'/api/method/frappe.integrations.oauth2.get_token', (string) $request?->getUri());
+
+        parse_str((string) $request?->getBody(), $body);
+        $this->assertSame('refresh_token', $body['grant_type']);
+        $this->assertSame('refresh-token', $body['refresh_token']);
+    }
+
+    public function test_logout_url_and_token_revocation_use_frappe_endpoints(): void
+    {
+        $mock = new MockHandler([new Response(200)]);
+        $provider = $this->configured();
+        $provider->setHttpClient(new Client(['handler' => HandlerStack::create($mock)]));
+
+        $this->assertSame(self::BASE_URL.'/api/method/logout', $provider->getLogoutUrl());
+        $this->assertSame(200, $provider->revokeToken('access-token')->getStatusCode());
+
+        $request = $mock->getLastRequest();
+        $this->assertSame('POST', $request?->getMethod());
+        $this->assertSame(
+            self::BASE_URL.'/api/method/frappe.integrations.oauth2.revoke_token',
+            (string) $request?->getUri()
+        );
+
+        parse_str((string) $request?->getBody(), $body);
+        $this->assertSame('access-token', $body['token']);
+    }
+}

--- a/tests/Frappe/fixtures/user.json
+++ b/tests/Frappe/fixtures/user.json
@@ -1,0 +1,10 @@
+{
+    "sub": "e1b9c2d3f4a5b6c7",
+    "name": "Ada Lovelace",
+    "given_name": "Ada",
+    "family_name": "Lovelace",
+    "email": "ada@example.com",
+    "picture": "https://erp.example.com/files/ada.png",
+    "roles": ["System Manager", "Sales User"],
+    "iss": "https://erp.example.com"
+}


### PR DESCRIPTION
## Summary

  Adding Laravel Socialite provider for Frappe-based applications, including ERPNext, Frappe HR, LMS, Helpdesk, Books, and custom Frappe apps.

  ## Changes

  - Add OAuth 2.0 / OpenID Connect authorization
  - Support configurable Frappe instances through `base_url`
  - Exchange authorization codes for access and refresh tokens
  - Fetch and map the authenticated user profile
  - Support `userFromToken()` and token refresh
  - Use `openid` as the default scope
  - Support custom User fields through the `fields` configuration
  - Automatically request the `all` scope when custom fields are configured
  - Add OAuth token revocation through `revokeToken()`
  - Add the Frappe browser logout URL through `getLogoutUrl()`
  - Document installation, configuration, custom fields, logout, and token revocation
  - Add provider tests and user fixtures

  ## Testing

  - OAuth login tested against a live Frappe / ERPNext instance
  - User profile and custom field retrieval tested
  - Access-token user fetching tested
  - Refresh-token flow tested
  - Token revocation and browser logout endpoint tested
  - Full test suite passes
  - Laravel Pint passes