### PR TITLE
feat: add OpenID Connect provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,8 @@
     "require-dev": {
         "composer/semver": "^3.0",
         "guzzlehttp/guzzle": "^7.9",
-        "illuminate/http": "^12.0",
-        "illuminate/session": "^12.0",
         "laravel/pint": "^1.18",
+        "orchestra/testbench": "^11.0",
         "mockery/mockery": "^1.6",
         "php-parallel-lint/php-console-highlighter": "^1.0",
         "php-parallel-lint/php-parallel-lint": "^1.4",

--- a/split-overrides.json
+++ b/split-overrides.json
@@ -11,7 +11,6 @@
     "LaravelPassport": "Laravel-Passport",
     "Live": "Microsoft-Live",
     "MediaCube": "Mediacube",
-    "OpenIDConnect": "openid-connect",
     "PayPalSandbox": "PayPal-Sandbox",
     "TeamService": "Microsoft-TeamService",
     "ThirtySevenSignals": "37Signals",

--- a/split-overrides.json
+++ b/split-overrides.json
@@ -11,6 +11,7 @@
     "LaravelPassport": "Laravel-Passport",
     "Live": "Microsoft-Live",
     "MediaCube": "Mediacube",
+    "OpenIDConnect": "openid-connect",
     "PayPalSandbox": "PayPal-Sandbox",
     "TeamService": "Microsoft-TeamService",
     "ThirtySevenSignals": "37Signals",

--- a/src/OpenIDConnect/IssuerValidators/DefaultIssuerValidator.php
+++ b/src/OpenIDConnect/IssuerValidators/DefaultIssuerValidator.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SocialiteProviders\OpenIDConnect\IssuerValidators;
+
+use stdClass;
+
+/**
+ * Strict equality, as OIDC Core 3.1.3.7 step 2 requires. Anything looser
+ * belongs in a provider-specific validator.
+ */
+class DefaultIssuerValidator implements IssuerValidator
+{
+    public function validate(string $expectedIssuer, stdClass $payload): bool
+    {
+        $iss = $payload->iss ?? null;
+
+        return is_string($iss) && $iss !== '' && $iss === $expectedIssuer;
+    }
+}

--- a/src/OpenIDConnect/IssuerValidators/EntraIssuerValidator.php
+++ b/src/OpenIDConnect/IssuerValidators/EntraIssuerValidator.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace SocialiteProviders\OpenIDConnect\IssuerValidators;
+
+use stdClass;
+
+/**
+ * Entra ID multi-tenant discovery advertises the issuer as a literal
+ * `https://login.microsoftonline.com/{tenantid}/v2.0` template, so the
+ * token's `tid` claim is substituted into the placeholder (case-insensitive:
+ * both {tenantid} and {tenantId} appear in the wild) before comparing
+ * strictly. Without a placeholder this is a plain strict comparison.
+ */
+class EntraIssuerValidator extends DefaultIssuerValidator
+{
+    public function validate(string $expectedIssuer, stdClass $payload): bool
+    {
+        $tid = $payload->tid ?? null;
+
+        if (is_string($tid) && $tid !== '') {
+            $expectedIssuer = preg_replace('/\{tenantid\}/i', $tid, $expectedIssuer);
+        }
+
+        return parent::validate($expectedIssuer, $payload);
+    }
+}

--- a/src/OpenIDConnect/IssuerValidators/IssuerValidator.php
+++ b/src/OpenIDConnect/IssuerValidators/IssuerValidator.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SocialiteProviders\OpenIDConnect\IssuerValidators;
+
+use stdClass;
+
+/**
+ * Validates a token's `iss` claim against the issuer the RP expects.
+ * Receives the full payload so other claims can inform the decision.
+ */
+interface IssuerValidator
+{
+    public function validate(string $expectedIssuer, stdClass $payload): bool;
+}

--- a/src/OpenIDConnect/OpenIDConnectExtendSocialite.php
+++ b/src/OpenIDConnect/OpenIDConnectExtendSocialite.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SocialiteProviders\OpenIDConnect;
+
+use SocialiteProviders\Manager\SocialiteWasCalled;
+
+/**
+ * Manual registration of the `openidconnect` driver, for apps that wire
+ * SocialiteProviders listeners themselves instead of using this package's
+ * service provider.
+ */
+class OpenIDConnectExtendSocialite
+{
+    public function handle(SocialiteWasCalled $socialiteWasCalled): void
+    {
+        $socialiteWasCalled->extendSocialite('openidconnect', Provider::class);
+    }
+}

--- a/src/OpenIDConnect/OpenIDConnectServiceProvider.php
+++ b/src/OpenIDConnect/OpenIDConnectServiceProvider.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace SocialiteProviders\OpenIDConnect;
+
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\ServiceProvider;
+use InvalidArgumentException;
+use SocialiteProviders\Manager\SocialiteWasCalled;
+use SocialiteProviders\OpenIDConnect\Providers\Auth0Provider;
+use SocialiteProviders\OpenIDConnect\Providers\EntraProvider;
+use SocialiteProviders\OpenIDConnect\Providers\GoogleProvider;
+use SocialiteProviders\OpenIDConnect\Providers\KeycloakProvider;
+use SocialiteProviders\OpenIDConnect\Providers\OktaProvider;
+
+/**
+ * Registers each config/oidc.php connection as its own Socialite driver
+ * named "{prefix}{connection}", mirroring its config into services.* where
+ * the manager's ConfigRetriever looks it up. A plain services.openidconnect
+ * block remains as a single-connection fallback.
+ */
+class OpenIDConnectServiceProvider extends ServiceProvider
+{
+    /** @var array<string, class-string<Provider>> */
+    protected const PROVIDERS = [
+        'entra'    => EntraProvider::class,
+        'keycloak' => KeycloakProvider::class,
+        'auth0'    => Auth0Provider::class,
+        'okta'     => OktaProvider::class,
+        'google'   => GoogleProvider::class,
+    ];
+
+    public function register(): void
+    {
+        $this->mergeConfigFrom(__DIR__.'/config/oidc.php', 'oidc');
+    }
+
+    public function boot(): void
+    {
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/config/oidc.php' => $this->app->configPath('oidc.php'),
+            ], 'oidc-config');
+        }
+
+        foreach ($this->connections() as $driver => [$connection, $providerClass]) {
+            config(['services.'.$driver => $connection]);
+        }
+
+        Event::listen(SocialiteWasCalled::class, function (SocialiteWasCalled $event) {
+            foreach ($this->connections() as $driver => [$connection, $providerClass]) {
+                $event->extendSocialite($driver, $providerClass);
+            }
+
+            if (($services = config('services.openidconnect')) !== null) {
+                $event->extendSocialite('openidconnect', $this->resolveProviderClass(
+                    $services['provider'] ?? Provider::class,
+                    'openidconnect',
+                ));
+            }
+        });
+    }
+
+    /**
+     * @return array<string, array{0: array, 1: class-string<Provider>}>
+     */
+    protected function connections(): array
+    {
+        $prefix = (string) config('oidc.driver_prefix', 'oidc_');
+        $connections = [];
+
+        foreach ((array) config('oidc.connections', []) as $name => $connection) {
+            if (! is_array($connection)) {
+                continue;
+            }
+
+            $providerClass = $this->resolveProviderClass($connection['provider'] ?? Provider::class, $name);
+
+            $connections[$prefix.$name] = [$connection, $providerClass];
+        }
+
+        return $connections;
+    }
+
+    /**
+     * @return class-string<Provider>
+     */
+    protected function resolveProviderClass(string $provider, string $connection): string
+    {
+        $class = static::PROVIDERS[strtolower($provider)] ?? $provider;
+
+        if (! is_a($class, Provider::class, true)) {
+            throw new InvalidArgumentException(
+                'OIDC: connection ['.$connection.'] provider ['.$provider.'] must be one of ['
+                .implode(', ', array_keys(static::PROVIDERS)).'] or a class extending '.Provider::class.'.'
+            );
+        }
+
+        return $class;
+    }
+}

--- a/src/OpenIDConnect/Provider.php
+++ b/src/OpenIDConnect/Provider.php
@@ -1,0 +1,1205 @@
+<?php
+
+namespace SocialiteProviders\OpenIDConnect;
+
+use Exception;
+use Firebase\JWT\JWK;
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+use Firebase\JWT\SignatureInvalidException;
+use GuzzleHttp\Client;
+use GuzzleHttp\RequestOptions;
+use Illuminate\Container\Container;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use SocialiteProviders\Manager\Config;
+use SocialiteProviders\Manager\Contracts\ConfigInterface;
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
+use SocialiteProviders\Manager\OAuth2\User;
+use SocialiteProviders\OpenIDConnect\IssuerValidators\DefaultIssuerValidator;
+use SocialiteProviders\OpenIDConnect\IssuerValidators\IssuerValidator;
+use stdClass;
+
+class Provider extends AbstractProvider
+{
+    public const IDENTIFIER = 'OPENIDCONNECT';
+
+    protected const DEFAULT_SCOPES = ['openid', 'email', 'profile'];
+
+    protected const BACKCHANNEL_LOGOUT_EVENT = 'http://schemas.openid.net/event/backchannel-logout';
+
+    public const NONCE_SESSION_KEY = 'openidconnect_nonce';
+
+    public $configurations = null;
+
+    protected $scopes = self::DEFAULT_SCOPES;
+
+    protected $scopeSeparator = ' ';
+
+    protected bool $usesNonce = true;
+
+    protected $usesPKCE = true;
+
+    protected bool $verifyJwt = true;
+
+    protected bool $requireEmail = false;
+
+    /** @var IssuerValidator|callable|null */
+    protected $issuerValidator = null;
+
+    public static function additionalConfigKeys(): array
+    {
+        return [
+            'base_url',
+            'scopes',
+            'use_nonce',
+            'require_email',
+            'verify_jwt',
+            'email_claims',
+            'jwt_public_key',
+            'jwt_algorithm',
+            'issuer',
+            'issuer_validator',
+            'token_auth_method',
+            'post_logout_redirect_uri',
+            'logout_token_replay_ttl',
+            'cache_ttl',
+            'clock_skew',
+            'http_timeout',
+            'http_connect_timeout',
+            'proxy',
+        ];
+    }
+
+    /**
+     * Config defaults this provider derives or assumes, merged under the
+     * configured values -- explicit config always wins. The hook a subclass
+     * overrides to encode an IdP's trivia (deriving base_url from a `tenant`
+     * or `realm`, pinning a quirk like the token auth method).
+     */
+    protected function configDefaults(array $config): array
+    {
+        return [];
+    }
+
+    public function setConfig(ConfigInterface $config)
+    {
+        $values = $config->get();
+        $defaults = $this->configDefaults($values);
+
+        if ($defaults !== []) {
+            // The manager's ConfigRetriever materialises absent keys as null;
+            // only a value the user actually set may beat a derived default.
+            $values = array_replace(
+                $defaults,
+                array_filter($values, static fn ($value) => $value !== null),
+            );
+
+            $config = new Config(
+                $values['client_id'] ?? null,
+                $values['client_secret'] ?? null,
+                $values['redirect'] ?? null,
+                $values,
+            );
+        }
+
+        return parent::setConfig($config);
+    }
+
+    /**
+     * Read a config value from the raw array. getConfig() treats falsy values
+     * as absent, which would make an explicit false or 0 unreachable.
+     */
+    protected function rawConfig(string $key): mixed
+    {
+        $config = $this->getConfig();
+
+        return is_array($config) && isset($config[$key]) ? $config[$key] : null;
+    }
+
+    public function redirect(): RedirectResponse
+    {
+        $state = null;
+
+        if ($this->usesState()) {
+            $this->request->session()->put('state', $state = $this->getState());
+        }
+
+        if ($this->usesNonce()) {
+            $this->request->session()->put(self::NONCE_SESSION_KEY, $this->getNonce());
+        }
+
+        if ($this->usesPKCE()) {
+            if (! $this->request->hasSession()) {
+                throw new InvalidArgumentException(
+                    'OIDC: PKCE requires a session to carry the code_verifier from the redirect to the callback. '
+                    .'Bind a session, or call withoutPKCE() to opt out.'
+                );
+            }
+
+            $this->request->session()->put('code_verifier', $this->getCodeVerifier());
+        }
+
+        return new RedirectResponse($this->getAuthUrl($state));
+    }
+
+    public function getScopes(): array
+    {
+        $configured = $this->parseList($this->getConfig('scopes'));
+
+        // Configured scopes replace the defaults (so an OP without `profile`
+        // can be narrowed down) but keep anything added via fluent scopes().
+        $scopes = $configured === []
+            ? $this->scopes
+            : array_merge($configured, array_diff($this->scopes, self::DEFAULT_SCOPES));
+
+        // Without `openid` the OP returns no id_token at all.
+        array_unshift($scopes, 'openid');
+
+        return array_values(array_unique($scopes));
+    }
+
+    /**
+     * Normalise a list given as an array, or a string separated by
+     * whitespace and/or commas.
+     *
+     * @return string[]
+     */
+    protected function parseList(mixed $values): array
+    {
+        if ($values === null || $values === '' || $values === []) {
+            return [];
+        }
+
+        $list = is_array($values)
+            ? $values
+            : preg_split('/[\s,]+/', (string) $values, -1, PREG_SPLIT_NO_EMPTY);
+
+        return array_values(array_filter(
+            array_map(static fn ($value) => is_string($value) ? trim($value) : null, $list ?: []),
+            static fn (?string $value) => $value !== null && $value !== ''
+        ));
+    }
+
+    protected function getTokenUrl(): string
+    {
+        return $this->getOpenIdConfig()['token_endpoint'];
+    }
+
+    protected function getUserInfoUrl(): string
+    {
+        return $this->getOpenIdConfig()['userinfo_endpoint'];
+    }
+
+    protected function getAuthUrl($state): string
+    {
+        return $this->buildAuthUrlFromBase(
+            $this->getOpenIdConfig()['authorization_endpoint'],
+            $state
+        );
+    }
+
+    /**
+     * The parent hardcodes '?', but discovered endpoints may already carry a
+     * query (e.g. /authorize?realm=prod).
+     */
+    protected function buildAuthUrlFromBase($url, $state): string
+    {
+        return $this->appendQuery(
+            $url,
+            http_build_query($this->getCodeFields($state), '', '&', $this->encodingType)
+        );
+    }
+
+    protected function appendQuery(string $url, string $query): string
+    {
+        if ($query === '') {
+            return $url;
+        }
+
+        [$base, $fragment] = array_pad(explode('#', $url, 2), 2, null);
+
+        $withQuery = $base.(str_contains($base, '?') ? '&' : '?').$query;
+
+        return $fragment === null ? $withQuery : $withQuery.'#'.$fragment;
+    }
+
+    protected function getCodeFields($state = null): array
+    {
+        $fields = parent::getCodeFields($state);
+
+        if ($this->usesNonce()) {
+            $fields['nonce'] = $this->getCurrentNonce();
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Stateless flows have no session to carry the nonce between redirect and
+     * callback, so it is skipped there -- safe for the code flow, where OIDC
+     * Core 3.1.2.1 only requires a nonce for implicit and hybrid.
+     */
+    protected function usesNonce(): bool
+    {
+        if ($this->isStateless()) {
+            return false;
+        }
+
+        $configured = $this->rawConfig('use_nonce');
+
+        return $configured === null
+            ? $this->usesNonce
+            : filter_var($configured, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    public function withoutNonce(): static
+    {
+        $this->usesNonce = false;
+
+        return $this;
+    }
+
+    public function withoutPKCE(): static
+    {
+        $this->usesPKCE = false;
+
+        return $this;
+    }
+
+    protected function getNonce(): string
+    {
+        return Str::random(40);
+    }
+
+    /**
+     * Whether id_token signatures are verified. Back-channel logout tokens
+     * are always verified regardless; see verifyLogoutToken().
+     */
+    protected function shouldVerifyJwt(): bool
+    {
+        $configured = $this->rawConfig('verify_jwt');
+
+        return $configured === null
+            ? $this->verifyJwt
+            : filter_var($configured, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    protected function getCacheTtl(): int
+    {
+        $ttl = $this->rawConfig('cache_ttl');
+
+        return ($ttl === null || $ttl === '') ? 3600 : (int) $ttl;
+    }
+
+    protected function timeoutConfig(string $key, float $default): float
+    {
+        $configured = $this->rawConfig($key);
+
+        return ($configured === null || $configured === '') ? $default : (float) $configured;
+    }
+
+    protected function getHttpClient()
+    {
+        if ($this->httpClient === null) {
+            $options = [
+                'connect_timeout' => $this->timeoutConfig('http_connect_timeout', 5),
+                'timeout'         => $this->timeoutConfig('http_timeout', 10),
+            ];
+
+            if ($proxy = $this->getConfig('proxy')) {
+                $options[RequestOptions::PROXY] = $proxy;
+            }
+
+            $this->httpClient = new Client($options);
+        }
+
+        return $this->httpClient;
+    }
+
+    protected function getCurrentNonce(): ?string
+    {
+        return $this->request->hasSession()
+            ? $this->request->session()->get(self::NONCE_SESSION_KEY)
+            : null;
+    }
+
+    /**
+     * Every endpoint is derived from base_url, so a plaintext issuer would
+     * expose discovery, the JWKS and the token exchange to tampering.
+     * Loopback hosts are exempt so local development works.
+     */
+    protected function getBaseUrl(): string
+    {
+        $baseUrl = rtrim((string) $this->getConfig('base_url'), '/');
+
+        if ($baseUrl === '') {
+            throw new InvalidArgumentException('OIDC: base_url is not configured.');
+        }
+
+        $scheme = strtolower((string) parse_url($baseUrl, PHP_URL_SCHEME));
+        $host = strtolower((string) parse_url($baseUrl, PHP_URL_HOST));
+
+        if ($scheme !== 'https' && ! ($scheme === 'http' && $this->isLoopbackHost($host))) {
+            throw new InvalidArgumentException(
+                'OIDC: base_url must use https (got '.($scheme ?: 'no scheme').'); plaintext is only permitted for loopback hosts.'
+            );
+        }
+
+        return $baseUrl;
+    }
+
+    protected function isLoopbackHost(string $host): bool
+    {
+        return in_array($host, ['localhost', '127.0.0.1', '[::1]', '::1'], true)
+            || str_ends_with($host, '.localhost');
+    }
+
+    protected function getOpenIdConfig(): array
+    {
+        if ($this->configurations === null) {
+            $configUrl = $this->getBaseUrl().'/.well-known/openid-configuration';
+            $cacheKey = 'openidconnect_discovery_'.md5($configUrl);
+
+            $this->configurations = Cache::remember($cacheKey, $this->getCacheTtl(), function () use ($configUrl) {
+                try {
+                    $response = $this->getHttpClient()->get($configUrl);
+
+                    $document = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+                    if (! is_array($document) || $document === []) {
+                        throw new InvalidArgumentException('the document is not a JSON object.');
+                    }
+
+                    return $document;
+                } catch (Exception $e) {
+                    throw new InvalidArgumentException('Unable to get the OIDC configuration from '.$configUrl.': '.$e->getMessage());
+                }
+            });
+        }
+
+        return $this->configurations;
+    }
+
+    protected function getJwks(bool $forceRefresh = false): array
+    {
+        if ($forceRefresh) {
+            Cache::forget($this->jwksCacheKey());
+        }
+
+        return Cache::remember($this->jwksCacheKey(), $this->getCacheTtl(), function () use ($forceRefresh) {
+            $config = $this->getOpenIdConfig();
+
+            if (! isset($config['jwks_uri'])) {
+                throw new InvalidArgumentException('JWKS URI not found in OIDC configuration');
+            }
+
+            // Bust any HTTP cache between us and the OP, not just our own.
+            $options = $forceRefresh ? [
+                RequestOptions::HEADERS => [
+                    'Cache-Control' => 'no-cache',
+                    'Pragma'        => 'no-cache',
+                ],
+            ] : [];
+
+            try {
+                $response = $this->getHttpClient()->get($config['jwks_uri'], $options);
+
+                return json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+            } catch (Exception $e) {
+                throw new InvalidArgumentException('Unable to fetch JWKS: '.$e->getMessage());
+            }
+        });
+    }
+
+    public function user()
+    {
+        if ($this->user) {
+            return $this->user;
+        }
+
+        if ($this->request->filled('error')) {
+            $description = $this->request->input('error_description') ?: $this->request->input('error');
+            throw new InvalidArgumentException('Callback: IdP returned error - '.$description, 401);
+        }
+
+        if ($this->hasInvalidState()) {
+            throw new InvalidArgumentException('Callback: invalid state.', 401);
+        }
+
+        if (! $this->request->filled('code')) {
+            throw new InvalidArgumentException('Callback: missing authorization code.', 401);
+        }
+
+        $tokenResponse = $this->getAccessTokenResponse($this->request->input('code'));
+
+        if (! is_array($tokenResponse)) {
+            throw new InvalidArgumentException('Token endpoint: malformed response.', 401);
+        }
+
+        $this->credentialsResponseBody = $tokenResponse;
+
+        // Some IdPs answer 200 with an error body, which Guzzle won't raise.
+        if (Arr::has($tokenResponse, 'error')) {
+            $description = Arr::get($tokenResponse, 'error_description') ?: Arr::get($tokenResponse, 'error');
+            throw new InvalidArgumentException('Token endpoint: returned error - '.$description, 401);
+        }
+
+        $idToken = Arr::get($tokenResponse, 'id_token');
+
+        if (! is_string($idToken) || $idToken === '') {
+            throw new InvalidArgumentException('Token endpoint: response contained no id_token.', 401);
+        }
+
+        $accessToken = Arr::get($tokenResponse, 'access_token');
+
+        $claims = (array) $this->decodeJWT($idToken, $accessToken);
+
+        // sub is the only claim the OP must return (OIDC Core 2).
+        if (empty($claims['sub'])) {
+            throw new InvalidArgumentException('JWT: Missing required sub claim.', 401);
+        }
+
+        if ($this->hasEmptyEmail($claims) && is_string($accessToken) && $accessToken !== '') {
+            $claims = $this->mergeUserInfoClaims($claims, $this->getUserByToken($accessToken));
+        }
+
+        if ($this->requiresEmail() && $this->hasEmptyEmail($claims)) {
+            throw new InvalidArgumentException('JWT: User has no email.', 401);
+        }
+
+        $this->user = $this->mapUserToObject($claims);
+
+        if ($this->user instanceof User) {
+            $this->user->setAccessTokenResponseBody($this->credentialsResponseBody);
+        }
+
+        return $this->user->setToken($accessToken)
+            ->setRefreshToken($this->parseRefreshToken($tokenResponse))
+            ->setExpiresIn($this->parseExpiresIn($tokenResponse))
+            ->setApprovedScopes($this->parseApprovedScopes($tokenResponse));
+    }
+
+    /**
+     * Decode an id_token from the token endpoint. Skipping the signature here
+     * (verify_jwt false) is OIDC Core 3.1.3.7 step 6's TLS exemption: the
+     * token answers a request we made over TLS, bound to this session by
+     * nonce and PKCE. Contrast verifyLogoutToken(), which never gets that.
+     */
+    protected function decodeJWT(string $jwt, ?string $accessToken = null)
+    {
+        $header = $this->decodeJwtHeader($jwt);
+        $alg = $header->alg ?? null;
+
+        if ($this->shouldVerifyJwt()) {
+            $payload = $this->verifyAndDecodeJWT($jwt, $alg);
+        } else {
+            [, $payloadSegment] = $this->jwtSegments($jwt);
+
+            $payload = json_decode($this->base64UrlDecode($payloadSegment));
+
+            if (! $payload instanceof stdClass) {
+                throw new InvalidArgumentException('JWT: Failed to parse.', 401);
+            }
+        }
+
+        $this->validateIdTokenClaims($payload, $alg, $accessToken);
+
+        if ($this->usesNonce() && $this->request->hasSession()) {
+            $this->request->session()->forget(self::NONCE_SESSION_KEY);
+        }
+
+        return $payload;
+    }
+
+    /**
+     * The token's `alg` header is only ever checked against the RP's allow
+     * list, never used to select the algorithm -- deriving it from the header
+     * is the substitution attack of RFC 8725 2.1: claim `alg: HS256` and
+     * HMAC-sign with the non-secret public key as the MAC secret.
+     */
+    protected function verifyAndDecodeJWT(string $jwt, ?string $alg)
+    {
+        $allowed = $this->getAllowedSigningAlgorithms();
+
+        if ($alg === null || ! in_array($alg, $allowed, true)) {
+            throw new InvalidArgumentException(
+                'JWT: Disallowed signing algorithm ['.($alg ?? 'missing').']; expected one of ['.implode(', ', $allowed).'].',
+                401
+            );
+        }
+
+        $previousLeeway = JWT::$leeway;
+
+        try {
+            JWT::$leeway = (int) ($this->getConfig('clock_skew') ?? 0);
+
+            $publicKey = $this->getConfig('jwt_public_key');
+
+            if ($publicKey) {
+                if ($this->isHmacAlgorithm($alg) && $this->isAsymmetricKey($publicKey)) {
+                    throw new InvalidArgumentException('HMAC algorithms cannot be used with an asymmetric public key.');
+                }
+
+                $decoded = JWT::decode($jwt, new Key($publicKey, $alg));
+            } else {
+                // A JWKS distributes public keys; an HMAC secret never is.
+                if ($this->isHmacAlgorithm($alg)) {
+                    throw new InvalidArgumentException('HMAC algorithms cannot be verified against a JWKS.');
+                }
+
+                $kid = $this->decodeJwtHeader($jwt)->kid ?? null;
+                $jwks = $this->getJwks();
+
+                // Unknown kid: the OP has likely rotated keys since we cached.
+                if ($kid !== null && ! $this->jwksContainsKid($jwks, $kid)) {
+                    $jwks = $this->getJwks(forceRefresh: true);
+                }
+
+                $decoded = $this->decodeAgainstJwks($jwt, $jwks, $kid, $alg);
+            }
+
+            return json_decode(json_encode($decoded));
+        } catch (Exception $e) {
+            throw new InvalidArgumentException('JWT: Verification failed - '.$e->getMessage(), 401);
+        } finally {
+            JWT::$leeway = $previousLeeway;
+        }
+    }
+
+    protected function decodeAgainstJwks(string $jwt, array $jwks, ?string $kid, string $alg)
+    {
+        if ($kid !== null) {
+            return JWT::decode($jwt, JWK::parseKeySet($jwks, $alg));
+        }
+
+        $decoded = $this->decodeAgainstEachKey($jwt, $jwks, $alg);
+
+        if ($decoded === null) {
+            $decoded = $this->decodeAgainstEachKey($jwt, $this->getJwks(forceRefresh: true), $alg);
+        }
+
+        if ($decoded === null) {
+            throw new InvalidArgumentException('no key in the JWKS verifies this token.');
+        }
+
+        return $decoded;
+    }
+
+    protected function decodeAgainstEachKey(string $jwt, array $jwks, string $alg)
+    {
+        foreach (JWK::parseKeySet($jwks, $alg) as $key) {
+            try {
+                return JWT::decode($jwt, $key);
+            } catch (SignatureInvalidException) {
+                continue;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Pinned `jwt_algorithm` config, else the OP's advertised
+     * `id_token_signing_alg_values_supported`, else RS256. Never `none`.
+     *
+     * @return string[]
+     */
+    protected function getAllowedSigningAlgorithms(): array
+    {
+        $configured = $this->getConfig('jwt_algorithm');
+
+        if ($configured) {
+            $algorithms = is_array($configured)
+                ? $configured
+                : preg_split('/[\s,]+/', (string) $configured, -1, PREG_SPLIT_NO_EMPTY);
+        } else {
+            $algorithms = (array) ($this->getOpenIdConfig()['id_token_signing_alg_values_supported'] ?? []);
+        }
+
+        $algorithms = array_values(array_filter(
+            array_map(static fn ($alg) => is_string($alg) ? trim($alg) : null, $algorithms),
+            static fn (?string $alg) => $alg !== null && $alg !== '' && strcasecmp($alg, 'none') !== 0
+        ));
+
+        return $algorithms ?: ['RS256'];
+    }
+
+    protected function isHmacAlgorithm(string $alg): bool
+    {
+        return str_starts_with(strtoupper($alg), 'HS');
+    }
+
+    protected function isAsymmetricKey(mixed $key): bool
+    {
+        if ($key instanceof \OpenSSLAsymmetricKey || $key instanceof \OpenSSLCertificate) {
+            return true;
+        }
+
+        return is_string($key) && str_contains($key, '-----BEGIN');
+    }
+
+    protected function jwksContainsKid(array $jwks, string $kid): bool
+    {
+        foreach ($jwks['keys'] ?? [] as $key) {
+            if (($key['kid'] ?? null) === $kid) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function jwksCacheKey(): string
+    {
+        return 'openidconnect_jwks_'.md5($this->getBaseUrl());
+    }
+
+    protected function decodeJwtHeader(string $jwt)
+    {
+        [$headerSegment] = $this->jwtSegments($jwt);
+
+        $header = json_decode($this->base64UrlDecode($headerSegment));
+
+        if (! $header instanceof stdClass) {
+            throw new InvalidArgumentException('JWT: Failed to parse header.', 401);
+        }
+
+        return $header;
+    }
+
+    /**
+     * Destructuring explode() directly would produce a TypeError -- not an
+     * Exception -- on a token without dots, escaping catch (Exception).
+     *
+     * @return string[]
+     */
+    protected function jwtSegments(string $jwt): array
+    {
+        $segments = explode('.', $jwt);
+
+        if (count($segments) !== 3) {
+            throw new InvalidArgumentException('JWT: Malformed token, expected three segments.', 401);
+        }
+
+        return $segments;
+    }
+
+    protected function validateIdTokenClaims($payload, ?string $alg, ?string $accessToken): void
+    {
+        if ($this->isInvalidNonce($payload->nonce ?? null)) {
+            throw new InvalidArgumentException('JWT: Contains an invalid nonce.', 401);
+        }
+
+        $this->validateIssuerClaim($payload, 'JWT');
+
+        $aud = $payload->aud ?? null;
+        $audList = is_array($aud) ? $aud : [$aud];
+        if (! in_array($this->clientId, $audList, true)) {
+            throw new InvalidArgumentException('JWT: Invalid audience.', 401);
+        }
+
+        // OIDC Core 3.1.3.7 step 4.
+        if (is_array($aud) && count($aud) > 1 && ! isset($payload->azp)) {
+            throw new InvalidArgumentException('JWT: Multiple audiences require an azp claim.', 401);
+        }
+
+        // Step 5, unconditionally: a token naming us as audience but
+        // authorized to a different party is not ours to accept.
+        if (isset($payload->azp) && $payload->azp !== $this->clientId) {
+            throw new InvalidArgumentException('JWT: Invalid authorized party (azp).', 401);
+        }
+
+        if ($accessToken !== null && isset($payload->at_hash) && $alg) {
+            $this->validateAtHash($payload->at_hash, $accessToken, $alg);
+        }
+
+        $this->validateTimeClaims($payload);
+    }
+
+    /**
+     * The expected issuer is the `issuer` config, else the discovery
+     * document's; the comparison itself is delegated to the pluggable
+     * validator.
+     */
+    protected function validateIssuerClaim($payload, string $context): void
+    {
+        $expectedIssuer = $this->getConfig('issuer') ?: ($this->getOpenIdConfig()['issuer'] ?? null);
+
+        if ($expectedIssuer === null) {
+            return;
+        }
+
+        $validator = $this->issuerValidator();
+
+        $valid = $validator instanceof IssuerValidator
+            ? $validator->validate($expectedIssuer, $payload)
+            : (bool) $validator($expectedIssuer, $payload);
+
+        if (! $valid) {
+            throw new InvalidArgumentException($context.': Invalid issuer.', 401);
+        }
+    }
+
+    /**
+     * @param  IssuerValidator|callable(string, stdClass): bool  $validator
+     */
+    public function validateIssuerUsing(IssuerValidator|callable $validator): static
+    {
+        $this->issuerValidator = $validator;
+
+        return $this;
+    }
+
+    /**
+     * @return IssuerValidator|callable
+     */
+    protected function issuerValidator()
+    {
+        if ($this->issuerValidator !== null) {
+            return $this->issuerValidator;
+        }
+
+        $class = $this->getConfig('issuer_validator');
+
+        if ($class) {
+            $validator = Container::getInstance()->make($class);
+
+            if (! $validator instanceof IssuerValidator) {
+                throw new InvalidArgumentException(
+                    'OIDC: issuer_validator ['.$class.'] must implement '.IssuerValidator::class.'.'
+                );
+            }
+
+            return $this->issuerValidator = $validator;
+        }
+
+        return $this->issuerValidator = new DefaultIssuerValidator;
+    }
+
+    /**
+     * Runs in both the verified and unverified paths. exp is required, not
+     * optional: firebase/php-jwt gates its own expiry check on isset(), so a
+     * token that simply omits the claim would otherwise never expire.
+     *
+     * @param  bool  $requireIat  Back-Channel Logout 2.4 requires iat too.
+     */
+    protected function validateTimeClaims($payload, bool $requireIat = false): void
+    {
+        $now = time();
+        $leeway = (int) ($this->getConfig('clock_skew') ?? 0);
+
+        if (! isset($payload->exp) || ! is_numeric($payload->exp)) {
+            throw new InvalidArgumentException('JWT: Missing required exp claim.', 401);
+        }
+
+        if ($now - $leeway >= (int) $payload->exp) {
+            throw new InvalidArgumentException('JWT: Token has expired.', 401);
+        }
+
+        if ($requireIat && (! isset($payload->iat) || ! is_numeric($payload->iat))) {
+            throw new InvalidArgumentException('JWT: Missing required iat claim.', 401);
+        }
+
+        if (isset($payload->nbf) && $now + $leeway < (int) $payload->nbf) {
+            throw new InvalidArgumentException('JWT: Token not yet valid.', 401);
+        }
+
+        if (isset($payload->iat) && $now + $leeway < (int) $payload->iat) {
+            throw new InvalidArgumentException('JWT: Token issued in the future.', 401);
+        }
+    }
+
+    /**
+     * at_hash is the left-most half of the access token's hash, base64url
+     * encoded (OIDC Core 3.1.3.6).
+     */
+    protected function validateAtHash(string $atHash, string $accessToken, string $alg): void
+    {
+        $map = [
+            'RS256' => 'sha256', 'RS384' => 'sha384', 'RS512' => 'sha512',
+            'PS256' => 'sha256', 'PS384' => 'sha384', 'PS512' => 'sha512',
+            'ES256' => 'sha256', 'ES384' => 'sha384', 'ES512' => 'sha512',
+            'HS256' => 'sha256', 'HS384' => 'sha384', 'HS512' => 'sha512',
+            'EdDSA' => 'sha512',
+        ];
+
+        if (! isset($map[$alg])) {
+            throw new InvalidArgumentException('JWT: Cannot validate at_hash for algorithm ['.$alg.'].', 401);
+        }
+
+        $digest = hash($map[$alg], $accessToken, true);
+        $expected = $this->base64UrlEncode(substr($digest, 0, intdiv(strlen($digest), 2)));
+
+        if (! hash_equals($expected, $atHash)) {
+            throw new InvalidArgumentException('JWT: at_hash mismatch.', 401);
+        }
+    }
+
+    /**
+     * Strict mode, so attacker-supplied garbage fails here as a parse error
+     * instead of surfacing later as a baffling claim mismatch.
+     */
+    private function base64UrlDecode(string $data): string
+    {
+        $decoded = base64_decode(
+            str_pad(strtr($data, '-_', '+/'), intdiv(strlen($data) + 3, 4) * 4, '=', STR_PAD_RIGHT),
+            true
+        );
+
+        if ($decoded === false) {
+            throw new InvalidArgumentException('JWT: Malformed base64url segment.', 401);
+        }
+
+        return $decoded;
+    }
+
+    private function base64UrlEncode(string $data): string
+    {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+
+    protected function isInvalidNonce($nonce): bool
+    {
+        if (! $this->usesNonce()) {
+            return false;
+        }
+
+        return ! (is_string($nonce) && strlen($nonce) > 0 && $nonce === $this->getCurrentNonce());
+    }
+
+    /**
+     * Merged over (not substituted for) the id_token claims, so claims only
+     * the id_token carried survive. OIDC Core 5.3.2 requires the subs to
+     * match exactly before the response may be used.
+     */
+    protected function mergeUserInfoClaims(array $claims, $userInfo): array
+    {
+        if (! is_array($userInfo)) {
+            return $claims;
+        }
+
+        if (($userInfo['sub'] ?? null) !== $claims['sub']) {
+            throw new InvalidArgumentException('UserInfo: sub does not match the id_token.', 401);
+        }
+
+        return array_merge($claims, array_filter($userInfo, static fn ($value) => $value !== null));
+    }
+
+    protected function requiresEmail(): bool
+    {
+        $configured = $this->rawConfig('require_email');
+
+        return $configured === null
+            ? $this->requireEmail
+            : filter_var($configured, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    /**
+     * The claims consulted for the user's email, in order. Configurable
+     * because not every IdP puts the login email in `email` -- Entra returns
+     * the contact-info email there (often empty or unrelated) and the login
+     * identity in `preferred_username`.
+     *
+     * @return string[]
+     */
+    protected function emailClaims(): array
+    {
+        $configured = $this->parseList($this->getConfig('email_claims'));
+
+        return $configured === [] ? ['email'] : $configured;
+    }
+
+    protected function resolveEmail(array|stdClass $claims): ?string
+    {
+        $claims = (array) $claims;
+
+        foreach ($this->emailClaims() as $claim) {
+            $value = $claims[$claim] ?? null;
+
+            if (is_string($value) && $value !== '' && $this->acceptableEmail($value)) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Whether a candidate claim value may be used as the email. The base
+     * accepts anything, since a configured claim list is the operator's
+     * explicit choice; subclasses tighten this where a claim has no fixed
+     * format (Entra's preferred_username can be a phone number).
+     */
+    protected function acceptableEmail(string $value): bool
+    {
+        return true;
+    }
+
+    protected function hasEmptyEmail(array|stdClass $payload): bool
+    {
+        return $this->resolveEmail($payload) === null;
+    }
+
+    protected function mapUserToObject(array $user)
+    {
+        return (new User)->setRaw($user)->map([
+            'id'          => $user['sub'] ?? null,
+            'email'       => $this->resolveEmail($user),
+            'name'        => $user['name'] ?? null,
+            'nickname'    => $user['nickname'] ?? null,
+            'given_name'  => $user['given_name'] ?? null,
+            'family_name' => $user['family_name'] ?? null,
+            'idp'         => $user['idp'] ?? null,
+            'role'        => $user['role'] ?? null,
+            'groups'      => $user['groups'] ?? null,
+        ]);
+    }
+
+    public function getAccessTokenResponse($code)
+    {
+        $fields = array_merge(
+            $this->getTokenFields($code),
+            ['grant_type' => 'authorization_code']
+        );
+
+        $response = $this->getHttpClient()->post($this->getTokenUrl(), $this->tokenRequestOptions($fields));
+
+        try {
+            return json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (Exception $e) {
+            throw new InvalidArgumentException('Token endpoint returned a non-JSON response: '.$e->getMessage());
+        }
+    }
+
+    protected function tokenRequestOptions(array $fields): array
+    {
+        $options = [RequestOptions::HEADERS => ['Accept' => 'application/json']];
+
+        if ($this->resolveTokenAuthMethod() === 'client_secret_basic') {
+            // RFC 6749 2.3.1: each half is form-urlencoded before base64.
+            // Guzzle's `auth` option encodes the raw pair, which breaks any
+            // secret containing +, /, = or a space.
+            $options[RequestOptions::HEADERS]['Authorization'] = 'Basic '.base64_encode(
+                urlencode($this->clientId).':'.urlencode($this->clientSecret)
+            );
+
+            unset($fields['client_id'], $fields['client_secret']);
+        }
+
+        $options[RequestOptions::FORM_PARAMS] = $fields;
+
+        return $options;
+    }
+
+    protected function resolveTokenAuthMethod(): string
+    {
+        $configured = $this->getConfig('token_auth_method');
+        if ($configured) {
+            return $configured;
+        }
+
+        $supported = $this->getOpenIdConfig()['token_endpoint_auth_methods_supported'] ?? [];
+
+        return in_array('client_secret_basic', $supported, true)
+            ? 'client_secret_basic'
+            : 'client_secret_post';
+    }
+
+    protected function getUserByToken($token)
+    {
+        $response = $this->getHttpClient()->get($this->getUserInfoUrl(), [
+            RequestOptions::HEADERS => [
+                'Accept'        => 'application/json',
+                'Authorization' => 'Bearer '.$token,
+            ],
+        ]);
+
+        return json_decode((string) $response->getBody(), true);
+    }
+
+    public function refreshToken($refreshToken)
+    {
+        $response = $this->getHttpClient()->post($this->getTokenUrl(), $this->tokenRequestOptions([
+            'client_id'     => $this->clientId,
+            'client_secret' => $this->clientSecret,
+            'grant_type'    => 'refresh_token',
+            'refresh_token' => $refreshToken,
+        ]));
+
+        return json_decode((string) $response->getBody(), true);
+    }
+
+    /**
+     * Build an RP-initiated logout redirect.
+     *
+     * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html
+     */
+    public function logout(?string $idToken = null, ?string $postLogoutRedirectUri = null, array $extra = []): RedirectResponse
+    {
+        $config = $this->getOpenIdConfig();
+
+        if (empty($config['end_session_endpoint'])) {
+            throw new InvalidArgumentException('Provider does not advertise an end_session_endpoint.');
+        }
+
+        // A state is only sent when a session can store it for
+        // validateLogoutState() to check later.
+        $state = null;
+
+        if ($this->request->hasSession()) {
+            $this->request->session()->put('logout_state', $state = Str::random(40));
+        }
+
+        $params = array_filter(array_merge([
+            'id_token_hint'            => $idToken,
+            'client_id'                => $this->clientId,
+            'post_logout_redirect_uri' => $postLogoutRedirectUri ?? $this->getConfig('post_logout_redirect_uri'),
+            'state'                    => $state,
+        ], $extra), fn ($v) => $v !== null && $v !== '');
+
+        return new RedirectResponse($this->appendQuery($config['end_session_endpoint'], http_build_query($params)));
+    }
+
+    /**
+     * The stored state is pulled, so it is good for exactly one round trip.
+     */
+    public function validateLogoutState(?Request $request = null): bool
+    {
+        $request ??= $this->request;
+
+        if (! $request->hasSession()) {
+            return false;
+        }
+
+        $expected = $request->session()->pull('logout_state');
+        $returned = $request->input('state');
+
+        return is_string($expected)
+            && $expected !== ''
+            && is_string($returned)
+            && hash_equals($expected, $returned);
+    }
+
+    /**
+     * Revoke a token per RFC 7009. Returns false rather than throwing for a
+     * non-2xx answer, since a conforming server returns 200 even for an
+     * already-revoked token and callers should not lose a logout over it.
+     */
+    public function revoke(string $token, string $tokenTypeHint = 'refresh_token'): bool
+    {
+        $config = $this->getOpenIdConfig();
+
+        if (empty($config['revocation_endpoint'])) {
+            throw new InvalidArgumentException('Provider does not advertise a revocation_endpoint.');
+        }
+
+        $options = $this->tokenRequestOptions([
+            'token'           => $token,
+            'token_type_hint' => $tokenTypeHint,
+            'client_id'       => $this->clientId,
+            'client_secret'   => $this->clientSecret,
+        ]);
+
+        $options[RequestOptions::HTTP_ERRORS] = false;
+
+        $response = $this->getHttpClient()->post($config['revocation_endpoint'], $options);
+
+        return in_array($response->getStatusCode(), [200, 204], true);
+    }
+
+    /**
+     * Verify a back-channel logout token (openid-connect-backchannel-1_0).
+     *
+     * Unlike an id_token, this arrives unsolicited on an unauthenticated
+     * endpoint -- no session nonce, no PKCE, no TLS exemption -- so the
+     * signature is always verified regardless of `verify_jwt`. Replay of a
+     * `jti` is refused per section 2.6; set `logout_token_replay_ttl` to 0 to
+     * handle that yourself. Returns the claims so the caller can destroy the
+     * sessions matching `sid` / `sub`.
+     */
+    public function verifyLogoutToken(string $logoutToken): array
+    {
+        $header = $this->decodeJwtHeader($logoutToken);
+        $alg = $header->alg ?? null;
+
+        $payload = $this->verifyAndDecodeJWT($logoutToken, $alg);
+
+        $this->validateIssuerClaim($payload, 'Logout token');
+
+        $aud = $payload->aud ?? null;
+        $audList = is_array($aud) ? $aud : [$aud];
+        if (! in_array($this->clientId, $audList, true)) {
+            throw new InvalidArgumentException('Logout token: invalid audience.', 401);
+        }
+
+        $this->validateTimeClaims($payload, requireIat: true);
+
+        if (empty($payload->jti ?? null)) {
+            throw new InvalidArgumentException('Logout token: missing jti.', 401);
+        }
+
+        // A nonce marks an id_token; refusing it prevents token confusion.
+        if (isset($payload->nonce)) {
+            throw new InvalidArgumentException('Logout token: must not contain a nonce.', 401);
+        }
+
+        $events = (array) ($payload->events ?? []);
+        if (! array_key_exists(self::BACKCHANNEL_LOGOUT_EVENT, $events)) {
+            throw new InvalidArgumentException('Logout token: missing backchannel-logout event.', 401);
+        }
+
+        if (empty($payload->sub ?? null) && empty($payload->sid ?? null)) {
+            throw new InvalidArgumentException('Logout token: must contain sub and/or sid.', 401);
+        }
+
+        // Claimed last, once the token is known genuine, so a forged token
+        // cannot burn the jti of a legitimate one still in flight.
+        $this->assertLogoutTokenNotReplayed((string) $payload->jti, $payload->exp ?? null);
+
+        return (array) $payload;
+    }
+
+    protected function assertLogoutTokenNotReplayed(string $jti, int|float|null $expiresAt = null): void
+    {
+        $ttl = $this->logoutTokenReplayTtl($expiresAt);
+
+        if ($ttl <= 0) {
+            return;
+        }
+
+        $key = 'openidconnect_logout_jti_'.md5($this->getBaseUrl().'|'.$this->clientId.'|'.$jti);
+
+        // Cache::add writes only when absent, atomically; has()/put() would
+        // let two deliveries of the same token race past each other.
+        if (! Cache::add($key, true, $ttl)) {
+            throw new InvalidArgumentException('Logout token: already used.', 401);
+        }
+    }
+
+    /**
+     * A jti is remembered until the token itself has expired (plus skew);
+     * past that point the token is refused on its own merits.
+     */
+    protected function logoutTokenReplayTtl(int|float|null $expiresAt = null): int
+    {
+        $configured = $this->rawConfig('logout_token_replay_ttl');
+
+        if ($configured !== null && $configured !== '') {
+            return (int) $configured;
+        }
+
+        if (is_numeric($expiresAt)) {
+            $remaining = (int) ceil((float) $expiresAt - time());
+            $skew = (int) ($this->getConfig('clock_skew') ?? 0);
+
+            return max(60, $remaining + $skew + 60);
+        }
+
+        return 900;
+    }
+}

--- a/src/OpenIDConnect/Providers/Auth0Provider.php
+++ b/src/OpenIDConnect/Providers/Auth0Provider.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SocialiteProviders\OpenIDConnect\Providers;
+
+use SocialiteProviders\OpenIDConnect\Provider;
+
+/**
+ * Auth0. The tenant domain is the issuer; regular web applications are
+ * registered with client_secret_post token authentication by default.
+ */
+class Auth0Provider extends Provider
+{
+    public static function additionalConfigKeys(): array
+    {
+        return array_merge(parent::additionalConfigKeys(), ['domain']);
+    }
+
+    protected function configDefaults(array $config): array
+    {
+        $defaults = [
+            'token_auth_method' => 'client_secret_post',
+        ];
+
+        if (isset($config['domain'])) {
+            $defaults['base_url'] = 'https://'.preg_replace('#^https?://#', '', rtrim((string) $config['domain'], '/'));
+        }
+
+        return $defaults;
+    }
+}

--- a/src/OpenIDConnect/Providers/EntraProvider.php
+++ b/src/OpenIDConnect/Providers/EntraProvider.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace SocialiteProviders\OpenIDConnect\Providers;
+
+use SocialiteProviders\OpenIDConnect\IssuerValidators\EntraIssuerValidator;
+use SocialiteProviders\OpenIDConnect\Provider;
+
+/**
+ * Entra ID (Azure AD). `tenant` is a tenant id, a verified domain, or one of
+ * the multi-tenant pseudo-tenants (common / organizations / consumers).
+ */
+class EntraProvider extends Provider
+{
+    public static function additionalConfigKeys(): array
+    {
+        return array_merge(parent::additionalConfigKeys(), ['tenant']);
+    }
+
+    protected function configDefaults(array $config): array
+    {
+        return [
+            'base_url'         => 'https://login.microsoftonline.com/'.($config['tenant'] ?? 'common').'/v2.0',
+            'issuer_validator' => EntraIssuerValidator::class,
+            // Deliberately no fallback to `email`: it is a free-text directory
+            // attribute any tenant admin can spoof (nOAuth), whereas a
+            // preferred_username UPN carries a tenant-verified domain.
+            'email_claims'     => ['preferred_username'],
+        ];
+    }
+
+    /**
+     * preferred_username "could be an email address, phone number, or a
+     * generic username without a specified format" (Microsoft id-token
+     * claims reference), so only email-shaped values are used.
+     */
+    protected function acceptableEmail(string $value): bool
+    {
+        return str_contains($value, '@');
+    }
+}

--- a/src/OpenIDConnect/Providers/GoogleProvider.php
+++ b/src/OpenIDConnect/Providers/GoogleProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace SocialiteProviders\OpenIDConnect\Providers;
+
+use SocialiteProviders\OpenIDConnect\Provider;
+
+class GoogleProvider extends Provider
+{
+    protected function configDefaults(array $config): array
+    {
+        return [
+            'base_url' => 'https://accounts.google.com',
+        ];
+    }
+}

--- a/src/OpenIDConnect/Providers/KeycloakProvider.php
+++ b/src/OpenIDConnect/Providers/KeycloakProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SocialiteProviders\OpenIDConnect\Providers;
+
+use SocialiteProviders\OpenIDConnect\Provider;
+
+/**
+ * Keycloak. The issuer lives under /realms/{realm}.
+ */
+class KeycloakProvider extends Provider
+{
+    public static function additionalConfigKeys(): array
+    {
+        return array_merge(parent::additionalConfigKeys(), ['server_url', 'realm']);
+    }
+
+    protected function configDefaults(array $config): array
+    {
+        if (! isset($config['server_url'], $config['realm'])) {
+            return [];
+        }
+
+        return [
+            'base_url' => rtrim((string) $config['server_url'], '/').'/realms/'.$config['realm'],
+        ];
+    }
+}

--- a/src/OpenIDConnect/Providers/OktaProvider.php
+++ b/src/OpenIDConnect/Providers/OktaProvider.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace SocialiteProviders\OpenIDConnect\Providers;
+
+use SocialiteProviders\OpenIDConnect\Provider;
+
+/**
+ * Okta. A custom authorization server lives under /oauth2/{server}; without
+ * one, the org authorization server is the issuer itself.
+ */
+class OktaProvider extends Provider
+{
+    public static function additionalConfigKeys(): array
+    {
+        return array_merge(parent::additionalConfigKeys(), ['domain', 'auth_server']);
+    }
+
+    protected function configDefaults(array $config): array
+    {
+        if (! isset($config['domain'])) {
+            return [];
+        }
+
+        $base = 'https://'.preg_replace('#^https?://#', '', rtrim((string) $config['domain'], '/'));
+
+        if (! empty($config['auth_server'])) {
+            $base .= '/oauth2/'.$config['auth_server'];
+        }
+
+        return ['base_url' => $base];
+    }
+}

--- a/src/OpenIDConnect/README.md
+++ b/src/OpenIDConnect/README.md
@@ -1,0 +1,191 @@
+# OpenID Connect
+
+A generic OpenID Connect driver for Laravel Socialite. Point it at any issuer that serves a discovery document: Keycloak, Entra ID, Auth0, Okta, Google, Authentik, or anything else that speaks OIDC. You can configure several issuers at once, and each becomes its own Socialite driver.
+
+Endpoints come from the issuer's discovery document. Signing keys come from its JWKS and refresh automatically when the issuer rotates them. Every id_token is validated properly (signature, `iss`, `aud`, `azp`, `exp`, `nonce`, `at_hash`) and PKCE is on by default.
+
+```bash
+composer require socialiteproviders/openid-connect
+```
+
+## Configure
+
+Publish the config file:
+
+```bash
+php artisan vendor:publish --tag=oidc-config
+```
+
+Add one entry per issuer to `config/oidc.php`:
+
+```php
+return [
+    'connections' => [
+
+        'keycloak' => [
+            'provider'      => 'keycloak',
+            'server_url'    => env('KEYCLOAK_SERVER_URL'),   // https://id.example.com
+            'realm'         => env('KEYCLOAK_REALM'),
+            'client_id'     => env('KEYCLOAK_CLIENT_ID'),
+            'client_secret' => env('KEYCLOAK_CLIENT_SECRET'),
+            'redirect'      => env('KEYCLOAK_REDIRECT_URI'),
+        ],
+
+        'entra' => [
+            'provider'      => 'entra',
+            'tenant'        => env('ENTRA_TENANT', 'common'),
+            'client_id'     => env('ENTRA_CLIENT_ID'),
+            'client_secret' => env('ENTRA_CLIENT_SECRET'),
+            'redirect'      => env('ENTRA_REDIRECT_URI'),
+        ],
+
+        // Any OIDC-compliant issuer works with just its base URL:
+        'authentik' => [
+            'base_url'      => env('AUTHENTIK_BASE_URL'),
+            'client_id'     => env('AUTHENTIK_CLIENT_ID'),
+            'client_secret' => env('AUTHENTIK_CLIENT_SECRET'),
+            'redirect'      => env('AUTHENTIK_REDIRECT_URI'),
+        ],
+
+    ],
+];
+```
+
+Each connection becomes a Socialite driver named `oidc_{connection}`. Connections share nothing: each has its own credentials, endpoints and caches.
+
+## Use
+
+Vanilla Socialite from here:
+
+```php
+// Send the user to the IdP:
+return Socialite::driver('oidc_keycloak')->redirect();
+
+// In your callback controller:
+$user = Socialite::driver('oidc_keycloak')->user();
+
+$user->getId();       // sub, the one claim every IdP must return
+$user->getEmail();    // null when the IdP didn't grant an email
+$user->getName();
+$user->getRaw();      // every claim from the id_token (merged with userinfo)
+```
+
+<details>
+<summary>Everything available on the returned user</summary>
+
+```php
+$user->getId();                              // sub
+$user->getRaw();                             // all claims
+$user->accessTokenResponseBody['id_token'];  // the raw id_token, stash it for logout
+$user->approvedScopes;                       // scopes the IdP actually granted
+$user->token;                                // access token
+$user->refreshToken;                         // refresh token, if granted
+```
+
+Mapped fields: `id` (`sub`), `email`, `name`, `nickname`, `given_name`, `family_name`, `idp`, `role`, `groups`.
+
+`email` isn't guaranteed. It depends on the `email` scope being granted, so a user without one gets a null email rather than a failed login. Set `require_email` if your application can't proceed without it. When the id_token has no email, the userinfo endpoint is consulted automatically and its claims merged in.
+
+Access and refresh tokens are bearer credentials. If you persist them, encrypt them at rest (Laravel's `encrypted` cast) and keep them out of JavaScript-readable storage.
+
+</details>
+
+For what comes after login (RP-initiated logout with state validation, RFC 7009 token revocation, back-channel logout, refreshing tokens, storing tokens safely) see [docs/logout.md](docs/logout.md).
+
+## Built-in providers
+
+The `provider` key picks the class that drives a connection. The built-in classes know the URL shape for their IdP, so you set `tenant` or `realm` or `domain` instead of building the base URL yourself. Anything you set explicitly wins over what the class derives:
+
+| `provider` | Reads | Derives |
+|---|---|---|
+| `entra` | `tenant` (default `common`) | `base_url`, multi-tenant issuer handling ([details](docs/extending.md#the-entra-issuer-template)), email from `preferred_username` ([why](docs/extending.md#entra-and-email)) |
+| `keycloak` | `server_url`, `realm` | `base_url` = `{server_url}/realms/{realm}` |
+| `auth0` | `domain` | `base_url`, `client_secret_post` token auth |
+| `okta` | `domain`, `auth_server` | `base_url`, `/oauth2/{auth_server}` when named |
+| `google` | none | `base_url` = `https://accounts.google.com` |
+
+For any other issuer, omit `provider` and set `base_url` directly. To encode your own IdP's shape, write a provider class and put its class name in `provider`. [docs/extending.md](docs/extending.md) covers the `configDefaults()` hook, the commonly overridden methods, and issuer validation (including [how Entra multi-tenant is handled](docs/extending.md#the-entra-issuer-template)).
+
+## Configuration reference
+
+<details>
+<summary>All connection keys</summary>
+
+Required: `client_id`, `client_secret`, `redirect`, and `base_url` (unless a built-in provider derives it).
+
+| Key | Default | Meaning |
+|---|---|---|
+| `base_url` | none | Issuer URL; discovery is `{base_url}/.well-known/openid-configuration`. https required (loopback hosts exempt, so local dev works). |
+| `provider` | `Provider::class` | Built-in shorthand or a Provider subclass name. |
+| `scopes` | `openid email profile` | Replaces the defaults. Array, or string separated by whitespace/commas. `openid` is always sent. |
+| `email_claims` | `['email']` | Claims consulted for the user's email, first non-empty wins. The `entra` provider defaults this to `['preferred_username']` ([why](docs/extending.md#entra-and-email)). |
+| `verify_jwt` | `true` | Verify id_token signatures. Only disable for an OP that can't serve a JWKS; back-channel logout tokens are always verified regardless. |
+| `jwt_public_key` | none | PEM public key used instead of fetching the JWKS. |
+| `jwt_algorithm` | advertised algs, else `RS256` | Pin the accepted signing algorithm(s), e.g. `RS256` or `RS256,ES256`. |
+| `issuer` | discovery `issuer` | Override the expected `iss` claim. |
+| `issuer_validator` | strict equality | [`IssuerValidator`](docs/extending.md#issuer-validators) class, for issuers an exact comparison can't handle. |
+| `token_auth_method` | advertised, preferring basic | `client_secret_basic` or `client_secret_post`. |
+| `use_nonce` | `true` | Send and validate a nonce. Ignored (always off) in stateless mode. |
+| `require_email` | `false` | Fail the login when no email can be obtained. |
+| `post_logout_redirect_uri` | none | Default for the [`logout()`](docs/logout.md) helper. |
+| `logout_token_replay_ttl` | token `exp` + skew | Seconds a back-channel logout `jti` is remembered. `0` disables built-in replay protection. |
+| `cache_ttl` | `3600` | TTL for the cached discovery document and JWKS. |
+| `clock_skew` | `0` | Leeway in seconds applied to `exp`/`nbf`/`iat`. |
+| `http_timeout` / `http_connect_timeout` | `10` / `5` | Guzzle timeouts for IdP calls. |
+| `proxy` | none | Proxy for IdP calls, in [Guzzle's format](https://docs.guzzlephp.org/en/stable/request-options.html#proxy) (a URL string, or an array per scheme). |
+
+The `driver_prefix` config key (default `oidc_`) controls the driver names.
+
+</details>
+
+<details>
+<summary>Single issuer without a config file</summary>
+
+A plain `services.php` entry registers an `openidconnect` driver with no `config/oidc.php` at all. The same keys apply, including `provider`:
+
+```php
+'openidconnect' => [
+    'base_url'      => env('OIDC_BASE_URL'),
+    'client_id'     => env('OIDC_CLIENT_ID'),
+    'client_secret' => env('OIDC_CLIENT_SECRET'),
+    'redirect'      => env('OIDC_REDIRECT_URI'),
+],
+```
+
+</details>
+
+## Security
+
+Every login validates the state (CSRF), the id_token signature against the discovered JWKS (refetched when keys rotate), the signing algorithm against an allow list, `iss`, `aud`/`azp`, `exp`/`nbf`/`iat`, the `nonce` (cleared after use, so replays fail), `at_hash` against the access token, and `sub`. PKCE is on by default. [docs/security.md](docs/security.md) has the full detail.
+
+<details>
+<summary>Stateless mode and PKCE</summary>
+
+The nonce and the PKCE verifier both live in the session between the redirect and the callback:
+
+- `->stateless()` skips the nonce automatically. That's safe for the code flow, where the code is bound to the client by PKCE and exchanged over the back channel. PKCE still works as long as a session store is bound to the request.
+- With genuinely no session, add `->withoutPKCE()`:
+
+```php
+Socialite::driver('oidc_keycloak')->stateless()->withoutPKCE()->redirect();
+```
+
+`withoutNonce()` disables the nonce alone.
+
+</details>
+
+## Testing
+
+```bash
+composer test
+```
+
+The suite covers discovery and caching, JWKS key rotation, algorithm and claim validation, nonce replay, userinfo merging, token endpoint auth methods, the logout flows, the built-in provider classes, and multi-connection isolation.
+
+## Credits
+
+The provider implementation originates from [SocialiteProviders/Providers#1447](https://github.com/SocialiteProviders/Providers/pull/1447) by [adrum](https://github.com/adrum).
+
+## License
+
+MIT

--- a/src/OpenIDConnect/README.md
+++ b/src/OpenIDConnect/README.md
@@ -5,7 +5,7 @@ A generic OpenID Connect driver for Laravel Socialite. Point it at any issuer th
 Endpoints come from the issuer's discovery document. Signing keys come from its JWKS and refresh automatically when the issuer rotates them. Every id_token is validated properly (signature, `iss`, `aud`, `azp`, `exp`, `nonce`, `at_hash`) and PKCE is on by default.
 
 ```bash
-composer require socialiteproviders/openid-connect
+composer require socialiteproviders/openidconnect
 ```
 
 ## Configure

--- a/src/OpenIDConnect/composer.json
+++ b/src/OpenIDConnect/composer.json
@@ -1,0 +1,45 @@
+{
+    "name": "socialiteproviders/openid-connect",
+    "description": "Generic OpenID Connect Provider for Laravel Socialite",
+    "license": "MIT",
+    "keywords": [
+        "laravel",
+        "oauth",
+        "oidc",
+        "openid",
+        "openid-connect",
+        "provider",
+        "socialite"
+    ],
+    "authors": [
+        {
+            "name": "adrum"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/socialiteproviders/providers/issues",
+        "source": "https://github.com/socialiteproviders/providers",
+        "docs": "https://socialiteproviders.com/openid-connect"
+    },
+    "require": {
+        "php": "^8.2",
+        "ext-json": "*",
+        "ext-openssl": "*",
+        "firebase/php-jwt": "^7.0",
+        "illuminate/http": "^11.0 | ^12.0 | ^13.0",
+        "illuminate/support": "^11.0 | ^12.0 | ^13.0",
+        "socialiteproviders/manager": "^4.4"
+    },
+    "autoload": {
+        "psr-4": {
+            "SocialiteProviders\\OpenIDConnect\\": ""
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "SocialiteProviders\\OpenIDConnect\\OpenIDConnectServiceProvider"
+            ]
+        }
+    }
+}

--- a/src/OpenIDConnect/composer.json
+++ b/src/OpenIDConnect/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "socialiteproviders/openid-connect",
+    "name": "socialiteproviders/openidconnect",
     "description": "Generic OpenID Connect Provider for Laravel Socialite",
     "license": "MIT",
     "keywords": [
@@ -19,7 +19,7 @@
     "support": {
         "issues": "https://github.com/socialiteproviders/providers/issues",
         "source": "https://github.com/socialiteproviders/providers",
-        "docs": "https://socialiteproviders.com/openid-connect"
+        "docs": "https://socialiteproviders.com/openidconnect"
     },
     "require": {
         "php": "^8.2",

--- a/src/OpenIDConnect/config/oidc.php
+++ b/src/OpenIDConnect/config/oidc.php
@@ -1,0 +1,79 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Driver prefix
+    |--------------------------------------------------------------------------
+    |
+    | Each connection below is registered as a Socialite driver named
+    | "{prefix}{connection}". With the default prefix, a 'keycloak' connection
+    | becomes Socialite::driver('oidc_keycloak').
+    |
+    */
+
+    'driver_prefix' => 'oidc_',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Connections
+    |--------------------------------------------------------------------------
+    |
+    | One entry per issuer. Every key the single-connection services block
+    | accepts is valid here; the full list with explanations is in the README.
+    | Common keys:
+    |
+    | base_url        The issuer URL; /.well-known/openid-configuration is
+    |                 appended for discovery. https is required except for
+    |                 loopback hosts.
+    | scopes          Replace the default 'openid email profile'.
+    | verify_jwt      Verify id_token signatures (default true).
+    | jwt_public_key  PEM alternative to the discovered JWKS.
+    | jwt_algorithm   Pin the accepted signing algorithm(s).
+    | issuer          Override the expected `iss` claim.
+    | proxy           Proxy for calls to the IdP, in Guzzle's format.
+    | issuer_validator  Class implementing IssuerValidator, for issuer shapes
+    |                 the default strict comparison cannot express (built-in
+    |                 providers set this where their IdP needs it).
+    | provider        Which Provider class drives this connection: a built-in
+    |                 shorthand (entra, keycloak, auth0, okta, google) or the
+    |                 name of any Provider subclass.
+    |                 Built-ins derive config from friendlier keys (tenant,
+    |                 server_url + realm, domain); your explicit values always
+    |                 win. Subclasses can override configDefaults() and any
+    |                 other method.
+    |
+    | Examples:
+    |
+    | 'keycloak' => [
+    |     'provider'      => 'keycloak',
+    |     'server_url'    => env('KEYCLOAK_SERVER_URL'),   // https://id.example.com
+    |     'realm'         => env('KEYCLOAK_REALM'),
+    |     'client_id'     => env('KEYCLOAK_CLIENT_ID'),
+    |     'client_secret' => env('KEYCLOAK_CLIENT_SECRET'),
+    |     'redirect'      => env('KEYCLOAK_REDIRECT_URI'),
+    | ],
+    |
+    | 'entra' => [
+    |     'provider'      => 'entra',
+    |     'tenant'        => env('ENTRA_TENANT', 'common'),
+    |     'client_id'     => env('ENTRA_CLIENT_ID'),
+    |     'client_secret' => env('ENTRA_CLIENT_SECRET'),
+    |     'redirect'      => env('ENTRA_REDIRECT_URI'),
+    | ],
+    |
+    | 'authentik' => [
+    |     'base_url'      => env('AUTHENTIK_BASE_URL'),
+    |     'client_id'     => env('AUTHENTIK_CLIENT_ID'),
+    |     'client_secret' => env('AUTHENTIK_CLIENT_SECRET'),
+    |     'redirect'      => env('AUTHENTIK_REDIRECT_URI'),
+    | ],
+    |
+    */
+
+    'connections' => [
+        //
+    ],
+
+];

--- a/src/OpenIDConnect/docs/extending.md
+++ b/src/OpenIDConnect/docs/extending.md
@@ -1,0 +1,118 @@
+# Extending
+
+There are two extension points: a provider class per connection, and an issuer validator for the one check whose shape varies between IdPs.
+
+## Custom provider classes
+
+The `provider` key in a connection names the class that drives it. Built-in shorthands (`entra`, `keycloak`, `auth0`, `okta`, `google`) map to subclasses shipped with the package. Any class extending `SocialiteProviders\OpenIDConnect\Provider` works the same way. There is no registration step: Socialite instantiates the class when the driver is first resolved.
+
+A subclass usually overrides two things:
+
+- `configDefaults(array $config): array`. Defaults derived from the connection's own values, merged under whatever the user set explicitly. This is where `base_url` gets built from a friendlier key, or a quirk gets pinned.
+- `additionalConfigKeys(): array`. Any extra keys the class reads, so the manager's config retriever passes them through.
+
+```php
+use SocialiteProviders\OpenIDConnect\Provider;
+
+class MyCorpProvider extends Provider
+{
+    public static function additionalConfigKeys(): array
+    {
+        return array_merge(parent::additionalConfigKeys(), ['tenant']);
+    }
+
+    protected function configDefaults(array $config): array
+    {
+        return [
+            'base_url'   => 'https://sso.mycorp.example/tenants/'.($config['tenant'] ?? 'default'),
+            'scopes'     => ['email', 'mycorp:roles'],
+            'clock_skew' => 30,
+        ];
+    }
+}
+```
+
+```php
+// config/oidc.php
+'connections' => [
+    'mycorp' => [
+        'provider'      => MyCorpProvider::class,
+        'tenant'        => 'acme',
+        'client_id'     => env('MYCORP_CLIENT_ID'),
+        'client_secret' => env('MYCORP_CLIENT_SECRET'),
+        'redirect'      => env('MYCORP_REDIRECT_URI'),
+    ],
+],
+```
+
+For deeper changes, override the relevant method. The common ones:
+
+| Override | To change |
+|---|---|
+| `mapUserToObject(array $user)` | Which claims land on the Socialite user |
+| `getScopes()` / `$scopes` | Scope handling |
+| `getBaseUrl()` | How the issuer URL is resolved or constrained |
+| `resolveTokenAuthMethod()` | Client authentication at the token endpoint |
+| `validateIdTokenClaims($payload, $alg, $accessToken)` | Claim validation (call `parent::` and add, rather than replace) |
+| `getHttpClient()` | HTTP behaviour (middleware, mTLS; a plain proxy is the `proxy` config key) |
+
+The built-in provider classes in [`src/Providers/`](../src/Providers) are the reference examples. Each is a few lines.
+
+## Issuer validators
+
+The `iss` claim is checked on every id_token and every back-channel logout token. The expected value is the `issuer` config, falling back to the discovery document's, and the default comparison is strict equality.
+
+Some IdPs don't emit their issuer verbatim, so the comparison is pluggable. A validator implements one method and gets the full token payload, so other claims can inform the decision:
+
+```php
+use SocialiteProviders\OpenIDConnect\IssuerValidators\IssuerValidator;
+use stdClass;
+
+class MyIssuerValidator implements IssuerValidator
+{
+    public function validate(string $expectedIssuer, stdClass $payload): bool
+    {
+        return str_starts_with($payload->iss ?? '', 'https://sso.mycorp.example/');
+    }
+}
+```
+
+Wire it in at whichever level fits:
+
+```php
+// Per connection, resolved through the container:
+'issuer_validator' => MyIssuerValidator::class,
+
+// Per request, a class instance or a closure:
+Socialite::driver('oidc_mycorp')
+    ->validateIssuerUsing(fn (string $expected, stdClass $payload) => /* bool */)
+    ->user();
+
+// Per provider class, as a derived default, the way EntraProvider does:
+protected function configDefaults(array $config): array
+{
+    return ['issuer_validator' => MyIssuerValidator::class];
+}
+```
+
+### The Entra issuer template
+
+Entra ID advertises the issuer for multi-tenant apps as a literal template, placeholder unsubstituted:
+
+```
+https://login.microsoftonline.com/{tenantid}/v2.0
+```
+
+A strict comparison can never match that. `EntraProvider` defaults `issuer_validator` to `EntraIssuerValidator`, which substitutes the token's `tid` claim into the placeholder before comparing exactly, so `'provider' => 'entra'` needs no issuer configuration at all. Single-tenant setups have no placeholder and are compared strictly, unchanged.
+
+### Entra and email
+
+Entra's `email` claim is the directory contact email, often empty and settable to any address by any tenant admin with no domain verification. Treating it as an account identifier in a multi-tenant app is the [nOAuth account takeover](https://www.descope.com/blog/post/noauth). The login identity lives in `preferred_username` instead: for work and school accounts it's the UPN, whose domain the issuing tenant has to have verified.
+
+So `EntraProvider` resolves the user's email from `preferred_username` only, skipping values that aren't email-shaped (`preferred_username` can be a phone number). It deliberately does not fall back to `email`. A fallback would surface the spoofable value in exactly the case that matters: a hostile tenant minting a token with a phone-shaped `preferred_username` and any `email` it likes. If the fallback is fine for you (a single-tenant app trusting its own directory, say), opt in per connection:
+
+```php
+'email_claims' => ['preferred_username', 'email'],
+```
+
+Whatever claim it comes from, treat the email as display data. Key accounts on `$user->getId()` (the `sub` claim), which is immutable and can't be spoofed across tenants. If you must link accounts by email, request Microsoft's `xms_edov` optional claim and only trust the email when it says the domain owner is verified. Querying Microsoft Graph doesn't help: it returns the same directory attributes, controlled by the same tenant admin.

--- a/src/OpenIDConnect/docs/logout.md
+++ b/src/OpenIDConnect/docs/logout.md
@@ -1,0 +1,140 @@
+# Logout, revocation & tokens
+
+Ending sessions at the IdP, killing tokens, and reacting when the IdP ends a session first. Examples use `oidc_keycloak`; substitute your driver.
+
+## Refreshing tokens
+
+```php
+$response = Socialite::driver('oidc_keycloak')->refreshToken($refreshToken);
+// ['access_token' => ..., 'refresh_token' => ..., 'expires_in' => ...]
+```
+
+## RP-initiated logout
+
+If the IdP advertises an `end_session_endpoint`, `logout()` builds the redirect that ends the session there too:
+
+```php
+// At login, stash the id_token. Most IdPs require it as id_token_hint:
+session(['oidc_id_token' => $user->accessTokenResponseBody['id_token']]);
+
+// In your logout controller:
+return Socialite::driver('oidc_keycloak')
+    ->logout(session('oidc_id_token'), route('home'));
+```
+
+The post-logout URI must be pre-registered with the client. The second argument overrides the `post_logout_redirect_uri` config.
+
+`logout()` mints a `state` and stores it in the session. Validate it in the controller backing your post-logout URI. The stored value is consumed on first use, so a replayed redirect fails:
+
+```php
+if (! Socialite::driver('oidc_keycloak')->validateLogoutState($request)) {
+    abort(403);
+}
+
+Auth::logout();
+$request->session()->invalidate();
+```
+
+## Token revocation
+
+If the IdP advertises a `revocation_endpoint` (RFC 7009), you can revoke tokens server-side. Useful at logout so a refresh token dies immediately instead of waiting out its lifetime:
+
+```php
+try {
+    Socialite::driver('oidc_keycloak')->revoke($refreshToken, 'refresh_token');
+} catch (Throwable $e) {
+    report($e); // best-effort: never block the logout on it
+}
+```
+
+Returns `true` for 200/204 and `false` otherwise. A conforming server answers 200 even for an already-revoked token, so `false` means the revocation genuinely didn't happen (rejected credentials, for example). Transport failures still throw, hence the wrap.
+
+## Back-channel logout
+
+If you register a `backchannel_logout_uri` with the IdP, it POSTs a signed `logout_token` there whenever the user logs out elsewhere (another app in the SSO federation, or an admin revoking the session). Your job: verify the token, destroy the matching local sessions.
+
+### The endpoint
+
+```php
+Route::post('/oidc/backchannel-logout', function (Request $request) {
+    try {
+        $claims = Socialite::driver('oidc_keycloak')
+            ->verifyLogoutToken($request->input('logout_token'));
+    } catch (\InvalidArgumentException $e) {
+        return response('', 400);
+    }
+
+    // Destroy sessions matching $claims['sid'] (that one session)
+    // or $claims['sub'] (all of the user's sessions), see below.
+
+    return response('', 200);
+})->withoutMiddleware(['web']); // no CSRF token or session cookie on IdP requests
+```
+
+`verifyLogoutToken()` enforces the full spec: the signature (always, even with `verify_jwt => false`, because this token arrives unsolicited on an unauthenticated endpoint), `iss`, `aud`, `iat`/`exp`, the required `events` claim, the presence of `sub` and/or `sid`, and the absence of a `nonce`. It also records the `jti` atomically and refuses a token already acted on, so IdP retries and replays both land in the `catch`. Set `logout_token_replay_ttl` to `0` to handle replay yourself.
+
+### Mapping `sid` to Laravel sessions
+
+The IdP identifies the session with a `sid` claim it mints itself, present in both the id_token at login and the logout_token at logout. Store the mapping at login, consult it at logout:
+
+```php
+// Migration
+Schema::create('oidc_sessions', function (Blueprint $table) {
+    $table->string('sid')->primary();
+    $table->string('laravel_session_id');
+    $table->foreignId('user_id')->constrained();
+    $table->timestamps();
+});
+
+// Login callback. sid arrives via the raw claims, not as a first-class field:
+if ($sid = $oidcUser->getRaw()['sid'] ?? null) {
+    DB::table('oidc_sessions')->updateOrInsert(['sid' => $sid], [
+        'laravel_session_id' => session()->getId(),
+        'user_id'            => $user->id,
+        'updated_at'         => now(),
+        'created_at'         => now(),
+    ]);
+}
+
+// Back-channel endpoint:
+$rows = DB::table('oidc_sessions')->where('sid', $claims['sid'])->get();
+
+$handler = Session::getHandler();
+foreach ($rows as $row) {
+    $handler->destroy($row->laravel_session_id);
+}
+
+DB::table('oidc_sessions')->whereIn('sid', $rows->pluck('sid'))->delete();
+```
+
+If the IdP doesn't emit `sid` (check `backchannel_logout_session_supported` in its discovery document), logout tokens only carry `sub`. You can still implement this, but you kill all of that user's sessions instead of the one that ended.
+
+## Storing tokens beyond the session
+
+Session storage is fine when the user always logs out from the browser they logged in with. To revoke or refresh from a back-channel handler or a background job, store tokens on the user record instead. Encrypted, always:
+
+```php
+// User model
+protected $casts = [
+    'oidc_id_token'      => 'encrypted',
+    'oidc_refresh_token' => 'encrypted',
+];
+
+// Login callback
+$user = User::updateOrCreate(['email' => $oidcUser->email], [
+    'name'               => $oidcUser->name,
+    'oidc_id_token'      => $oidcUser->accessTokenResponseBody['id_token'],
+    'oidc_refresh_token' => $oidcUser->refreshToken,
+]);
+
+// Logout controller
+if ($user->oidc_refresh_token) {
+    Socialite::driver('oidc_keycloak')->revoke($user->oidc_refresh_token);
+}
+$idToken = $user->oidc_id_token;
+$user->update(['oidc_id_token' => null, 'oidc_refresh_token' => null]);
+
+return Socialite::driver('oidc_keycloak')->logout($idToken, route('home'));
+```
+
+Both tokens are bearer credentials. Never expose them to JavaScript-readable storage.

--- a/src/OpenIDConnect/docs/security.md
+++ b/src/OpenIDConnect/docs/security.md
@@ -1,0 +1,43 @@
+# Security model
+
+What a login enforces, and why. The short version: state (CSRF), signature, algorithm allow list, `iss`, `aud`/`azp`, `exp`/`nbf`/`iat`, `nonce`, `at_hash`, `sub`, with PKCE on by default.
+
+## Signatures and algorithms
+
+The allow list comes from the `jwt_algorithm` config or the OP's advertised `id_token_signing_alg_values_supported`, falling back to `RS256`. The token header's `alg` is only ever checked against that list, never trusted to select the algorithm. Deriving it from the header is the substitution attack of RFC 8725 section 2.1.
+
+`alg: none` is always rejected, even if advertised or configured.
+
+HS\* algorithms are rejected against a JWKS or an asymmetric key, so public material can never double as an HMAC secret (key confusion).
+
+A token naming a `kid` the cached JWKS doesn't have triggers one refetch, which is how key rotation works without any cache tuning. `jwt_public_key` (PEM) replaces the JWKS entirely when set.
+
+## Claims
+
+`iss` is strict equality by default, pluggable per [issuer validators](extending.md#issuer-validators).
+
+The token must name this client in `aud`. Multiple audiences require `azp` (OIDC Core 3.1.3.7 step 4), and a present `azp` must be this client (step 5). A token naming us as audience but authorized to a different party is not ours to accept.
+
+`exp` is required outright. `firebase/php-jwt` only enforces expiry when the claim is present, so a token omitting it would otherwise never expire. `nbf` and `iat` are checked when present, all with `clock_skew` leeway.
+
+The `nonce` is minted at redirect, compared at callback, and cleared after use, so a replayed id_token fails.
+
+`at_hash` is validated against the access token when present (left-most half of the hash, OIDC Core 3.1.3.6), so a valid id_token can't be paired with someone else's access token.
+
+`sub` is the one claim every OP must return (OIDC Core 2). A login without it is rejected.
+
+## Transport
+
+`base_url` must be https. Every endpoint derives from it, so a plaintext issuer would expose discovery, the JWKS and the token exchange to tampering. Loopback hosts (`localhost`, `127.0.0.1`, `::1`, `*.localhost`) are exempt so local development works.
+
+Userinfo is consulted only when the id_token has no email. The access token travels in the Authorization header, never a query parameter (which leaks into logs and Referer headers), and the response's `sub` must match the id_token's before its claims are used (OIDC Core 5.3.2).
+
+`client_secret_basic` credentials are form-urlencoded before base64 (RFC 6749 section 2.3.1), so secrets containing `+`, `/`, `=` or spaces work.
+
+IdP calls default to 5s connect / 10s total timeouts, so a hanging IdP can't tie up PHP workers.
+
+## What `verify_jwt => false` actually means
+
+It skips only the signature check on id_tokens, leaning on OIDC Core 3.1.3.7 step 6: the token answers a request this client made over TLS, bound to the session by nonce and PKCE. Every claim check above still runs. It exists for the rare OP that can't serve a JWKS.
+
+It never applies to back-channel logout tokens, which arrive unsolicited on an unauthenticated endpoint and are always signature-verified (see [logout](logout.md#back-channel-logout)).

--- a/tests/OpenIDConnect/Feature/DriverPrefixTest.php
+++ b/tests/OpenIDConnect/Feature/DriverPrefixTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect\Feature;
+
+use Laravel\Socialite\Facades\Socialite;
+use SocialiteProviders\OpenIDConnect\Provider;
+use SocialiteProviders\Tests\OpenIDConnect\TestCase;
+
+class DriverPrefixTest extends TestCase
+{
+    protected function defineEnvironment($app): void
+    {
+        $app['config']->set('oidc.driver_prefix', 'sso_');
+        $app['config']->set('oidc.connections', [
+            'main' => [
+                'base_url'      => 'https://sso.test',
+                'client_id'     => 'main-client',
+                'client_secret' => 'main-secret',
+                'redirect'      => 'https://app.test/callback',
+            ],
+        ]);
+    }
+
+    public function test_the_driver_prefix_is_configurable(): void
+    {
+        $this->assertInstanceOf(Provider::class, Socialite::driver('sso_main'));
+        $this->assertSame('main-client', config('services.sso_main.client_id'));
+    }
+
+    public function test_the_default_prefix_is_not_used_when_overridden(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Socialite::driver('oidc_main');
+    }
+}

--- a/tests/OpenIDConnect/Feature/MultiConnectionTest.php
+++ b/tests/OpenIDConnect/Feature/MultiConnectionTest.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect\Feature;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Http\Request;
+use Illuminate\Session\ArraySessionHandler;
+use Illuminate\Session\Store;
+use InvalidArgumentException;
+use Laravel\Socialite\Facades\Socialite;
+use ReflectionMethod;
+use ReflectionProperty;
+use SocialiteProviders\OpenIDConnect\IssuerValidators\EntraIssuerValidator;
+use SocialiteProviders\OpenIDConnect\OpenIDConnectServiceProvider;
+use SocialiteProviders\OpenIDConnect\Provider;
+use SocialiteProviders\OpenIDConnect\Providers\EntraProvider;
+use SocialiteProviders\Tests\OpenIDConnect\Support\CustomProvider;
+use SocialiteProviders\Tests\OpenIDConnect\TestCase;
+
+class MultiConnectionTest extends TestCase
+{
+    protected function defineEnvironment($app): void
+    {
+        $app['config']->set('oidc.connections', [
+            'keycloak' => [
+                'base_url'      => 'https://kc.test/realms/main',
+                'client_id'     => 'kc-client',
+                'client_secret' => 'kc-secret',
+                'redirect'      => 'https://app.test/kc/callback',
+            ],
+            'authentik' => [
+                'base_url'      => 'https://ak.test/application/o/app',
+                'client_id'     => 'ak-client',
+                'client_secret' => 'ak-secret',
+                'redirect'      => 'https://app.test/ak/callback',
+            ],
+            'entra' => [
+                'provider'      => 'entra',
+                'tenant'        => 'contoso',
+                'client_id'     => 'ms-client',
+                'client_secret' => 'ms-secret',
+                'redirect'      => 'https://app.test/ms/callback',
+            ],
+            'custom' => [
+                'provider'      => CustomProvider::class,
+                'base_url'      => 'https://custom.test',
+                'client_id'     => 'custom-client',
+                'client_secret' => 'custom-secret',
+                'redirect'      => 'https://app.test/custom/callback',
+            ],
+        ]);
+
+        $app['config']->set('services.openidconnect', [
+            'base_url'      => 'https://single.test',
+            'client_id'     => 'single-client',
+            'client_secret' => 'single-secret',
+            'redirect'      => 'https://app.test/callback',
+        ]);
+    }
+
+    private function clientIdOf(Provider $provider): string
+    {
+        return (new ReflectionProperty($provider, 'clientId'))->getValue($provider);
+    }
+
+    private function configValueOf(Provider $provider, string $key): mixed
+    {
+        return (new ReflectionMethod($provider, 'getConfig'))->invoke($provider, $key);
+    }
+
+    public function test_each_connection_is_mirrored_into_the_services_config(): void
+    {
+        $this->assertSame('kc-client', config('services.oidc_keycloak.client_id'));
+        $this->assertSame('ak-client', config('services.oidc_authentik.client_id'));
+    }
+
+    public function test_each_connection_registers_its_own_driver_with_its_own_config(): void
+    {
+        $keycloak = Socialite::driver('oidc_keycloak');
+        $authentik = Socialite::driver('oidc_authentik');
+
+        $this->assertInstanceOf(Provider::class, $keycloak);
+        $this->assertInstanceOf(Provider::class, $authentik);
+        $this->assertSame('kc-client', $this->clientIdOf($keycloak));
+        $this->assertSame('ak-client', $this->clientIdOf($authentik));
+        $this->assertSame('https://kc.test/realms/main', $this->configValueOf($keycloak, 'base_url'));
+        $this->assertSame('https://ak.test/application/o/app', $this->configValueOf($authentik, 'base_url'));
+    }
+
+    public function test_connections_redirect_to_their_own_issuers(): void
+    {
+        foreach ([
+            'oidc_keycloak'  => ['https://kc.test/realms/main', 'kc-client'],
+            'oidc_authentik' => ['https://ak.test/application/o/app', 'ak-client'],
+        ] as $driver => [$baseUrl, $clientId]) {
+            $provider = Socialite::driver($driver);
+
+            $request = Request::create('https://app.test/login', 'GET');
+            $request->setLaravelSession(new Store('testing', new ArraySessionHandler(120)));
+            $provider->setRequest($request);
+
+            $provider->setHttpClient(new Client([
+                'handler' => HandlerStack::create(new MockHandler([
+                    new Response(200, [], json_encode([
+                        'authorization_endpoint' => $baseUrl.'/authorize',
+                        'issuer'                 => $baseUrl,
+                    ])),
+                ])),
+            ]));
+
+            $url = $provider->redirect()->getTargetUrl();
+
+            $this->assertStringStartsWith($baseUrl.'/authorize?', $url);
+            parse_str((string) parse_url($url, PHP_URL_QUERY), $query);
+            $this->assertSame($clientId, $query['client_id']);
+        }
+    }
+
+    public function test_a_provider_shorthand_resolves_to_the_built_in_class_with_derived_config(): void
+    {
+        $entra = Socialite::driver('oidc_entra');
+
+        $this->assertInstanceOf(EntraProvider::class, $entra);
+        $this->assertSame(
+            'https://login.microsoftonline.com/contoso/v2.0',
+            $this->configValueOf($entra, 'base_url'),
+        );
+        $this->assertSame(
+            EntraIssuerValidator::class,
+            $this->configValueOf($entra, 'issuer_validator'),
+        );
+    }
+
+    public function test_a_connection_can_swap_in_a_provider_subclass(): void
+    {
+        $this->assertInstanceOf(CustomProvider::class, Socialite::driver('oidc_custom'));
+    }
+
+    public function test_the_single_connection_services_fallback_still_registers(): void
+    {
+        $provider = Socialite::driver('openidconnect');
+
+        $this->assertInstanceOf(Provider::class, $provider);
+        $this->assertSame('single-client', $this->clientIdOf($provider));
+    }
+
+    public function test_an_unregistered_driver_is_refused(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Socialite::driver('oidc_nope');
+    }
+
+    public function test_an_invalid_provider_class_is_refused_at_registration(): void
+    {
+        config(['oidc.connections' => [
+            'bad' => [
+                'provider'  => \stdClass::class,
+                'base_url'  => 'https://bad.test',
+            ],
+        ]]);
+
+        $serviceProvider = new OpenIDConnectServiceProvider($this->app);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('extending');
+
+        (new ReflectionMethod($serviceProvider, 'connections'))->invoke($serviceProvider);
+    }
+
+    public function test_an_unknown_provider_shorthand_lists_the_known_ones(): void
+    {
+        config(['oidc.connections' => [
+            'bad' => ['provider' => 'nope', 'base_url' => 'https://bad.test'],
+        ]]);
+
+        $serviceProvider = new OpenIDConnectServiceProvider($this->app);
+
+        try {
+            (new ReflectionMethod($serviceProvider, 'connections'))->invoke($serviceProvider);
+            $this->fail('Expected the unknown shorthand to be refused.');
+        } catch (InvalidArgumentException $e) {
+            $this->assertStringContainsString('[nope]', $e->getMessage());
+            $this->assertStringContainsString('entra', $e->getMessage());
+            $this->assertStringContainsString('keycloak', $e->getMessage());
+        }
+    }
+}

--- a/tests/OpenIDConnect/Support/AcceptSuffixIssuerValidator.php
+++ b/tests/OpenIDConnect/Support/AcceptSuffixIssuerValidator.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect\Support;
+
+use SocialiteProviders\OpenIDConnect\IssuerValidators\IssuerValidator;
+use stdClass;
+
+/**
+ * Accepts any issuer ending in '/accepted', regardless of the expected value.
+ * Exists to prove the `issuer_validator` config key swaps the comparison.
+ */
+class AcceptSuffixIssuerValidator implements IssuerValidator
+{
+    public function validate(string $expectedIssuer, stdClass $payload): bool
+    {
+        return is_string($payload->iss ?? null) && str_ends_with($payload->iss, '/accepted');
+    }
+}

--- a/tests/OpenIDConnect/Support/CustomProvider.php
+++ b/tests/OpenIDConnect/Support/CustomProvider.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect\Support;
+
+use SocialiteProviders\OpenIDConnect\Provider;
+
+/**
+ * Proves a connection can swap in its own Provider subclass.
+ */
+class CustomProvider extends Provider {}

--- a/tests/OpenIDConnect/Support/InteractsWithOidc.php
+++ b/tests/OpenIDConnect/Support/InteractsWithOidc.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect\Support;
+
+use Firebase\JWT\JWT;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Http\Request;
+use Illuminate\Session\ArraySessionHandler;
+use Illuminate\Session\Store;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use SocialiteProviders\Manager\Config;
+use SocialiteProviders\OpenIDConnect\Provider;
+
+/**
+ * Builds providers wired to a Guzzle MockHandler, and signed test tokens.
+ *
+ * Key slots: slot 1 is "the OP's current key", slot 2 is "the key the OP
+ * rotated to". Both are real 2048-bit RSA keys, generated once per process.
+ */
+trait InteractsWithOidc
+{
+    protected static array $rsaKeys = [];
+
+    /** @var array<int, array{request: RequestInterface, response: ?ResponseInterface}> */
+    protected array $httpHistory = [];
+
+    protected ?MockHandler $mockHandler = null;
+
+    protected static string $opBaseUrl = 'https://op.test';
+
+    protected static string $opClientId = 'client-id';
+
+    protected static string $opClientSecret = 'client-secret';
+
+    protected static string $opRedirect = 'https://app.test/callback';
+
+    protected static string $opNonce = 'test-nonce-value';
+
+    protected static string $opState = 'test-state-value';
+
+    /**
+     * @return array{private: string, public: string, n: string, e: string}
+     */
+    protected static function rsaKey(int $slot = 1): array
+    {
+        if (! isset(static::$rsaKeys[$slot])) {
+            $resource = openssl_pkey_new([
+                'private_key_bits' => 2048,
+                'private_key_type' => OPENSSL_KEYTYPE_RSA,
+            ]);
+
+            openssl_pkey_export($resource, $privatePem);
+            $details = openssl_pkey_get_details($resource);
+
+            static::$rsaKeys[$slot] = [
+                'private' => $privatePem,
+                'public'  => $details['key'],
+                'n'       => static::base64Url($details['rsa']['n']),
+                'e'       => static::base64Url($details['rsa']['e']),
+            ];
+        }
+
+        return static::$rsaKeys[$slot];
+    }
+
+    protected static function base64Url(string $data): string
+    {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+
+    protected function jwk(string $kid = 'kid-1', int $slot = 1): array
+    {
+        $key = static::rsaKey($slot);
+
+        return [
+            'kty' => 'RSA',
+            'use' => 'sig',
+            'alg' => 'RS256',
+            'kid' => $kid,
+            'n'   => $key['n'],
+            'e'   => $key['e'],
+        ];
+    }
+
+    /**
+     * @param  array  $keys  list of jwk() arrays; defaults to slot 1 under kid-1
+     */
+    protected function jwksDocument(?array $keys = null): array
+    {
+        return ['keys' => $keys ?? [$this->jwk()]];
+    }
+
+    protected function idTokenClaims(array $overrides = []): array
+    {
+        return array_merge([
+            'iss'   => static::$opBaseUrl,
+            'aud'   => static::$opClientId,
+            'sub'   => 'user-123',
+            'email' => 'user@example.com',
+            'name'  => 'Test User',
+            'exp'   => time() + 3600,
+            'iat'   => time(),
+            'nonce' => static::$opNonce,
+        ], $overrides);
+    }
+
+    protected function encodeToken(array $claims, string $kid = 'kid-1', string $alg = 'RS256', int $slot = 1): string
+    {
+        return JWT::encode($claims, static::rsaKey($slot)['private'], $alg, $kid);
+    }
+
+    protected function encodeTokenWithoutKid(array $claims, string $alg = 'RS256', int $slot = 1): string
+    {
+        return JWT::encode($claims, static::rsaKey($slot)['private'], $alg);
+    }
+
+    /**
+     * A structurally valid JWT whose signature verifies against nothing.
+     */
+    protected function unsignedToken(array $claims, array $header = ['alg' => 'RS256', 'typ' => 'JWT']): string
+    {
+        return static::base64Url(json_encode($header))
+            .'.'.static::base64Url(json_encode($claims))
+            .'.'.static::base64Url('not-a-signature');
+    }
+
+    protected function atHashFor(string $accessToken, string $algo = 'sha256'): string
+    {
+        $digest = hash($algo, $accessToken, true);
+
+        return static::base64Url(substr($digest, 0, intdiv(strlen($digest), 2)));
+    }
+
+    protected function discoveryDocument(array $overrides = []): array
+    {
+        return array_merge([
+            'issuer'                                => static::$opBaseUrl,
+            'authorization_endpoint'                => static::$opBaseUrl.'/authorize',
+            'token_endpoint'                        => static::$opBaseUrl.'/token',
+            'userinfo_endpoint'                     => static::$opBaseUrl.'/userinfo',
+            'jwks_uri'                              => static::$opBaseUrl.'/jwks',
+            'end_session_endpoint'                  => static::$opBaseUrl.'/logout',
+            'revocation_endpoint'                   => static::$opBaseUrl.'/revoke',
+            'id_token_signing_alg_values_supported' => ['RS256'],
+        ], $overrides);
+    }
+
+    protected function jsonResponse(array $data, int $status = 200): Response
+    {
+        return new Response($status, ['Content-Type' => 'application/json'], json_encode($data));
+    }
+
+    protected function tokenEndpointResponse(string $idToken, array $overrides = []): Response
+    {
+        return $this->jsonResponse(array_merge([
+            'access_token'  => 'the-access-token',
+            'token_type'    => 'Bearer',
+            'expires_in'    => 3600,
+            'refresh_token' => 'the-refresh-token',
+            'scope'         => 'openid email profile',
+            'id_token'      => $idToken,
+        ], $overrides));
+    }
+
+    protected function sessionStore(): Store
+    {
+        return new Store('testing', new ArraySessionHandler(120));
+    }
+
+    protected function callbackRequest(?array $query = null, bool $withSession = true, ?array $session = null): Request
+    {
+        $query ??= ['code' => 'the-auth-code', 'state' => static::$opState];
+
+        $request = Request::create('https://app.test/callback', 'GET', $query);
+
+        if ($withSession) {
+            $store = $this->sessionStore();
+
+            foreach ($session ?? ['state' => static::$opState, Provider::NONCE_SESSION_KEY => static::$opNonce] as $key => $value) {
+                $store->put($key, $value);
+            }
+
+            $request->setLaravelSession($store);
+        }
+
+        return $request;
+    }
+
+    protected function redirectRequest(bool $withSession = true): Request
+    {
+        $request = Request::create('https://app.test/login', 'GET');
+
+        if ($withSession) {
+            $request->setLaravelSession($this->sessionStore());
+        }
+
+        return $request;
+    }
+
+    /**
+     * @param  array  $config  additional provider config, merged over base_url
+     * @param  array  $responses  Guzzle MockHandler queue
+     * @param  class-string<Provider>  $providerClass
+     */
+    protected function makeProvider(array $config = [], array $responses = [], ?Request $request = null, string $providerClass = Provider::class): Provider
+    {
+        $request ??= $this->callbackRequest();
+
+        $config = array_merge(['base_url' => static::$opBaseUrl], $config);
+
+        $provider = new $providerClass(
+            $request,
+            static::$opClientId,
+            static::$opClientSecret,
+            static::$opRedirect,
+        );
+
+        $provider->setConfig(new Config(
+            static::$opClientId,
+            static::$opClientSecret,
+            static::$opRedirect,
+            $config,
+        ));
+
+        $this->mockHandler = new MockHandler($responses);
+
+        $stack = HandlerStack::create($this->mockHandler);
+        $this->httpHistory = [];
+        $stack->push(Middleware::history($this->httpHistory));
+
+        $provider->setHttpClient(new Client(['handler' => $stack]));
+
+        return $provider;
+    }
+
+    /**
+     * The standard happy-path queue: discovery, token exchange, JWKS.
+     */
+    protected function happyPathResponses(?array $claims = null, string $kid = 'kid-1', array $tokenOverrides = []): array
+    {
+        $claims ??= $this->idTokenClaims();
+
+        return [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse($this->encodeToken($claims, $kid), $tokenOverrides),
+            $this->jsonResponse($this->jwksDocument()),
+        ];
+    }
+
+    /**
+     * Requests recorded by the history middleware, as "METHOD path" strings.
+     *
+     * @return string[]
+     */
+    protected function requestedPaths(): array
+    {
+        return array_map(
+            static fn (array $entry) => $entry['request']->getMethod().' '.$entry['request']->getUri()->getPath(),
+            $this->httpHistory,
+        );
+    }
+
+    protected function lastRequestTo(string $path): ?RequestInterface
+    {
+        foreach (array_reverse($this->httpHistory) as $entry) {
+            if ($path === $entry['request']->getUri()->getPath()) {
+                return $entry['request'];
+            }
+        }
+
+        return null;
+    }
+
+    protected function queryOf(string $url): array
+    {
+        parse_str((string) parse_url($url, PHP_URL_QUERY), $query);
+
+        return $query;
+    }
+}

--- a/tests/OpenIDConnect/TestCase.php
+++ b/tests/OpenIDConnect/TestCase.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect;
+
+use Firebase\JWT\JWT;
+use Orchestra\Testbench\TestCase as Orchestra;
+use SocialiteProviders\Manager\ServiceProvider;
+use SocialiteProviders\OpenIDConnect\OpenIDConnectServiceProvider;
+
+abstract class TestCase extends Orchestra
+{
+    protected function getPackageProviders($app)
+    {
+        return [
+            ServiceProvider::class,
+            OpenIDConnectServiceProvider::class,
+        ];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // php-jwt's leeway is global mutable state the provider writes to.
+        JWT::$leeway = 0;
+    }
+}

--- a/tests/OpenIDConnect/Unit/AtHashTest.php
+++ b/tests/OpenIDConnect/Unit/AtHashTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect\Unit;
+
+use InvalidArgumentException;
+use ReflectionMethod;
+use SocialiteProviders\Tests\OpenIDConnect\Support\InteractsWithOidc;
+use SocialiteProviders\Tests\OpenIDConnect\TestCase;
+
+class AtHashTest extends TestCase
+{
+    use InteractsWithOidc;
+
+    public function test_a_correct_at_hash_is_accepted(): void
+    {
+        $claims = $this->idTokenClaims([
+            'at_hash' => $this->atHashFor('the-access-token'),
+        ]);
+
+        $provider = $this->makeProvider([], $this->happyPathResponses($claims));
+
+        $this->assertSame('user-123', $provider->user()->getId());
+    }
+
+    public function test_an_at_hash_for_a_different_access_token_is_rejected(): void
+    {
+        $claims = $this->idTokenClaims([
+            'at_hash' => $this->atHashFor('a-stolen-access-token'),
+        ]);
+
+        $provider = $this->makeProvider([], $this->happyPathResponses($claims));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('at_hash mismatch');
+
+        $provider->user();
+    }
+
+    public function test_at_hash_validation_fails_closed_on_an_unmappable_algorithm(): void
+    {
+        $provider = $this->makeProvider([], []);
+        $validate = new ReflectionMethod($provider, 'validateAtHash');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot validate at_hash for algorithm [NOPE]');
+
+        $validate->invoke($provider, 'any-hash', 'the-access-token', 'NOPE');
+    }
+
+    public function test_eddsa_at_hash_is_validated_with_sha512(): void
+    {
+        $provider = $this->makeProvider([], []);
+        $validate = new ReflectionMethod($provider, 'validateAtHash');
+
+        $validate->invoke($provider, $this->atHashFor('the-access-token', 'sha512'), 'the-access-token', 'EdDSA');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('at_hash mismatch');
+
+        $validate->invoke($provider, $this->atHashFor('a-different-token', 'sha512'), 'the-access-token', 'EdDSA');
+    }
+
+    public function test_a_token_without_at_hash_is_tolerated(): void
+    {
+        // at_hash is OPTIONAL for the code flow (OIDC Core 3.1.3.6).
+        $provider = $this->makeProvider([], $this->happyPathResponses());
+
+        $this->assertSame('user-123', $provider->user()->getId());
+    }
+
+    public function test_at_hash_is_validated_in_the_unverified_path_too(): void
+    {
+        $claims = $this->idTokenClaims([
+            'at_hash' => $this->atHashFor('a-stolen-access-token'),
+        ]);
+
+        $provider = $this->makeProvider(['verify_jwt' => false], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse($this->unsignedToken($claims)),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('at_hash mismatch');
+
+        $provider->user();
+    }
+}

--- a/tests/OpenIDConnect/Unit/AudienceTest.php
+++ b/tests/OpenIDConnect/Unit/AudienceTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect\Unit;
+
+use InvalidArgumentException;
+use SocialiteProviders\Tests\OpenIDConnect\Support\InteractsWithOidc;
+use SocialiteProviders\Tests\OpenIDConnect\TestCase;
+
+class AudienceTest extends TestCase
+{
+    use InteractsWithOidc;
+
+    public function test_a_token_for_another_client_is_rejected(): void
+    {
+        $claims = $this->idTokenClaims(['aud' => 'someone-else']);
+
+        $provider = $this->makeProvider([], $this->happyPathResponses($claims));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid audience');
+
+        $provider->user();
+    }
+
+    public function test_an_audience_array_containing_this_client_is_accepted_with_azp(): void
+    {
+        $claims = $this->idTokenClaims([
+            'aud' => [static::$opClientId, 'other-client'],
+            'azp' => static::$opClientId,
+        ]);
+
+        $provider = $this->makeProvider([], $this->happyPathResponses($claims));
+
+        $this->assertSame('user-123', $provider->user()->getId());
+    }
+
+    public function test_multiple_audiences_without_azp_are_rejected(): void
+    {
+        $claims = $this->idTokenClaims([
+            'aud' => [static::$opClientId, 'other-client'],
+        ]);
+
+        $provider = $this->makeProvider([], $this->happyPathResponses($claims));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('azp');
+
+        $provider->user();
+    }
+
+    public function test_an_azp_naming_a_different_party_is_rejected_even_with_a_single_audience(): void
+    {
+        $claims = $this->idTokenClaims([
+            'aud' => static::$opClientId,
+            'azp' => 'other-client',
+        ]);
+
+        $provider = $this->makeProvider([], $this->happyPathResponses($claims));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('azp');
+
+        $provider->user();
+    }
+
+    public function test_a_single_string_audience_matching_this_client_is_accepted(): void
+    {
+        $provider = $this->makeProvider([], $this->happyPathResponses());
+
+        $this->assertSame('user-123', $provider->user()->getId());
+    }
+
+    public function test_a_single_element_audience_array_with_a_foreign_azp_is_rejected(): void
+    {
+        $claims = $this->idTokenClaims([
+            'aud' => [static::$opClientId],
+            'azp' => 'another-client',
+        ]);
+
+        $provider = $this->makeProvider([], $this->happyPathResponses($claims));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('azp');
+
+        $provider->user();
+    }
+}

--- a/tests/OpenIDConnect/Unit/BackchannelLogoutTest.php
+++ b/tests/OpenIDConnect/Unit/BackchannelLogoutTest.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect\Unit;
+
+use InvalidArgumentException;
+use SocialiteProviders\OpenIDConnect\IssuerValidators\EntraIssuerValidator;
+use SocialiteProviders\Tests\OpenIDConnect\Support\InteractsWithOidc;
+use SocialiteProviders\Tests\OpenIDConnect\TestCase;
+
+class BackchannelLogoutTest extends TestCase
+{
+    use InteractsWithOidc;
+
+    private function logoutTokenClaims(array $overrides = []): array
+    {
+        return array_merge([
+            'iss'    => static::$opBaseUrl,
+            'aud'    => static::$opClientId,
+            'iat'    => time(),
+            'exp'    => time() + 120,
+            'jti'    => 'jti-'.bin2hex(random_bytes(8)),
+            'sid'    => 'idp-session-1',
+            'sub'    => 'user-123',
+            'events' => ['http://schemas.openid.net/event/backchannel-logout' => (object) []],
+        ], $overrides);
+    }
+
+    /**
+     * Discovery + JWKS, the two calls verifyLogoutToken() needs.
+     */
+    private function backchannelResponses(): array
+    {
+        return [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->jsonResponse($this->jwksDocument()),
+        ];
+    }
+
+    public function test_a_valid_logout_token_returns_its_claims(): void
+    {
+        $provider = $this->makeProvider([], $this->backchannelResponses());
+
+        $claims = $provider->verifyLogoutToken($this->encodeToken($this->logoutTokenClaims([
+            'jti' => 'jti-valid',
+        ])));
+
+        $this->assertSame('idp-session-1', $claims['sid']);
+        $this->assertSame('user-123', $claims['sub']);
+    }
+
+    public function test_logout_tokens_are_verified_even_when_verify_jwt_is_false(): void
+    {
+        // The id_token TLS exemption never applies to an unsolicited POST.
+        $provider = $this->makeProvider(['verify_jwt' => false], $this->backchannelResponses());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Verification failed');
+
+        $provider->verifyLogoutToken($this->unsignedToken($this->logoutTokenClaims()));
+    }
+
+    public function test_a_replayed_jti_is_rejected(): void
+    {
+        $token = $this->encodeToken($this->logoutTokenClaims(['jti' => 'jti-replay']));
+
+        $provider = $this->makeProvider([], $this->backchannelResponses());
+        $provider->verifyLogoutToken($token);
+
+        $again = $this->makeProvider([], []);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('already used');
+
+        $again->verifyLogoutToken($token);
+    }
+
+    public function test_replay_protection_can_be_opted_out_of(): void
+    {
+        $token = $this->encodeToken($this->logoutTokenClaims(['jti' => 'jti-optout']));
+
+        $provider = $this->makeProvider(['logout_token_replay_ttl' => 0], $this->backchannelResponses());
+        $provider->verifyLogoutToken($token);
+
+        $again = $this->makeProvider(['logout_token_replay_ttl' => 0], []);
+
+        $this->assertSame('user-123', $again->verifyLogoutToken($token)['sub']);
+    }
+
+    public function test_a_missing_events_claim_is_rejected(): void
+    {
+        $claims = $this->logoutTokenClaims();
+        unset($claims['events']);
+
+        $provider = $this->makeProvider([], $this->backchannelResponses());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('backchannel-logout event');
+
+        $provider->verifyLogoutToken($this->encodeToken($claims));
+    }
+
+    public function test_a_nonce_is_forbidden_in_logout_tokens(): void
+    {
+        // Back-Channel Logout 2.4: a nonce marks an id_token; refusing it
+        // prevents token-type confusion.
+        $provider = $this->makeProvider([], $this->backchannelResponses());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('must not contain a nonce');
+
+        $provider->verifyLogoutToken($this->encodeToken($this->logoutTokenClaims([
+            'nonce' => 'some-nonce',
+        ])));
+    }
+
+    public function test_a_missing_jti_is_rejected(): void
+    {
+        $claims = $this->logoutTokenClaims();
+        unset($claims['jti']);
+
+        $provider = $this->makeProvider([], $this->backchannelResponses());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('missing jti');
+
+        $provider->verifyLogoutToken($this->encodeToken($claims));
+    }
+
+    public function test_a_missing_iat_is_rejected(): void
+    {
+        $claims = $this->logoutTokenClaims();
+        unset($claims['iat']);
+
+        $provider = $this->makeProvider([], $this->backchannelResponses());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('iat');
+
+        $provider->verifyLogoutToken($this->encodeToken($claims));
+    }
+
+    public function test_a_token_with_neither_sub_nor_sid_is_rejected(): void
+    {
+        $claims = $this->logoutTokenClaims();
+        unset($claims['sub'], $claims['sid']);
+
+        $provider = $this->makeProvider([], $this->backchannelResponses());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('sub and/or sid');
+
+        $provider->verifyLogoutToken($this->encodeToken($claims));
+    }
+
+    public function test_a_logout_token_from_another_issuer_is_rejected(): void
+    {
+        $provider = $this->makeProvider([], $this->backchannelResponses());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid issuer');
+
+        $provider->verifyLogoutToken($this->encodeToken($this->logoutTokenClaims([
+            'iss' => 'https://evil.test',
+        ])));
+    }
+
+    public function test_a_logout_token_for_another_client_is_rejected(): void
+    {
+        $provider = $this->makeProvider([], $this->backchannelResponses());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('invalid audience');
+
+        $provider->verifyLogoutToken($this->encodeToken($this->logoutTokenClaims([
+            'aud' => 'someone-else',
+        ])));
+    }
+
+    public function test_an_expired_logout_token_is_rejected(): void
+    {
+        $provider = $this->makeProvider([], $this->backchannelResponses());
+
+        try {
+            $provider->verifyLogoutToken($this->encodeToken($this->logoutTokenClaims([
+                'exp' => time() - 120,
+                'iat' => time() - 240,
+            ])));
+            $this->fail('Expected the expired logout token to be rejected.');
+        } catch (InvalidArgumentException $e) {
+            $this->assertSame(401, $e->getCode());
+            $this->assertStringContainsStringIgnoringCase('expired', $e->getMessage());
+        }
+    }
+
+    public function test_the_configured_issuer_validator_applies_to_logout_tokens_too(): void
+    {
+        $provider = $this->makeProvider(
+            [
+                'issuer'           => 'https://login.microsoftonline.com/{tenantid}/v2.0',
+                'issuer_validator' => EntraIssuerValidator::class,
+            ],
+            $this->backchannelResponses(),
+        );
+
+        $claims = $provider->verifyLogoutToken($this->encodeToken($this->logoutTokenClaims([
+            'iss' => 'https://login.microsoftonline.com/tenant-123/v2.0',
+            'tid' => 'tenant-123',
+        ])));
+
+        $this->assertSame('user-123', $claims['sub']);
+    }
+}

--- a/tests/OpenIDConnect/Unit/BaseUrlTest.php
+++ b/tests/OpenIDConnect/Unit/BaseUrlTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect\Unit;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionMethod;
+use SocialiteProviders\OpenIDConnect\Provider;
+use SocialiteProviders\Tests\OpenIDConnect\Support\InteractsWithOidc;
+use SocialiteProviders\Tests\OpenIDConnect\TestCase;
+
+class BaseUrlTest extends TestCase
+{
+    use InteractsWithOidc;
+
+    private function baseUrlOf(Provider $provider): string
+    {
+        return (new ReflectionMethod($provider, 'getBaseUrl'))->invoke($provider);
+    }
+
+    public function test_https_base_url_is_accepted_and_trailing_slash_trimmed(): void
+    {
+        $provider = $this->makeProvider(['base_url' => 'https://id.example.com/realms/main/']);
+
+        $this->assertSame('https://id.example.com/realms/main', $this->baseUrlOf($provider));
+    }
+
+    public function test_missing_base_url_is_rejected(): void
+    {
+        $provider = $this->makeProvider(['base_url' => null]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('base_url is not configured');
+
+        $this->baseUrlOf($provider);
+    }
+
+    public function test_plain_http_base_url_is_rejected(): void
+    {
+        $provider = $this->makeProvider(['base_url' => 'http://id.example.com']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('must use https');
+
+        $this->baseUrlOf($provider);
+    }
+
+    public function test_schemeless_base_url_is_rejected(): void
+    {
+        $provider = $this->makeProvider(['base_url' => 'id.example.com']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('must use https');
+
+        $this->baseUrlOf($provider);
+    }
+
+    #[DataProvider('loopbackHosts')]
+    public function test_plain_http_is_allowed_for_loopback_hosts(string $baseUrl): void
+    {
+        $provider = $this->makeProvider(['base_url' => $baseUrl]);
+
+        $this->assertSame($baseUrl, $this->baseUrlOf($provider));
+    }
+
+    public static function loopbackHosts(): array
+    {
+        return [
+            'localhost'      => ['http://localhost:8080'],
+            'ipv4 loopback'  => ['http://127.0.0.1:8080'],
+            'ipv6 loopback'  => ['http://[::1]:8080'],
+            'localhost tld'  => ['http://keycloak.localhost'],
+        ];
+    }
+
+    public function test_lookalike_host_is_not_treated_as_loopback(): void
+    {
+        $provider = $this->makeProvider(['base_url' => 'http://localhost.evil.com']);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->baseUrlOf($provider);
+    }
+}

--- a/tests/OpenIDConnect/Unit/CallbackGuardTest.php
+++ b/tests/OpenIDConnect/Unit/CallbackGuardTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect\Unit;
+
+use GuzzleHttp\Psr7\Response;
+use InvalidArgumentException;
+use SocialiteProviders\Tests\OpenIDConnect\Support\InteractsWithOidc;
+use SocialiteProviders\Tests\OpenIDConnect\TestCase;
+
+class CallbackGuardTest extends TestCase
+{
+    use InteractsWithOidc;
+
+    public function test_idp_error_response_is_surfaced_without_any_http_calls(): void
+    {
+        $provider = $this->makeProvider([], [], $this->callbackRequest([
+            'error'             => 'access_denied',
+            'error_description' => 'User cancelled',
+        ]));
+
+        try {
+            $provider->user();
+            $this->fail('Expected the IdP error to be surfaced.');
+        } catch (InvalidArgumentException $e) {
+            $this->assertStringContainsString('User cancelled', $e->getMessage());
+            $this->assertSame(401, $e->getCode());
+        }
+
+        $this->assertSame([], $this->requestedPaths());
+    }
+
+    public function test_mismatched_state_is_rejected(): void
+    {
+        $provider = $this->makeProvider([], [], $this->callbackRequest(
+            ['code' => 'the-auth-code', 'state' => 'attacker-state'],
+        ));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('invalid state');
+
+        $provider->user();
+    }
+
+    public function test_missing_code_is_rejected(): void
+    {
+        $provider = $this->makeProvider([], [], $this->callbackRequest(
+            ['state' => static::$opState],
+        ));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('missing authorization code');
+
+        $provider->user();
+    }
+
+    public function test_token_endpoint_error_with_http_200_is_rejected(): void
+    {
+        // Some IdPs answer 200 with an error body; Guzzle won't raise for us.
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->jsonResponse(['error' => 'invalid_grant', 'error_description' => 'Code expired']),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Code expired');
+
+        $provider->user();
+    }
+
+    public function test_token_response_without_id_token_is_rejected(): void
+    {
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->jsonResponse(['access_token' => 'the-access-token', 'token_type' => 'Bearer']),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('no id_token');
+
+        $provider->user();
+    }
+
+    public function test_id_token_without_sub_is_rejected(): void
+    {
+        $claims = $this->idTokenClaims(['sub' => null]);
+
+        $provider = $this->makeProvider([], $this->happyPathResponses($claims));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('sub');
+
+        $provider->user();
+    }
+
+    public function test_a_non_json_token_response_is_rejected(): void
+    {
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+            new Response(200, ['Content-Type' => 'text/html'], '<html>gateway error</html>'),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $provider->user();
+    }
+}

--- a/tests/OpenIDConnect/Unit/DiscoveryTest.php
+++ b/tests/OpenIDConnect/Unit/DiscoveryTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect\Unit;
+
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Support\Facades\Cache;
+use InvalidArgumentException;
+use ReflectionMethod;
+use SocialiteProviders\OpenIDConnect\Provider;
+use SocialiteProviders\Tests\OpenIDConnect\Support\InteractsWithOidc;
+use SocialiteProviders\Tests\OpenIDConnect\TestCase;
+
+class DiscoveryTest extends TestCase
+{
+    use InteractsWithOidc;
+
+    private function openIdConfigOf(Provider $provider): array
+    {
+        return (new ReflectionMethod($provider, 'getOpenIdConfig'))->invoke($provider);
+    }
+
+    public function test_discovery_document_is_fetched_from_well_known_url(): void
+    {
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+        ]);
+
+        $config = $this->openIdConfigOf($provider);
+
+        $this->assertSame(static::$opBaseUrl.'/token', $config['token_endpoint']);
+        $this->assertSame(['GET /.well-known/openid-configuration'], $this->requestedPaths());
+    }
+
+    public function test_all_endpoints_are_derived_from_the_discovery_document(): void
+    {
+        $doc = $this->discoveryDocument([
+            'authorization_endpoint' => static::$opBaseUrl.'/custom/auth',
+            'token_endpoint'         => static::$opBaseUrl.'/custom/token',
+            'userinfo_endpoint'      => static::$opBaseUrl.'/custom/userinfo',
+            'jwks_uri'               => static::$opBaseUrl.'/custom/jwks',
+        ]);
+
+        $provider = $this->makeProvider([], [$this->jsonResponse($doc)]);
+
+        $config = $this->openIdConfigOf($provider);
+
+        $this->assertSame(static::$opBaseUrl.'/custom/auth', $config['authorization_endpoint']);
+        $this->assertSame(static::$opBaseUrl.'/custom/token', $config['token_endpoint']);
+        $this->assertSame(static::$opBaseUrl.'/custom/userinfo', $config['userinfo_endpoint']);
+        $this->assertSame(static::$opBaseUrl.'/custom/jwks', $config['jwks_uri']);
+    }
+
+    public function test_discovery_document_is_cached_across_provider_instances(): void
+    {
+        $first = $this->makeProvider([], [$this->jsonResponse($this->discoveryDocument())]);
+        $this->openIdConfigOf($first);
+
+        // No queued responses: any HTTP call would blow up the MockHandler.
+        $second = $this->makeProvider([], []);
+
+        $this->assertSame(
+            static::$opBaseUrl.'/token',
+            $this->openIdConfigOf($second)['token_endpoint']
+        );
+        $this->assertSame([], $this->requestedPaths());
+    }
+
+    public function test_discovery_document_is_cached_under_a_url_derived_key(): void
+    {
+        $provider = $this->makeProvider([], [$this->jsonResponse($this->discoveryDocument())]);
+        $this->openIdConfigOf($provider);
+
+        $key = 'openidconnect_discovery_'.md5(static::$opBaseUrl.'/.well-known/openid-configuration');
+
+        $this->assertTrue(Cache::has($key));
+    }
+
+    public function test_a_cache_ttl_of_zero_disables_caching(): void
+    {
+        $provider = $this->makeProvider(['cache_ttl' => 0], [
+            $this->jsonResponse($this->discoveryDocument()),
+        ]);
+        $this->openIdConfigOf($provider);
+
+        $key = 'openidconnect_discovery_'.md5(static::$opBaseUrl.'/.well-known/openid-configuration');
+
+        $this->assertFalse(Cache::has($key));
+    }
+
+    public function test_an_empty_cache_ttl_falls_back_to_the_default(): void
+    {
+        $provider = $this->makeProvider(['cache_ttl' => ''], [
+            $this->jsonResponse($this->discoveryDocument()),
+        ]);
+        $this->openIdConfigOf($provider);
+
+        $key = 'openidconnect_discovery_'.md5(static::$opBaseUrl.'/.well-known/openid-configuration');
+
+        $this->assertTrue(Cache::has($key));
+    }
+
+    public function test_malformed_discovery_json_is_rejected(): void
+    {
+        $provider = $this->makeProvider([], [
+            new Response(200, [], 'this is not json'),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to get the OIDC configuration');
+
+        $this->openIdConfigOf($provider);
+    }
+
+    public function test_a_null_discovery_document_is_rejected(): void
+    {
+        $provider = $this->makeProvider([], [
+            new Response(200, ['Content-Type' => 'application/json'], 'null'),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('not a JSON object');
+
+        $this->openIdConfigOf($provider);
+    }
+
+    public function test_an_empty_discovery_document_is_rejected(): void
+    {
+        $provider = $this->makeProvider([], [
+            new Response(200, ['Content-Type' => 'application/json'], '[]'),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('not a JSON object');
+
+        $this->openIdConfigOf($provider);
+    }
+
+    public function test_discovery_http_failure_is_rejected(): void
+    {
+        $provider = $this->makeProvider([], [new Response(500, [], 'oops')]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to get the OIDC configuration');
+
+        $this->openIdConfigOf($provider);
+    }
+
+    public function test_discovery_failure_is_not_cached(): void
+    {
+        $provider = $this->makeProvider([], [new Response(500, [], 'oops')]);
+
+        try {
+            $this->openIdConfigOf($provider);
+            $this->fail('Expected discovery to fail.');
+        } catch (InvalidArgumentException) {
+            // expected
+        }
+
+        $key = 'openidconnect_discovery_'.md5(static::$opBaseUrl.'/.well-known/openid-configuration');
+        $this->assertFalse(Cache::has($key));
+
+        // A later attempt succeeds once the OP recovers.
+        $retry = $this->makeProvider([], [$this->jsonResponse($this->discoveryDocument())]);
+        $this->assertSame(static::$opBaseUrl.'/token', $this->openIdConfigOf($retry)['token_endpoint']);
+    }
+}

--- a/tests/OpenIDConnect/Unit/EmailClaimsTest.php
+++ b/tests/OpenIDConnect/Unit/EmailClaimsTest.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect\Unit;
+
+use InvalidArgumentException;
+use ReflectionMethod;
+use SocialiteProviders\OpenIDConnect\Providers\EntraProvider;
+use SocialiteProviders\Tests\OpenIDConnect\Support\InteractsWithOidc;
+use SocialiteProviders\Tests\OpenIDConnect\TestCase;
+
+class EmailClaimsTest extends TestCase
+{
+    use InteractsWithOidc;
+
+    public function test_the_email_claim_is_used_by_default(): void
+    {
+        $provider = $this->makeProvider([], $this->happyPathResponses());
+
+        $this->assertSame('user@example.com', $provider->user()->getEmail());
+    }
+
+    public function test_configured_claims_are_tried_in_order(): void
+    {
+        $claims = $this->idTokenClaims([
+            'email'              => null,
+            'preferred_username' => 'login@example.com',
+        ]);
+
+        $provider = $this->makeProvider(
+            ['email_claims' => ['preferred_username', 'email']],
+            $this->happyPathResponses($claims),
+        );
+
+        $this->assertSame('login@example.com', $provider->user()->getEmail());
+    }
+
+    public function test_an_empty_first_claim_falls_through_to_the_next(): void
+    {
+        $claims = $this->idTokenClaims([
+            'preferred_username' => '',
+            'email'              => 'contact@example.com',
+        ]);
+
+        $provider = $this->makeProvider(
+            ['email_claims' => ['preferred_username', 'email']],
+            $this->happyPathResponses($claims),
+        );
+
+        $this->assertSame('contact@example.com', $provider->user()->getEmail());
+    }
+
+    public function test_claims_can_be_configured_as_a_string(): void
+    {
+        $claims = $this->idTokenClaims([
+            'email' => null,
+            'upn'   => 'upn@example.com',
+        ]);
+
+        $provider = $this->makeProvider(
+            ['email_claims' => 'upn, email'],
+            $this->happyPathResponses($claims),
+        );
+
+        $this->assertSame('upn@example.com', $provider->user()->getEmail());
+    }
+
+    public function test_an_alternate_claim_satisfies_require_email(): void
+    {
+        $claims = $this->idTokenClaims([
+            'email'              => null,
+            'preferred_username' => 'login@example.com',
+        ]);
+
+        $provider = $this->makeProvider(
+            ['require_email' => true, 'email_claims' => ['preferred_username', 'email']],
+            $this->happyPathResponses($claims),
+        );
+
+        $this->assertSame('login@example.com', $provider->user()->getEmail());
+    }
+
+    public function test_userinfo_is_not_consulted_when_an_alternate_claim_is_present(): void
+    {
+        $claims = $this->idTokenClaims([
+            'email'              => null,
+            'preferred_username' => 'login@example.com',
+        ]);
+
+        $provider = $this->makeProvider(
+            ['email_claims' => ['preferred_username', 'email']],
+            $this->happyPathResponses($claims),
+        );
+        $provider->user();
+
+        $this->assertNotContains('GET /userinfo', $this->requestedPaths());
+    }
+
+    public function test_require_email_still_fails_when_no_configured_claim_resolves(): void
+    {
+        $claims = $this->idTokenClaims(['email' => null]);
+
+        $provider = $this->makeProvider(
+            ['require_email' => true, 'email_claims' => ['preferred_username', 'email']],
+            [
+                $this->jsonResponse($this->discoveryDocument()),
+                $this->tokenEndpointResponse($this->encodeToken($claims)),
+                $this->jsonResponse($this->jwksDocument()),
+                $this->jsonResponse(['sub' => 'user-123', 'name' => 'No Email']),
+            ],
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('no email');
+
+        $provider->user();
+    }
+
+    private function entraResolveEmail(array $claims, array $config = []): ?string
+    {
+        $provider = $this->makeProvider($config, [], providerClass: EntraProvider::class);
+
+        return (new ReflectionMethod($provider, 'resolveEmail'))->invoke($provider, $claims);
+    }
+
+    public function test_entra_uses_preferred_username_and_ignores_the_contact_email(): void
+    {
+        $this->assertSame('login@contoso.com', $this->entraResolveEmail([
+            'preferred_username' => 'login@contoso.com',
+            'email'              => 'unrelated-contact@gmail.com',
+        ]));
+    }
+
+    public function test_entra_does_not_fall_back_to_the_spoofable_email_claim(): void
+    {
+        // A phone-shaped preferred_username with a free-text email claim is
+        // the token an attacker-controlled tenant would mint; email must not
+        // be consulted unless the app opts in.
+        $this->assertNull($this->entraResolveEmail([
+            'preferred_username' => '+61400000000',
+            'email'              => 'ceo@victim.com',
+        ]));
+
+        $this->assertNull($this->entraResolveEmail([
+            'email' => 'contact@contoso.com',
+        ]));
+    }
+
+    public function test_an_entra_login_without_an_acceptable_preferred_username_gets_a_null_email(): void
+    {
+        $claims = $this->idTokenClaims([
+            'preferred_username' => '+61400000000',
+            'email'              => 'ceo@victim.com',
+        ]);
+
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse($this->encodeToken($claims)),
+            $this->jsonResponse($this->jwksDocument()),
+            $this->jsonResponse(['sub' => 'user-123', 'email' => 'ceo@victim.com']),
+        ], providerClass: EntraProvider::class);
+
+        $this->assertNull($provider->user()->getEmail());
+    }
+
+    public function test_entra_email_fallback_is_opt_in(): void
+    {
+        $this->assertSame('contact@contoso.com', $this->entraResolveEmail(
+            ['email'        => 'contact@contoso.com'],
+            ['email_claims' => ['preferred_username', 'email']],
+        ));
+    }
+}

--- a/tests/OpenIDConnect/Unit/HttpClientTest.php
+++ b/tests/OpenIDConnect/Unit/HttpClientTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect\Unit;
+
+use GuzzleHttp\Client;
+use Illuminate\Http\Request;
+use ReflectionMethod;
+use ReflectionProperty;
+use SocialiteProviders\Manager\Config;
+use SocialiteProviders\OpenIDConnect\Provider;
+use SocialiteProviders\Tests\OpenIDConnect\TestCase;
+
+class HttpClientTest extends TestCase
+{
+    private function clientOptions(array $config): array
+    {
+        $provider = new Provider(
+            Request::create('https://app.test/login'),
+            'the-client',
+            'the-secret',
+            'https://app.test/callback',
+        );
+
+        $provider->setConfig(new Config('the-client', 'the-secret', 'https://app.test/callback', $config));
+
+        $client = (new ReflectionMethod($provider, 'getHttpClient'))->invoke($provider);
+        $this->assertInstanceOf(Client::class, $client);
+
+        return (new ReflectionProperty($client, 'config'))->getValue($client);
+    }
+
+    public function test_proxy_config_is_passed_to_the_http_client(): void
+    {
+        $options = $this->clientOptions([
+            'base_url' => 'https://op.test',
+            'proxy'    => 'http://proxy.corp.test:8080',
+        ]);
+
+        $this->assertSame('http://proxy.corp.test:8080', $options['proxy']);
+    }
+
+    public function test_no_proxy_is_set_by_default(): void
+    {
+        $options = $this->clientOptions(['base_url' => 'https://op.test']);
+
+        $this->assertArrayNotHasKey('proxy', $options);
+    }
+
+    public function test_timeouts_fall_back_to_the_defaults(): void
+    {
+        $options = $this->clientOptions(['base_url' => 'https://op.test']);
+
+        $this->assertSame(5.0, $options['connect_timeout']);
+        $this->assertSame(10.0, $options['timeout']);
+    }
+
+    public function test_an_explicit_zero_timeout_disables_the_timeout(): void
+    {
+        $options = $this->clientOptions([
+            'base_url'             => 'https://op.test',
+            'http_connect_timeout' => 0,
+            'http_timeout'         => 0,
+        ]);
+
+        $this->assertSame(0.0, $options['connect_timeout']);
+        $this->assertSame(0.0, $options['timeout']);
+    }
+
+    public function test_an_empty_timeout_falls_back_to_the_default(): void
+    {
+        $options = $this->clientOptions([
+            'base_url'             => 'https://op.test',
+            'http_connect_timeout' => '',
+            'http_timeout'         => '',
+        ]);
+
+        $this->assertSame(5.0, $options['connect_timeout']);
+        $this->assertSame(10.0, $options['timeout']);
+    }
+
+    public function test_proxy_is_a_declared_config_key(): void
+    {
+        $this->assertContains('proxy', Provider::additionalConfigKeys());
+    }
+}

--- a/tests/OpenIDConnect/Unit/IdTokenVerificationTest.php
+++ b/tests/OpenIDConnect/Unit/IdTokenVerificationTest.php
@@ -1,0 +1,323 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect\Unit;
+
+use Firebase\JWT\JWT;
+use InvalidArgumentException;
+use SocialiteProviders\Tests\OpenIDConnect\Support\InteractsWithOidc;
+use SocialiteProviders\Tests\OpenIDConnect\TestCase;
+
+class IdTokenVerificationTest extends TestCase
+{
+    use InteractsWithOidc;
+
+    public function test_a_validly_signed_id_token_produces_a_mapped_user(): void
+    {
+        $provider = $this->makeProvider([], $this->happyPathResponses());
+
+        $user = $provider->user();
+
+        $this->assertSame('user-123', $user->getId());
+        $this->assertSame('user@example.com', $user->getEmail());
+        $this->assertSame('Test User', $user->getName());
+        $this->assertSame('the-access-token', $user->token);
+        $this->assertSame('the-refresh-token', $user->refreshToken);
+        $this->assertSame(3600, $user->expiresIn);
+        $this->assertSame(['openid', 'email', 'profile'], $user->approvedScopes);
+        $this->assertArrayHasKey('id_token', $user->accessTokenResponseBody);
+
+        // No userinfo call: the id_token already carried an email.
+        $this->assertSame([
+            'GET /.well-known/openid-configuration',
+            'POST /token',
+            'GET /jwks',
+        ], $this->requestedPaths());
+    }
+
+    public function test_alg_none_is_always_rejected(): void
+    {
+        // Advertise `none` support and even pin it in config: it must still lose.
+        $token = $this->unsignedToken($this->idTokenClaims(), ['alg' => 'none', 'typ' => 'JWT']);
+
+        $provider = $this->makeProvider(['jwt_algorithm' => 'none'], [
+            $this->jsonResponse($this->discoveryDocument([
+                'id_token_signing_alg_values_supported' => ['none', 'RS256'],
+            ])),
+            $this->tokenEndpointResponse($token),
+            $this->jsonResponse($this->jwksDocument()),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Disallowed signing algorithm [none]');
+
+        $provider->user();
+    }
+
+    public function test_algorithm_not_on_the_allow_list_is_rejected(): void
+    {
+        $token = $this->unsignedToken($this->idTokenClaims(), ['alg' => 'ES256', 'typ' => 'JWT']);
+
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse($token),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Disallowed signing algorithm [ES256]');
+
+        $provider->user();
+    }
+
+    public function test_a_token_with_no_alg_header_is_rejected(): void
+    {
+        $token = $this->unsignedToken($this->idTokenClaims(), ['typ' => 'JWT']);
+
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse($token),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Disallowed signing algorithm [missing]');
+
+        $provider->user();
+    }
+
+    public function test_a_tampered_signature_is_rejected(): void
+    {
+        $token = $this->encodeToken($this->idTokenClaims());
+
+        [$header, , $signature] = explode('.', $token);
+        $forgedPayload = static::base64Url(json_encode($this->idTokenClaims(['sub' => 'admin'])));
+        $forged = $header.'.'.$forgedPayload.'.'.$signature;
+
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse($forged),
+            $this->jsonResponse($this->jwksDocument()),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Verification failed');
+
+        $provider->user();
+    }
+
+    public function test_hmac_algorithms_are_rejected_against_a_jwks(): void
+    {
+        // Key confusion: HMAC-signing with public material.
+        $token = JWT::encode($this->idTokenClaims(), str_repeat('shared-secret!', 4), 'HS256');
+
+        $provider = $this->makeProvider(['jwt_algorithm' => 'HS256'], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse($token),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('HMAC algorithms cannot be verified against a JWKS');
+
+        $provider->user();
+    }
+
+    public function test_hmac_algorithms_are_rejected_with_an_asymmetric_public_key(): void
+    {
+        // RFC 8725 2.1: HS256 with the (public!) PEM as the MAC secret.
+        $publicPem = static::rsaKey()['public'];
+        $token = JWT::encode($this->idTokenClaims(), $publicPem, 'HS256');
+
+        $provider = $this->makeProvider([
+            'jwt_algorithm'  => 'HS256',
+            'jwt_public_key' => $publicPem,
+        ], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse($token),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('HMAC algorithms cannot be used with an asymmetric public key');
+
+        $provider->user();
+    }
+
+    public function test_a_pinned_jwt_algorithm_overrides_the_discovery_document(): void
+    {
+        $provider = $this->makeProvider(['jwt_algorithm' => 'RS256'], [
+            $this->jsonResponse($this->discoveryDocument([
+                'id_token_signing_alg_values_supported' => ['ES256'],
+            ])),
+            $this->tokenEndpointResponse($this->encodeToken($this->idTokenClaims())),
+            $this->jsonResponse($this->jwksDocument()),
+        ]);
+
+        $this->assertSame('user-123', $provider->user()->getId());
+    }
+
+    public function test_missing_advertised_algorithms_fall_back_to_rs256(): void
+    {
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument([
+                'id_token_signing_alg_values_supported' => null,
+            ])),
+            $this->tokenEndpointResponse($this->encodeToken($this->idTokenClaims())),
+            $this->jsonResponse($this->jwksDocument()),
+        ]);
+
+        $this->assertSame('user-123', $provider->user()->getId());
+    }
+
+    public function test_a_pem_public_key_verifies_without_touching_the_jwks(): void
+    {
+        $provider = $this->makeProvider([
+            'jwt_public_key' => static::rsaKey()['public'],
+        ], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse($this->encodeToken($this->idTokenClaims())),
+        ]);
+
+        $user = $provider->user();
+
+        $this->assertSame('user-123', $user->getId());
+        $this->assertNotContains('GET /jwks', $this->requestedPaths());
+    }
+
+    public function test_verify_jwt_false_skips_the_signature_but_not_the_claims(): void
+    {
+        $provider = $this->makeProvider(['verify_jwt' => false], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse($this->unsignedToken($this->idTokenClaims())),
+        ]);
+
+        $this->assertSame('user-123', $provider->user()->getId());
+        $this->assertNotContains('GET /jwks', $this->requestedPaths());
+    }
+
+    public function test_verify_jwt_false_still_rejects_an_expired_token(): void
+    {
+        $claims = $this->idTokenClaims(['exp' => time() - 60]);
+
+        $provider = $this->makeProvider(['verify_jwt' => false], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse($this->unsignedToken($claims)),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('expired');
+
+        $provider->user();
+    }
+
+    public function test_verify_jwt_false_still_rejects_a_wrong_audience(): void
+    {
+        $claims = $this->idTokenClaims(['aud' => 'someone-else']);
+
+        $provider = $this->makeProvider(['verify_jwt' => false], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse($this->unsignedToken($claims)),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid audience');
+
+        $provider->user();
+    }
+
+    public function test_malformed_token_with_two_segments_is_rejected(): void
+    {
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse('only.twosegments'),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('expected three segments');
+
+        $provider->user();
+    }
+
+    public function test_malformed_base64_header_is_rejected(): void
+    {
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse('!!!not-base64!!!.payload.signature'),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Malformed base64url segment');
+
+        $provider->user();
+    }
+
+    public function test_a_four_segment_token_is_rejected(): void
+    {
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse($this->unsignedToken($this->idTokenClaims()).'.extra'),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('expected three segments');
+
+        $provider->user();
+    }
+
+    public function test_a_header_that_is_not_a_json_object_is_rejected(): void
+    {
+        $token = static::base64Url('[1,2]').'.'.static::base64Url('{}').'.sig';
+
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse($token),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Failed to parse header');
+
+        $provider->user();
+    }
+
+    public function test_an_out_of_alphabet_payload_is_rejected(): void
+    {
+        $token = static::base64Url(json_encode(['alg' => 'RS256'])).'.!!!.sig';
+
+        $provider = $this->makeProvider(['verify_jwt' => false], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse($token),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Malformed base64url segment');
+
+        $provider->user();
+    }
+
+    public function test_verify_jwt_as_a_falsy_string_also_opts_out(): void
+    {
+        // env('OIDC_VERIFY_JWT') style values arrive as strings.
+        $provider = $this->makeProvider(['verify_jwt' => 'false'], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse($this->unsignedToken($this->idTokenClaims())),
+        ]);
+
+        $this->assertSame('user-123', $provider->user()->getId());
+        $this->assertNotContains('GET /jwks', $this->requestedPaths());
+    }
+
+    public function test_hs256_is_rejected_even_when_the_discovery_document_advertises_it(): void
+    {
+        // A compromised or misconfigured OP advertising HS256 must not turn
+        // the (public) JWKS material into an acceptable MAC secret.
+        $forged = JWT::encode($this->idTokenClaims(), static::rsaKey()['public'], 'HS256');
+
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument([
+                'id_token_signing_alg_values_supported' => ['RS256', 'HS256'],
+            ])),
+            $this->tokenEndpointResponse($forged),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('HMAC algorithms cannot be verified against a JWKS');
+
+        $provider->user();
+    }
+}

--- a/tests/OpenIDConnect/Unit/IssuerValidationTest.php
+++ b/tests/OpenIDConnect/Unit/IssuerValidationTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect\Unit;
+
+use InvalidArgumentException;
+use SocialiteProviders\OpenIDConnect\IssuerValidators\DefaultIssuerValidator;
+use SocialiteProviders\OpenIDConnect\IssuerValidators\EntraIssuerValidator;
+use SocialiteProviders\Tests\OpenIDConnect\Support\AcceptSuffixIssuerValidator;
+use SocialiteProviders\Tests\OpenIDConnect\Support\InteractsWithOidc;
+use SocialiteProviders\Tests\OpenIDConnect\TestCase;
+use stdClass;
+
+class IssuerValidationTest extends TestCase
+{
+    use InteractsWithOidc;
+
+    public function test_a_token_from_a_different_issuer_is_rejected(): void
+    {
+        $claims = $this->idTokenClaims(['iss' => 'https://evil.test']);
+
+        $provider = $this->makeProvider([], $this->happyPathResponses($claims));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid issuer');
+
+        $provider->user();
+    }
+
+    public function test_the_expected_issuer_defaults_to_the_discovery_documents(): void
+    {
+        // discoveryDocument() advertises issuer = base_url.
+        $provider = $this->makeProvider([], $this->happyPathResponses());
+
+        $this->assertSame('user-123', $provider->user()->getId());
+    }
+
+    public function test_the_issuer_config_overrides_the_discovery_document(): void
+    {
+        $claims = $this->idTokenClaims(['iss' => 'https://alias.test']);
+
+        $provider = $this->makeProvider(
+            ['issuer' => 'https://alias.test'],
+            $this->happyPathResponses($claims),
+        );
+
+        $this->assertSame('user-123', $provider->user()->getId());
+    }
+
+    public function test_the_default_validator_does_not_substitute_templates(): void
+    {
+        $claims = $this->idTokenClaims([
+            'iss' => 'https://login.microsoftonline.com/tenant-123/v2.0',
+            'tid' => 'tenant-123',
+        ]);
+
+        $provider = $this->makeProvider(
+            ['issuer' => 'https://login.microsoftonline.com/{tenantid}/v2.0'],
+            $this->happyPathResponses($claims),
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid issuer');
+
+        $provider->user();
+    }
+
+    public function test_the_entra_validator_substitutes_the_tenantid_template_from_the_tid_claim(): void
+    {
+        // The PR #1447 blocker: Entra advertises the placeholder literally.
+        $claims = $this->idTokenClaims([
+            'iss' => 'https://login.microsoftonline.com/tenant-123/v2.0',
+            'tid' => 'tenant-123',
+        ]);
+
+        $provider = $this->makeProvider(
+            [
+                'issuer'           => 'https://login.microsoftonline.com/{tenantid}/v2.0',
+                'issuer_validator' => EntraIssuerValidator::class,
+            ],
+            $this->happyPathResponses($claims),
+        );
+
+        $this->assertSame('user-123', $provider->user()->getId());
+    }
+
+    public function test_the_entra_validator_still_rejects_a_mismatched_issuer(): void
+    {
+        $claims = $this->idTokenClaims([
+            'iss' => 'https://login.microsoftonline.com/tenant-999/v2.0',
+            'tid' => 'tenant-123',
+        ]);
+
+        $provider = $this->makeProvider(
+            [
+                'issuer'           => 'https://login.microsoftonline.com/{tenantid}/v2.0',
+                'issuer_validator' => EntraIssuerValidator::class,
+            ],
+            $this->happyPathResponses($claims),
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid issuer');
+
+        $provider->user();
+    }
+
+    public function test_a_custom_validator_callable_replaces_the_comparison(): void
+    {
+        $claims = $this->idTokenClaims(['iss' => 'https://anything.test']);
+
+        $provider = $this->makeProvider([], $this->happyPathResponses($claims));
+
+        $seen = [];
+        $provider->validateIssuerUsing(function (string $expected, stdClass $payload) use (&$seen): bool {
+            $seen = [$expected, $payload->iss];
+
+            return true;
+        });
+
+        $this->assertSame('user-123', $provider->user()->getId());
+        $this->assertSame([static::$opBaseUrl, 'https://anything.test'], $seen);
+    }
+
+    public function test_a_rejecting_custom_callable_fails_the_login(): void
+    {
+        $provider = $this->makeProvider([], $this->happyPathResponses());
+        $provider->validateIssuerUsing(fn (): bool => false);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid issuer');
+
+        $provider->user();
+    }
+
+    public function test_an_issuer_validator_class_can_be_set_per_connection_config(): void
+    {
+        $claims = $this->idTokenClaims(['iss' => 'https://whatever.test/accepted']);
+
+        $provider = $this->makeProvider(
+            ['issuer_validator' => AcceptSuffixIssuerValidator::class],
+            $this->happyPathResponses($claims),
+        );
+
+        $this->assertSame('user-123', $provider->user()->getId());
+    }
+
+    public function test_a_config_class_not_implementing_the_interface_is_refused(): void
+    {
+        $provider = $this->makeProvider(
+            ['issuer_validator' => stdClass::class],
+            $this->happyPathResponses(),
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('must implement');
+
+        $provider->user();
+    }
+
+    public function test_default_validator_rejects_a_missing_iss(): void
+    {
+        $validator = new DefaultIssuerValidator;
+
+        $this->assertFalse($validator->validate('https://op.test', new stdClass));
+    }
+
+    public function test_entra_validator_is_case_insensitive_on_the_placeholder_only(): void
+    {
+        $validator = new EntraIssuerValidator;
+
+        $payload = new stdClass;
+        $payload->iss = 'https://login.microsoftonline.com/abc/v2.0';
+        $payload->tid = 'abc';
+
+        $this->assertTrue($validator->validate('https://login.microsoftonline.com/{tenantId}/v2.0', $payload));
+
+        // But the issuer comparison itself stays exact.
+        $payload->iss = 'https://LOGIN.microsoftonline.com/abc/v2.0';
+        $this->assertFalse($validator->validate('https://login.microsoftonline.com/{tenantid}/v2.0', $payload));
+    }
+
+    public function test_entra_validator_compares_strictly_without_a_placeholder(): void
+    {
+        $validator = new EntraIssuerValidator;
+
+        $payload = new stdClass;
+        $payload->iss = 'https://login.microsoftonline.com/tenant-123/v2.0';
+        $payload->tid = 'tenant-123';
+
+        $this->assertTrue($validator->validate('https://login.microsoftonline.com/tenant-123/v2.0', $payload));
+        $this->assertFalse($validator->validate('https://login.microsoftonline.com/tenant-999/v2.0', $payload));
+    }
+}

--- a/tests/OpenIDConnect/Unit/JwksTest.php
+++ b/tests/OpenIDConnect/Unit/JwksTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect\Unit;
+
+use Illuminate\Support\Facades\Cache;
+use InvalidArgumentException;
+use SocialiteProviders\Tests\OpenIDConnect\Support\InteractsWithOidc;
+use SocialiteProviders\Tests\OpenIDConnect\TestCase;
+
+class JwksTest extends TestCase
+{
+    use InteractsWithOidc;
+
+    public function test_the_jwks_is_cached_across_logins(): void
+    {
+        $provider = $this->makeProvider([], $this->happyPathResponses());
+        $provider->user();
+
+        $request = $this->callbackRequest();
+        $second = $this->makeProvider([], [
+            $this->tokenEndpointResponse($this->encodeToken($this->idTokenClaims())),
+        ], $request);
+
+        $this->assertSame('user-123', $second->user()->getId());
+        $this->assertSame(['POST /token'], $this->requestedPaths());
+    }
+
+    public function test_a_token_without_a_kid_verifies_against_the_jwks(): void
+    {
+        $token = $this->encodeTokenWithoutKid($this->idTokenClaims());
+
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse($token),
+            $this->jsonResponse($this->jwksDocument([$this->jwk('kid-1', 1)])),
+        ], $this->callbackRequest());
+
+        $this->assertSame('user-123', $provider->user()->getId());
+    }
+
+    public function test_a_token_without_a_kid_still_survives_key_rotation(): void
+    {
+        $token = $this->encodeTokenWithoutKid($this->idTokenClaims(), slot: 2);
+
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse($token),
+            $this->jsonResponse($this->jwksDocument([$this->jwk('kid-1', 1)])),
+            $this->jsonResponse($this->jwksDocument([$this->jwk('kid-2', 2)])),
+        ], $this->callbackRequest());
+
+        $this->assertSame('user-123', $provider->user()->getId());
+        $this->assertSame(
+            ['GET /.well-known/openid-configuration', 'POST /token', 'GET /jwks', 'GET /jwks'],
+            $this->requestedPaths()
+        );
+    }
+
+    public function test_a_kid_less_token_signed_by_a_foreign_key_is_rejected(): void
+    {
+        $forged = $this->encodeTokenWithoutKid($this->idTokenClaims(), slot: 2);
+
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse($forged),
+            $this->jsonResponse($this->jwksDocument([$this->jwk('kid-1', 1)])),
+            $this->jsonResponse($this->jwksDocument([$this->jwk('kid-1', 1)])),
+        ], $this->callbackRequest());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('no key in the JWKS verifies this token');
+
+        $provider->user();
+    }
+
+    public function test_a_claim_failure_on_a_kid_less_token_is_reported_as_itself(): void
+    {
+        $expired = $this->encodeTokenWithoutKid($this->idTokenClaims(['exp' => time() - 6000]));
+
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse($expired),
+            $this->jsonResponse($this->jwksDocument([$this->jwk('kid-1', 1)])),
+        ], $this->callbackRequest());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expired token');
+
+        $provider->user();
+    }
+
+    public function test_an_unknown_kid_triggers_a_jwks_refetch_so_key_rotation_works(): void
+    {
+        // The cached JWKS only knows kid-1; the OP has rotated to kid-2.
+        $rotated = $this->encodeToken($this->idTokenClaims(), kid: 'kid-2', slot: 2);
+
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse($rotated),
+            $this->jsonResponse($this->jwksDocument([$this->jwk('kid-1', 1)])),
+            $this->jsonResponse($this->jwksDocument([
+                $this->jwk('kid-1', 1),
+                $this->jwk('kid-2', 2),
+            ])),
+        ]);
+
+        $this->assertSame('user-123', $provider->user()->getId());
+
+        $this->assertSame(2, count(array_filter(
+            $this->requestedPaths(),
+            static fn (string $path) => $path === 'GET /jwks',
+        )));
+    }
+
+    public function test_the_rotation_refetch_sends_no_cache_headers(): void
+    {
+        $rotated = $this->encodeToken($this->idTokenClaims(), kid: 'kid-2', slot: 2);
+
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse($rotated),
+            $this->jsonResponse($this->jwksDocument([$this->jwk('kid-1', 1)])),
+            $this->jsonResponse($this->jwksDocument([$this->jwk('kid-2', 2)])),
+        ]);
+        $provider->user();
+
+        [$first, $second] = array_values(array_filter(
+            $this->httpHistory,
+            static fn (array $entry) => $entry['request']->getUri()->getPath() === '/jwks',
+        ));
+
+        $this->assertFalse($first['request']->hasHeader('Cache-Control'));
+        $this->assertSame('no-cache', $second['request']->getHeaderLine('Cache-Control'));
+        $this->assertSame('no-cache', $second['request']->getHeaderLine('Pragma'));
+    }
+
+    public function test_a_known_kid_does_not_refetch_the_jwks(): void
+    {
+        $provider = $this->makeProvider([], $this->happyPathResponses());
+
+        $provider->user();
+
+        $this->assertSame(1, count(array_filter(
+            $this->requestedPaths(),
+            static fn (string $path) => $path === 'GET /jwks',
+        )));
+    }
+
+    public function test_a_kid_still_missing_after_the_refetch_fails(): void
+    {
+        $rotated = $this->encodeToken($this->idTokenClaims(), kid: 'kid-99', slot: 2);
+
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse($rotated),
+            $this->jsonResponse($this->jwksDocument([$this->jwk('kid-1', 1)])),
+            $this->jsonResponse($this->jwksDocument([$this->jwk('kid-1', 1)])),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Verification failed');
+
+        $provider->user();
+    }
+
+    public function test_missing_jwks_uri_in_discovery_is_reported(): void
+    {
+        $doc = $this->discoveryDocument();
+        unset($doc['jwks_uri']);
+
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($doc),
+            $this->tokenEndpointResponse($this->encodeToken($this->idTokenClaims())),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('JWKS URI not found');
+
+        $provider->user();
+    }
+
+    public function test_jwks_cache_key_is_scoped_to_the_issuer(): void
+    {
+        $provider = $this->makeProvider([], $this->happyPathResponses());
+        $provider->user();
+
+        $this->assertTrue(Cache::has('openidconnect_jwks_'.md5(static::$opBaseUrl)));
+    }
+}

--- a/tests/OpenIDConnect/Unit/LogoutTest.php
+++ b/tests/OpenIDConnect/Unit/LogoutTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect\Unit;
+
+use Illuminate\Http\Request;
+use InvalidArgumentException;
+use SocialiteProviders\Tests\OpenIDConnect\Support\InteractsWithOidc;
+use SocialiteProviders\Tests\OpenIDConnect\TestCase;
+
+class LogoutTest extends TestCase
+{
+    use InteractsWithOidc;
+
+    public function test_logout_builds_an_end_session_redirect(): void
+    {
+        $request = $this->redirectRequest();
+        $provider = $this->makeProvider(
+            ['post_logout_redirect_uri' => 'https://app.test/goodbye'],
+            [$this->jsonResponse($this->discoveryDocument())],
+            $request,
+        );
+
+        $url = $provider->logout('the-id-token')->getTargetUrl();
+        $query = $this->queryOf($url);
+
+        $this->assertStringStartsWith(static::$opBaseUrl.'/logout?', $url);
+        $this->assertSame('the-id-token', $query['id_token_hint']);
+        $this->assertSame(static::$opClientId, $query['client_id']);
+        $this->assertSame('https://app.test/goodbye', $query['post_logout_redirect_uri']);
+        $this->assertSame($request->session()->get('logout_state'), $query['state']);
+    }
+
+    public function test_an_explicit_post_logout_uri_overrides_the_config(): void
+    {
+        $provider = $this->makeProvider(
+            ['post_logout_redirect_uri' => 'https://app.test/goodbye'],
+            [$this->jsonResponse($this->discoveryDocument())],
+            $this->redirectRequest(),
+        );
+
+        $query = $this->queryOf($provider->logout('t', 'https://app.test/elsewhere')->getTargetUrl());
+
+        $this->assertSame('https://app.test/elsewhere', $query['post_logout_redirect_uri']);
+    }
+
+    public function test_logout_without_an_advertised_end_session_endpoint_is_refused(): void
+    {
+        $doc = $this->discoveryDocument();
+        unset($doc['end_session_endpoint']);
+
+        $provider = $this->makeProvider([], [$this->jsonResponse($doc)], $this->redirectRequest());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('end_session_endpoint');
+
+        $provider->logout();
+    }
+
+    public function test_no_state_is_sent_when_there_is_no_session_to_check_it_against(): void
+    {
+        $provider = $this->makeProvider(
+            [],
+            [$this->jsonResponse($this->discoveryDocument())],
+            $this->redirectRequest(withSession: false),
+        );
+
+        $query = $this->queryOf($provider->logout('the-id-token')->getTargetUrl());
+
+        $this->assertArrayNotHasKey('state', $query);
+    }
+
+    public function test_the_logout_state_round_trip_validates_once_and_only_once(): void
+    {
+        $request = $this->redirectRequest();
+        $provider = $this->makeProvider([], [$this->jsonResponse($this->discoveryDocument())], $request);
+
+        $url = $provider->logout('the-id-token')->getTargetUrl();
+        $state = $this->queryOf($url)['state'];
+
+        // The IdP redirects back with that state, same session.
+        $return = Request::create('https://app.test/goodbye', 'GET', ['state' => $state]);
+        $return->setLaravelSession($request->session());
+
+        $this->assertTrue($provider->validateLogoutState($return));
+
+        $this->assertFalse($provider->validateLogoutState($return));
+    }
+
+    public function test_a_forged_logout_state_fails(): void
+    {
+        $request = $this->redirectRequest();
+        $provider = $this->makeProvider([], [$this->jsonResponse($this->discoveryDocument())], $request);
+
+        $provider->logout('the-id-token');
+
+        $return = Request::create('https://app.test/goodbye', 'GET', ['state' => 'forged']);
+        $return->setLaravelSession($request->session());
+
+        $this->assertFalse($provider->validateLogoutState($return));
+    }
+
+    public function test_logout_state_validation_without_a_session_is_false(): void
+    {
+        $provider = $this->makeProvider([], [], $this->redirectRequest(withSession: false));
+
+        $this->assertFalse($provider->validateLogoutState(
+            Request::create('https://app.test/goodbye', 'GET', ['state' => 'anything'])
+        ));
+    }
+
+    public function test_an_empty_state_on_both_sides_does_not_validate(): void
+    {
+        $provider = $this->makeProvider([], [], $this->redirectRequest());
+
+        $return = Request::create('https://app.test/goodbye', 'GET', ['state' => '']);
+        $return->setLaravelSession($this->sessionStore());
+        $return->session()->put('logout_state', '');
+
+        $this->assertFalse($provider->validateLogoutState($return));
+    }
+
+    public function test_logout_appends_to_an_end_session_endpoint_that_already_carries_a_query(): void
+    {
+        $provider = $this->makeProvider(
+            [],
+            [$this->jsonResponse($this->discoveryDocument([
+                'end_session_endpoint' => static::$opBaseUrl.'/logout?tenant=legacy',
+            ]))],
+            $this->redirectRequest(),
+        );
+
+        $url = $provider->logout('the-id-token')->getTargetUrl();
+
+        $this->assertSame(1, substr_count($url, '?'));
+        $query = $this->queryOf($url);
+        $this->assertSame('legacy', $query['tenant']);
+        $this->assertSame('the-id-token', $query['id_token_hint']);
+    }
+}

--- a/tests/OpenIDConnect/Unit/NonceTest.php
+++ b/tests/OpenIDConnect/Unit/NonceTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect\Unit;
+
+use InvalidArgumentException;
+use SocialiteProviders\OpenIDConnect\Provider;
+use SocialiteProviders\Tests\OpenIDConnect\Support\InteractsWithOidc;
+use SocialiteProviders\Tests\OpenIDConnect\TestCase;
+
+class NonceTest extends TestCase
+{
+    use InteractsWithOidc;
+
+    public function test_a_token_with_a_mismatched_nonce_is_rejected(): void
+    {
+        $claims = $this->idTokenClaims(['nonce' => 'a-different-nonce']);
+
+        $provider = $this->makeProvider([], $this->happyPathResponses($claims));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('invalid nonce');
+
+        $provider->user();
+    }
+
+    public function test_a_token_without_a_nonce_is_rejected_when_one_was_sent(): void
+    {
+        $claims = $this->idTokenClaims();
+        unset($claims['nonce']);
+
+        $provider = $this->makeProvider([], $this->happyPathResponses($claims));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('invalid nonce');
+
+        $provider->user();
+    }
+
+    public function test_the_nonce_is_cleared_after_a_successful_login(): void
+    {
+        $request = $this->callbackRequest();
+
+        $provider = $this->makeProvider([], $this->happyPathResponses(), $request);
+        $provider->user();
+
+        $this->assertNull($request->session()->get(Provider::NONCE_SESSION_KEY));
+    }
+
+    public function test_a_replayed_id_token_fails_once_the_nonce_is_consumed(): void
+    {
+        $request = $this->callbackRequest();
+        $idToken = $this->encodeToken($this->idTokenClaims());
+
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse($idToken),
+            $this->jsonResponse($this->jwksDocument()),
+        ], $request);
+
+        $provider->user();
+
+        // Same session, same id_token, fresh provider -- as in a replayed
+        // callback. State is re-primed to isolate the nonce check.
+        $request->session()->put('state', static::$opState);
+
+        $replay = $this->makeProvider([], [
+            $this->tokenEndpointResponse($idToken),
+        ], $request);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('invalid nonce');
+
+        $replay->user();
+    }
+
+    public function test_use_nonce_false_accepts_a_token_without_a_nonce(): void
+    {
+        $claims = $this->idTokenClaims();
+        unset($claims['nonce']);
+
+        $provider = $this->makeProvider(['use_nonce' => false], $this->happyPathResponses($claims));
+
+        $this->assertSame('user-123', $provider->user()->getId());
+    }
+
+    public function test_stateless_mode_skips_nonce_validation(): void
+    {
+        $claims = $this->idTokenClaims();
+        unset($claims['nonce']);
+
+        // PKCE must also be opted out: its verifier lives in the session.
+        $provider = $this->makeProvider(
+            [],
+            $this->happyPathResponses($claims),
+            $this->callbackRequest(withSession: false),
+        );
+
+        $this->assertSame('user-123', $provider->stateless()->withoutPKCE()->user()->getId());
+    }
+}

--- a/tests/OpenIDConnect/Unit/ProviderFlavorsTest.php
+++ b/tests/OpenIDConnect/Unit/ProviderFlavorsTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect\Unit;
+
+use Illuminate\Http\Request;
+use ReflectionMethod;
+use SocialiteProviders\Manager\Config;
+use SocialiteProviders\OpenIDConnect\IssuerValidators\EntraIssuerValidator;
+use SocialiteProviders\OpenIDConnect\Provider;
+use SocialiteProviders\OpenIDConnect\Providers\Auth0Provider;
+use SocialiteProviders\OpenIDConnect\Providers\EntraProvider;
+use SocialiteProviders\OpenIDConnect\Providers\GoogleProvider;
+use SocialiteProviders\OpenIDConnect\Providers\KeycloakProvider;
+use SocialiteProviders\OpenIDConnect\Providers\OktaProvider;
+use SocialiteProviders\Tests\OpenIDConnect\TestCase;
+
+class TenantPathProvider extends Provider
+{
+    public static function additionalConfigKeys(): array
+    {
+        return array_merge(parent::additionalConfigKeys(), ['tenant']);
+    }
+
+    protected function configDefaults(array $config): array
+    {
+        return [
+            'base_url'   => 'https://sso.mycorp.example/tenants/'.($config['tenant'] ?? 'default'),
+            'clock_skew' => 30,
+        ];
+    }
+}
+
+class ProviderFlavorsTest extends TestCase
+{
+    /**
+     * @param  class-string<Provider>  $class
+     */
+    private function flavor(string $class, array $config): Provider
+    {
+        $provider = new $class(
+            Request::create('https://app.test/login'),
+            'the-client',
+            'the-secret',
+            'https://app.test/callback',
+        );
+
+        $provider->setConfig(new Config('the-client', 'the-secret', 'https://app.test/callback', $config));
+
+        return $provider;
+    }
+
+    private function configOf(Provider $provider, string $key): mixed
+    {
+        return (new ReflectionMethod($provider, 'getConfig'))->invoke($provider, $key);
+    }
+
+    public function test_entra_derives_the_base_url_from_the_tenant(): void
+    {
+        $provider = $this->flavor(EntraProvider::class, ['tenant' => 'contoso']);
+
+        $this->assertSame('https://login.microsoftonline.com/contoso/v2.0', $this->configOf($provider, 'base_url'));
+    }
+
+    public function test_entra_defaults_to_the_common_tenant(): void
+    {
+        $provider = $this->flavor(EntraProvider::class, []);
+
+        $this->assertSame('https://login.microsoftonline.com/common/v2.0', $this->configOf($provider, 'base_url'));
+    }
+
+    public function test_entra_declares_tenant_as_a_config_key_so_it_survives_the_config_retriever(): void
+    {
+        $this->assertContains('tenant', EntraProvider::additionalConfigKeys());
+    }
+
+    public function test_entra_defaults_to_its_issuer_validator(): void
+    {
+        $provider = $this->flavor(EntraProvider::class, []);
+
+        $this->assertSame(
+            EntraIssuerValidator::class,
+            $this->configOf($provider, 'issuer_validator'),
+        );
+
+        $pinned = $this->flavor(EntraProvider::class, ['issuer_validator' => 'App\\Custom']);
+        $this->assertSame('App\\Custom', $this->configOf($pinned, 'issuer_validator'));
+    }
+
+    public function test_entra_defaults_to_preferred_username_for_email(): void
+    {
+        $provider = $this->flavor(EntraProvider::class, []);
+
+        $this->assertSame(['preferred_username'], $this->configOf($provider, 'email_claims'));
+
+        $pinned = $this->flavor(EntraProvider::class, ['email_claims' => ['preferred_username', 'email']]);
+        $this->assertSame(['preferred_username', 'email'], $this->configOf($pinned, 'email_claims'));
+    }
+
+    public function test_keycloak_derives_the_base_url_from_server_and_realm(): void
+    {
+        $provider = $this->flavor(KeycloakProvider::class, [
+            'server_url' => 'https://id.example.com/',
+            'realm'      => 'main',
+        ]);
+
+        $this->assertSame('https://id.example.com/realms/main', $this->configOf($provider, 'base_url'));
+    }
+
+    public function test_auth0_derives_the_base_url_and_defaults_to_secret_post(): void
+    {
+        $provider = $this->flavor(Auth0Provider::class, ['domain' => 'tenant.eu.auth0.com']);
+
+        $this->assertSame('https://tenant.eu.auth0.com', $this->configOf($provider, 'base_url'));
+        $this->assertSame('client_secret_post', $this->configOf($provider, 'token_auth_method'));
+    }
+
+    public function test_okta_appends_a_custom_authorization_server(): void
+    {
+        $custom = $this->flavor(OktaProvider::class, [
+            'domain'      => 'acme.okta.com',
+            'auth_server' => 'default',
+        ]);
+        $this->assertSame('https://acme.okta.com/oauth2/default', $this->configOf($custom, 'base_url'));
+
+        $org = $this->flavor(OktaProvider::class, ['domain' => 'acme.okta.com']);
+        $this->assertSame('https://acme.okta.com', $this->configOf($org, 'base_url'));
+    }
+
+    public function test_google_pins_its_issuer(): void
+    {
+        $provider = $this->flavor(GoogleProvider::class, []);
+
+        $this->assertSame('https://accounts.google.com', $this->configOf($provider, 'base_url'));
+    }
+
+    public function test_explicit_config_always_beats_the_derived_defaults(): void
+    {
+        $provider = $this->flavor(GoogleProvider::class, ['base_url' => 'https://sso.proxy.test']);
+
+        $this->assertSame('https://sso.proxy.test', $this->configOf($provider, 'base_url'));
+    }
+
+    public function test_a_custom_subclass_can_derive_whatever_it_needs(): void
+    {
+        $provider = $this->flavor(TenantPathProvider::class, ['tenant' => 'acme']);
+
+        $this->assertSame('https://sso.mycorp.example/tenants/acme', $this->configOf($provider, 'base_url'));
+        $this->assertSame(30, $this->configOf($provider, 'clock_skew'));
+
+        $pinned = $this->flavor(TenantPathProvider::class, ['tenant' => 'acme', 'clock_skew' => 5]);
+        $this->assertSame(5, $this->configOf($pinned, 'clock_skew'));
+    }
+
+    public function test_the_base_provider_applies_no_defaults(): void
+    {
+        $provider = $this->flavor(Provider::class, ['base_url' => 'https://op.test']);
+
+        $this->assertSame('https://op.test', $this->configOf($provider, 'base_url'));
+        $this->assertNull($this->configOf($provider, 'token_auth_method'));
+    }
+}

--- a/tests/OpenIDConnect/Unit/RedirectFlowTest.php
+++ b/tests/OpenIDConnect/Unit/RedirectFlowTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect\Unit;
+
+use InvalidArgumentException;
+use SocialiteProviders\OpenIDConnect\Provider;
+use SocialiteProviders\Tests\OpenIDConnect\Support\InteractsWithOidc;
+use SocialiteProviders\Tests\OpenIDConnect\TestCase;
+
+class RedirectFlowTest extends TestCase
+{
+    use InteractsWithOidc;
+
+    public function test_redirect_carries_state_nonce_and_pkce_challenge(): void
+    {
+        $request = $this->redirectRequest();
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+        ], $request);
+
+        $url = $provider->redirect()->getTargetUrl();
+        $query = $this->queryOf($url);
+
+        $this->assertStringStartsWith(static::$opBaseUrl.'/authorize?', $url);
+        $this->assertSame('code', $query['response_type']);
+        $this->assertSame(static::$opClientId, $query['client_id']);
+        $this->assertSame(static::$opRedirect, $query['redirect_uri']);
+
+        // State, nonce and the PKCE verifier survive in the session for the callback.
+        $this->assertSame($request->session()->get('state'), $query['state']);
+        $this->assertSame($request->session()->get(Provider::NONCE_SESSION_KEY), $query['nonce']);
+        $this->assertNotEmpty($request->session()->get('code_verifier'));
+
+        // PKCE is on by default.
+        $this->assertSame('S256', $query['code_challenge_method']);
+        $this->assertNotEmpty($query['code_challenge']);
+    }
+
+    public function test_default_scopes_are_openid_email_profile(): void
+    {
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+        ], $this->redirectRequest());
+
+        $query = $this->queryOf($provider->redirect()->getTargetUrl());
+
+        $this->assertSame('openid email profile', $query['scope']);
+    }
+
+    public function test_a_fragment_on_the_authorization_endpoint_stays_behind_the_query(): void
+    {
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument([
+                'authorization_endpoint' => static::$opBaseUrl.'/authorize#done',
+            ])),
+        ], $this->redirectRequest());
+
+        $url = $provider->redirect()->getTargetUrl();
+
+        $this->assertStringStartsWith(static::$opBaseUrl.'/authorize?', $url);
+        $this->assertStringEndsWith('#done', $url);
+        $this->assertSame('code', $this->queryOf($url)['response_type']);
+    }
+
+    public function test_without_pkce_omits_the_challenge(): void
+    {
+        $request = $this->redirectRequest();
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+        ], $request);
+
+        $query = $this->queryOf($provider->withoutPKCE()->redirect()->getTargetUrl());
+
+        $this->assertArrayNotHasKey('code_challenge', $query);
+        $this->assertArrayNotHasKey('code_challenge_method', $query);
+        $this->assertNull($request->session()->get('code_verifier'));
+    }
+
+    public function test_without_nonce_omits_the_nonce(): void
+    {
+        $request = $this->redirectRequest();
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+        ], $request);
+
+        $query = $this->queryOf($provider->withoutNonce()->redirect()->getTargetUrl());
+
+        $this->assertArrayNotHasKey('nonce', $query);
+        $this->assertNull($request->session()->get(Provider::NONCE_SESSION_KEY));
+    }
+
+    public function test_use_nonce_config_false_omits_the_nonce(): void
+    {
+        $provider = $this->makeProvider(['use_nonce' => false], [
+            $this->jsonResponse($this->discoveryDocument()),
+        ], $this->redirectRequest());
+
+        $query = $this->queryOf($provider->redirect()->getTargetUrl());
+
+        $this->assertArrayNotHasKey('nonce', $query);
+    }
+
+    public function test_pkce_without_a_session_is_refused_with_a_pointed_error(): void
+    {
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+        ], $this->redirectRequest(withSession: false));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('PKCE requires a session');
+
+        $provider->stateless()->redirect();
+    }
+
+    public function test_stateless_without_pkce_redirects_without_a_session(): void
+    {
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+        ], $this->redirectRequest(withSession: false));
+
+        $query = $this->queryOf($provider->stateless()->withoutPKCE()->redirect()->getTargetUrl());
+
+        $this->assertArrayNotHasKey('state', $query);
+        $this->assertArrayNotHasKey('nonce', $query);
+        $this->assertArrayNotHasKey('code_challenge', $query);
+        $this->assertSame('code', $query['response_type']);
+    }
+
+    public function test_authorization_endpoint_with_existing_query_is_extended_not_mangled(): void
+    {
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument([
+                'authorization_endpoint' => static::$opBaseUrl.'/authorize?realm=prod',
+            ])),
+        ], $this->redirectRequest());
+
+        $url = $provider->redirect()->getTargetUrl();
+
+        $this->assertSame(1, substr_count($url, '?'));
+        $query = $this->queryOf($url);
+        $this->assertSame('prod', $query['realm']);
+        $this->assertSame('code', $query['response_type']);
+    }
+
+    public function test_the_code_challenge_is_derived_from_the_stored_verifier(): void
+    {
+        $request = $this->redirectRequest();
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+        ], $request);
+
+        $query = $this->queryOf($provider->redirect()->getTargetUrl());
+        $verifier = $request->session()->get('code_verifier');
+
+        $this->assertSame(
+            static::base64Url(hash('sha256', $verifier, true)),
+            $query['code_challenge'],
+        );
+    }
+}

--- a/tests/OpenIDConnect/Unit/RefreshTokenTest.php
+++ b/tests/OpenIDConnect/Unit/RefreshTokenTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect\Unit;
+
+use SocialiteProviders\Tests\OpenIDConnect\Support\InteractsWithOidc;
+use SocialiteProviders\Tests\OpenIDConnect\TestCase;
+
+class RefreshTokenTest extends TestCase
+{
+    use InteractsWithOidc;
+
+    public function test_refresh_token_posts_the_grant_and_returns_the_parsed_body(): void
+    {
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->jsonResponse([
+                'access_token'  => 'new-access-token',
+                'refresh_token' => 'new-refresh-token',
+                'expires_in'    => 3600,
+            ]),
+        ]);
+
+        $result = $provider->refreshToken('old-refresh-token');
+
+        $this->assertSame('new-access-token', $result['access_token']);
+
+        parse_str((string) $this->lastRequestTo('/token')->getBody(), $body);
+
+        $this->assertSame('refresh_token', $body['grant_type']);
+        $this->assertSame('old-refresh-token', $body['refresh_token']);
+        $this->assertSame(static::$opClientId, $body['client_id']);
+    }
+
+    public function test_refresh_token_respects_the_token_auth_method(): void
+    {
+        $provider = $this->makeProvider(
+            ['token_auth_method' => 'client_secret_basic'],
+            [
+                $this->jsonResponse($this->discoveryDocument()),
+                $this->jsonResponse(['access_token' => 'new-access-token']),
+            ],
+        );
+
+        $provider->refreshToken('old-refresh-token');
+
+        $request = $this->lastRequestTo('/token');
+        parse_str((string) $request->getBody(), $body);
+
+        $this->assertTrue($request->hasHeader('Authorization'));
+        $this->assertArrayNotHasKey('client_secret', $body);
+    }
+}

--- a/tests/OpenIDConnect/Unit/RevokeTest.php
+++ b/tests/OpenIDConnect/Unit/RevokeTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect\Unit;
+
+use GuzzleHttp\Psr7\Response;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SocialiteProviders\Tests\OpenIDConnect\Support\InteractsWithOidc;
+use SocialiteProviders\Tests\OpenIDConnect\TestCase;
+
+class RevokeTest extends TestCase
+{
+    use InteractsWithOidc;
+
+    #[DataProvider('revocationStatuses')]
+    public function test_revocation_result_follows_the_response_status(int $status, bool $expected): void
+    {
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+            new Response($status),
+        ]);
+
+        $this->assertSame($expected, $provider->revoke('the-refresh-token'));
+    }
+
+    public static function revocationStatuses(): array
+    {
+        return [
+            'ok'                  => [200, true],
+            'no content'          => [204, true],
+            'already revoked 400' => [400, false],
+            'bad credentials 401' => [401, false],
+            'server error 500'    => [500, false],
+        ];
+    }
+
+    public function test_the_revocation_request_carries_token_and_hint(): void
+    {
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+            new Response(200),
+        ]);
+
+        $provider->revoke('some-token', 'access_token');
+
+        parse_str((string) $this->lastRequestTo('/revoke')->getBody(), $body);
+
+        $this->assertSame('some-token', $body['token']);
+        $this->assertSame('access_token', $body['token_type_hint']);
+        $this->assertSame(static::$opClientId, $body['client_id']);
+    }
+
+    public function test_basic_auth_revocation_sends_the_secret_in_the_header_only(): void
+    {
+        $provider = $this->makeProvider(['token_auth_method' => 'client_secret_basic'], [
+            $this->jsonResponse($this->discoveryDocument()),
+            new Response(200),
+        ]);
+
+        $provider->revoke('some-token');
+
+        $request = $this->lastRequestTo('/revoke');
+        parse_str((string) $request->getBody(), $body);
+
+        $this->assertStringStartsWith('Basic ', $request->getHeaderLine('Authorization'));
+        $this->assertArrayNotHasKey('client_id', $body);
+        $this->assertArrayNotHasKey('client_secret', $body);
+        $this->assertSame('some-token', $body['token']);
+    }
+
+    public function test_revoke_without_an_advertised_endpoint_is_refused(): void
+    {
+        $doc = $this->discoveryDocument();
+        unset($doc['revocation_endpoint']);
+
+        $provider = $this->makeProvider([], [$this->jsonResponse($doc)]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('revocation_endpoint');
+
+        $provider->revoke('the-refresh-token');
+    }
+}

--- a/tests/OpenIDConnect/Unit/ScopeTest.php
+++ b/tests/OpenIDConnect/Unit/ScopeTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect\Unit;
+
+use SocialiteProviders\Tests\OpenIDConnect\Support\InteractsWithOidc;
+use SocialiteProviders\Tests\OpenIDConnect\TestCase;
+
+class ScopeTest extends TestCase
+{
+    use InteractsWithOidc;
+
+    public function test_configured_scopes_replace_the_defaults(): void
+    {
+        $provider = $this->makeProvider(['scopes' => ['email']]);
+
+        $this->assertSame(['openid', 'email'], $provider->getScopes());
+    }
+
+    public function test_openid_is_always_sent_even_when_not_configured(): void
+    {
+        $provider = $this->makeProvider(['scopes' => ['email', 'groups']]);
+
+        $this->assertSame(['openid', 'email', 'groups'], $provider->getScopes());
+    }
+
+    public function test_scope_strings_split_on_whitespace_and_commas(): void
+    {
+        $provider = $this->makeProvider(['scopes' => 'email, profile groups']);
+
+        $this->assertSame(['openid', 'email', 'profile', 'groups'], $provider->getScopes());
+    }
+
+    public function test_duplicates_are_removed(): void
+    {
+        $provider = $this->makeProvider(['scopes' => ['openid', 'email', 'email']]);
+
+        $this->assertSame(['openid', 'email'], $provider->getScopes());
+    }
+
+    public function test_fluent_scopes_extend_configured_scopes(): void
+    {
+        $provider = $this->makeProvider(['scopes' => ['email']]);
+        $provider->scopes(['offline_access']);
+
+        $this->assertSame(['openid', 'email', 'offline_access'], $provider->getScopes());
+    }
+
+    public function test_empty_scope_config_falls_back_to_defaults(): void
+    {
+        $provider = $this->makeProvider(['scopes' => '']);
+
+        $this->assertSame(['openid', 'email', 'profile'], $provider->getScopes());
+    }
+}

--- a/tests/OpenIDConnect/Unit/TimeClaimsTest.php
+++ b/tests/OpenIDConnect/Unit/TimeClaimsTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect\Unit;
+
+use Firebase\JWT\JWT;
+use InvalidArgumentException;
+use SocialiteProviders\Tests\OpenIDConnect\Support\InteractsWithOidc;
+use SocialiteProviders\Tests\OpenIDConnect\TestCase;
+
+class TimeClaimsTest extends TestCase
+{
+    use InteractsWithOidc;
+
+    public function test_a_token_without_exp_never_slips_through(): void
+    {
+        // firebase/php-jwt only checks exp when present, so a token that
+        // omits it would otherwise be valid forever.
+        $claims = $this->idTokenClaims();
+        unset($claims['exp']);
+
+        $provider = $this->makeProvider([], $this->happyPathResponses($claims));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing required exp claim');
+
+        $provider->user();
+    }
+
+    public function test_an_expired_token_is_rejected(): void
+    {
+        $claims = $this->idTokenClaims(['exp' => time() - 120]);
+
+        $provider = $this->makeProvider([], $this->happyPathResponses($claims));
+
+        try {
+            $provider->user();
+            $this->fail('Expected the expired token to be rejected.');
+        } catch (InvalidArgumentException $e) {
+            $this->assertSame(401, $e->getCode());
+            $this->assertStringContainsStringIgnoringCase('expired', $e->getMessage());
+        }
+    }
+
+    public function test_clock_skew_leeway_saves_a_slightly_expired_token(): void
+    {
+        $claims = $this->idTokenClaims(['exp' => time() - 30]);
+
+        $provider = $this->makeProvider(['clock_skew' => 120], $this->happyPathResponses($claims));
+
+        $this->assertSame('user-123', $provider->user()->getId());
+    }
+
+    public function test_the_global_jwt_leeway_is_restored_after_verification(): void
+    {
+        // JWT::$leeway is a process-wide static, so a long-running worker
+        // would otherwise inherit this provider's tolerance.
+        $previous = JWT::$leeway;
+        JWT::$leeway = 45;
+
+        try {
+            $provider = $this->makeProvider(['clock_skew' => 120], $this->happyPathResponses());
+            $provider->user();
+
+            $this->assertSame(45, JWT::$leeway);
+        } finally {
+            JWT::$leeway = $previous;
+        }
+    }
+
+    public function test_the_global_jwt_leeway_is_restored_after_a_failed_verification(): void
+    {
+        $previous = JWT::$leeway;
+        JWT::$leeway = 45;
+
+        try {
+            $claims = $this->idTokenClaims(['exp' => time() - 6000]);
+            $provider = $this->makeProvider([], $this->happyPathResponses($claims));
+
+            try {
+                $provider->user();
+                $this->fail('Expected the expired token to be rejected.');
+            } catch (InvalidArgumentException) {
+                // The restoration, not the rejection, is what is under test.
+            }
+
+            $this->assertSame(45, JWT::$leeway);
+        } finally {
+            JWT::$leeway = $previous;
+        }
+    }
+
+    public function test_a_not_yet_valid_nbf_is_rejected(): void
+    {
+        $claims = $this->idTokenClaims(['nbf' => time() + 600]);
+
+        $provider = $this->makeProvider([], $this->happyPathResponses($claims));
+
+        try {
+            $provider->user();
+            $this->fail('Expected the not-yet-valid token to be rejected.');
+        } catch (InvalidArgumentException $e) {
+            $this->assertSame(401, $e->getCode());
+        }
+    }
+
+    public function test_an_iat_from_the_future_is_rejected(): void
+    {
+        $claims = $this->idTokenClaims(['iat' => time() + 600]);
+
+        $provider = $this->makeProvider([], $this->happyPathResponses($claims));
+
+        try {
+            $provider->user();
+            $this->fail('Expected the future-issued token to be rejected.');
+        } catch (InvalidArgumentException $e) {
+            $this->assertSame(401, $e->getCode());
+        }
+    }
+
+    public function test_clock_skew_leeway_saves_a_slightly_future_iat(): void
+    {
+        $claims = $this->idTokenClaims(['iat' => time() + 30, 'nbf' => time() + 30]);
+
+        $provider = $this->makeProvider(['clock_skew' => 120], $this->happyPathResponses($claims));
+
+        $this->assertSame('user-123', $provider->user()->getId());
+    }
+
+    public function test_a_non_numeric_exp_is_rejected(): void
+    {
+        // PHP 8 compares int >= non-numeric-string as strings, so a bogus
+        // exp would sail through a bare comparison. The unverified path is
+        // the one that leans on our own check rather than php-jwt's.
+        $claims = $this->idTokenClaims(['exp' => 'soon']);
+
+        $provider = $this->makeProvider(['verify_jwt' => false], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse($this->unsignedToken($claims)),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('exp');
+
+        $provider->user();
+    }
+}

--- a/tests/OpenIDConnect/Unit/TokenAuthMethodTest.php
+++ b/tests/OpenIDConnect/Unit/TokenAuthMethodTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect\Unit;
+
+use SocialiteProviders\Tests\OpenIDConnect\Support\InteractsWithOidc;
+use SocialiteProviders\Tests\OpenIDConnect\TestCase;
+
+class TokenAuthMethodTest extends TestCase
+{
+    use InteractsWithOidc;
+
+    private function tokenRequestBody(): array
+    {
+        parse_str((string) $this->lastRequestTo('/token')->getBody(), $body);
+
+        return $body;
+    }
+
+    public function test_client_secret_post_is_the_default(): void
+    {
+        $provider = $this->makeProvider([], $this->happyPathResponses());
+        $provider->user();
+
+        $body = $this->tokenRequestBody();
+
+        $this->assertSame(static::$opClientId, $body['client_id']);
+        $this->assertSame(static::$opClientSecret, $body['client_secret']);
+        $this->assertSame('authorization_code', $body['grant_type']);
+        $this->assertSame('the-auth-code', $body['code']);
+        $this->assertFalse($this->lastRequestTo('/token')->hasHeader('Authorization'));
+    }
+
+    public function test_client_secret_basic_moves_credentials_to_the_authorization_header(): void
+    {
+        $provider = $this->makeProvider(
+            ['token_auth_method' => 'client_secret_basic'],
+            $this->happyPathResponses(),
+        );
+        $provider->user();
+
+        $request = $this->lastRequestTo('/token');
+        $body = $this->tokenRequestBody();
+
+        $expected = 'Basic '.base64_encode(urlencode(static::$opClientId).':'.urlencode(static::$opClientSecret));
+        $this->assertSame($expected, $request->getHeaderLine('Authorization'));
+        $this->assertArrayNotHasKey('client_id', $body);
+        $this->assertArrayNotHasKey('client_secret', $body);
+    }
+
+    public function test_basic_credentials_are_form_urlencoded_before_base64(): void
+    {
+        // RFC 6749 2.3.1. A secret with +, / and = must round-trip; base64ing
+        // the raw pair would not.
+        static::$opClientSecret = 'se+cret/=:with space';
+
+        try {
+            $provider = $this->makeProvider(
+                ['token_auth_method' => 'client_secret_basic'],
+                $this->happyPathResponses(),
+            );
+            $provider->user();
+
+            $header = $this->lastRequestTo('/token')->getHeaderLine('Authorization');
+            $decoded = base64_decode(substr($header, 6));
+
+            [$id, $secret] = explode(':', $decoded, 2);
+
+            $this->assertSame(static::$opClientId, urldecode($id));
+            $this->assertSame('se+cret/=:with space', urldecode($secret));
+        } finally {
+            static::$opClientSecret = 'client-secret';
+        }
+    }
+
+    public function test_discovery_advertising_basic_selects_it_automatically(): void
+    {
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument([
+                'token_endpoint_auth_methods_supported' => ['client_secret_basic', 'client_secret_post'],
+            ])),
+            $this->tokenEndpointResponse($this->encodeToken($this->idTokenClaims())),
+            $this->jsonResponse($this->jwksDocument()),
+        ]);
+        $provider->user();
+
+        $this->assertTrue($this->lastRequestTo('/token')->hasHeader('Authorization'));
+    }
+
+    public function test_explicit_config_beats_the_discovery_document(): void
+    {
+        $provider = $this->makeProvider(
+            ['token_auth_method' => 'client_secret_post'],
+            [
+                $this->jsonResponse($this->discoveryDocument([
+                    'token_endpoint_auth_methods_supported' => ['client_secret_basic'],
+                ])),
+                $this->tokenEndpointResponse($this->encodeToken($this->idTokenClaims())),
+                $this->jsonResponse($this->jwksDocument()),
+            ],
+        );
+        $provider->user();
+
+        $this->assertFalse($this->lastRequestTo('/token')->hasHeader('Authorization'));
+    }
+}

--- a/tests/OpenIDConnect/Unit/TokenResponseTest.php
+++ b/tests/OpenIDConnect/Unit/TokenResponseTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect\Unit;
+
+use SocialiteProviders\Tests\OpenIDConnect\Support\InteractsWithOidc;
+use SocialiteProviders\Tests\OpenIDConnect\TestCase;
+
+class TokenResponseTest extends TestCase
+{
+    use InteractsWithOidc;
+
+    public function test_the_full_token_response_and_approved_scopes_are_exposed(): void
+    {
+        $provider = $this->makeProvider([], $this->happyPathResponses());
+
+        $user = $provider->user();
+
+        $this->assertSame('the-access-token', $user->token);
+        $this->assertSame('the-refresh-token', $user->refreshToken);
+        $this->assertSame(['openid', 'email', 'profile'], $user->approvedScopes);
+        $this->assertArrayHasKey('id_token', $user->accessTokenResponseBody);
+    }
+
+    public function test_a_minimal_token_response_is_tolerated(): void
+    {
+        $idToken = $this->encodeToken($this->idTokenClaims());
+
+        $provider = $this->makeProvider([], [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->jsonResponse(['access_token' => 'the-access-token', 'id_token' => $idToken]),
+            $this->jsonResponse($this->jwksDocument()),
+        ]);
+
+        $user = $provider->user();
+
+        $this->assertSame('user-123', $user->getId());
+        $this->assertNull($user->refreshToken);
+        $this->assertNull($user->expiresIn);
+        $this->assertSame([], $user->approvedScopes);
+    }
+}

--- a/tests/OpenIDConnect/Unit/UserInfoTest.php
+++ b/tests/OpenIDConnect/Unit/UserInfoTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace SocialiteProviders\Tests\OpenIDConnect\Unit;
+
+use InvalidArgumentException;
+use SocialiteProviders\Tests\OpenIDConnect\Support\InteractsWithOidc;
+use SocialiteProviders\Tests\OpenIDConnect\TestCase;
+
+class UserInfoTest extends TestCase
+{
+    use InteractsWithOidc;
+
+    private function responsesWithEmaillessIdToken(array $userInfo): array
+    {
+        $claims = $this->idTokenClaims(['email' => null, 'groups' => ['admins']]);
+
+        return [
+            $this->jsonResponse($this->discoveryDocument()),
+            $this->tokenEndpointResponse($this->encodeToken($claims)),
+            $this->jsonResponse($this->jwksDocument()),
+            $this->jsonResponse($userInfo),
+        ];
+    }
+
+    public function test_userinfo_fills_in_a_missing_email(): void
+    {
+        $provider = $this->makeProvider([], $this->responsesWithEmaillessIdToken([
+            'sub'   => 'user-123',
+            'email' => 'from-userinfo@example.com',
+        ]));
+
+        $user = $provider->user();
+
+        $this->assertSame('from-userinfo@example.com', $user->getEmail());
+
+        // Merged, not substituted: claims only the id_token carried survive.
+        $this->assertSame(['admins'], $user->getRaw()['groups']);
+    }
+
+    public function test_the_access_token_travels_in_the_authorization_header_never_the_query(): void
+    {
+        $provider = $this->makeProvider([], $this->responsesWithEmaillessIdToken([
+            'sub'   => 'user-123',
+            'email' => 'from-userinfo@example.com',
+        ]));
+
+        $provider->user();
+
+        $userInfoRequest = $this->lastRequestTo('/userinfo');
+
+        $this->assertNotNull($userInfoRequest);
+        $this->assertSame('Bearer the-access-token', $userInfoRequest->getHeaderLine('Authorization'));
+        $this->assertStringNotContainsString('access_token', (string) $userInfoRequest->getUri());
+    }
+
+    public function test_a_userinfo_response_for_a_different_sub_is_rejected(): void
+    {
+        // OIDC Core 5.3.2: the subs must match exactly or the response is
+        // unusable.
+        $provider = $this->makeProvider([], $this->responsesWithEmaillessIdToken([
+            'sub'   => 'a-different-user',
+            'email' => 'attacker@example.com',
+        ]));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('sub does not match');
+
+        $provider->user();
+    }
+
+    public function test_userinfo_is_not_consulted_when_the_id_token_has_an_email(): void
+    {
+        $provider = $this->makeProvider([], $this->happyPathResponses());
+
+        $provider->user();
+
+        $this->assertNotContains('GET /userinfo', $this->requestedPaths());
+    }
+
+    public function test_require_email_fails_the_login_when_no_email_can_be_found(): void
+    {
+        $provider = $this->makeProvider(
+            ['require_email' => true],
+            $this->responsesWithEmaillessIdToken(['sub' => 'user-123', 'name' => 'No Email']),
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('no email');
+
+        $provider->user();
+    }
+
+    public function test_a_missing_email_is_tolerated_by_default(): void
+    {
+        $provider = $this->makeProvider(
+            [],
+            $this->responsesWithEmaillessIdToken(['sub' => 'user-123', 'name' => 'No Email']),
+        );
+
+        $this->assertNull($provider->user()->getEmail());
+    }
+}


### PR DESCRIPTION
Ports the provider from #1447 (thanks @adrum) as `src/OpenIDConnect`, with multi-issuer support on top.

Each connection in `config/oidc.php` registers as its own driver (`oidc_keycloak`, `oidc_entra`, ...) with isolated config and caches. A plain `services.openidconnect` block still works for a single IdP. Per-IdP classes (`entra`, `keycloak`, `auth0`, `okta`, `google`) derive config from friendlier keys (`tenant`, `realm`, `domain`), and any `Provider` subclass can be named in config the same way. Pluggable issuer validation fixes the multi-tenant `{tenantid}` mismatch reported on #1447.

Discovery, JWKS rotation, PKCE, and full `id_token` validation (`iss`, `aud`, `azp`, `exp`/`nbf`/`iat`, `nonce`, `at_hash`) are covered by 199 tests under `tests/OpenIDConnect`, which join the matrix from #1472 automatically.

Supports PHP ^8.2 and Laravel ^11, matching `socialiteproviders/manager`'s own window.

## Root dev dependency change

The provider uses the `Cache` facade, so its suite needs a booted container. `orchestra/testbench` replaces the root's `illuminate/http` and `illuminate/session` dev deps — `laravel/framework` declares `replace` for both, so they cannot coexist, and Testbench provides the `Request` and session `Store` that `tests/TestCase.php` already uses. Net one dev dep instead of two; Steam's suite passes unchanged.