### PR TITLE
Allow configuring azure graph URL

### DIFF
--- a/src/Azure/Provider.php
+++ b/src/Azure/Provider.php
@@ -62,7 +62,7 @@ class Provider extends AbstractProvider
      */
     protected function getUserByToken($token)
     {
-        $response = $this->getHttpClient()->get($this->graphUrl, [
+        $response = $this->getHttpClient()->get($this->getConfig('graph_url', $this->graphUrl), [
             RequestOptions::HEADERS => [
                 'Accept'        => 'application/json',
                 'Authorization' => 'Bearer '.$token,
@@ -116,6 +116,6 @@ class Provider extends AbstractProvider
 
     public static function additionalConfigKeys(): array
     {
-        return ['tenant', 'proxy'];
+        return ['tenant', 'proxy', 'graph_url'];
     }
 }

--- a/src/Azure/README.md
+++ b/src/Azure/README.md
@@ -16,7 +16,8 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
   'client_secret' => env('AZURE_CLIENT_SECRET'),
   'redirect' => env('AZURE_REDIRECT_URI'),
   'tenant' => env('AZURE_TENANT_ID'),
-  'proxy' => env('PROXY')  // optionally
+  'proxy' => env('PROXY'), // optionally
+  'graph_url' => env('AZURE_GRAPH_URL'), // optionally, defaults to https://graph.microsoft.com/v1.0/me
 ],
 ```
 

--- a/src/Azure/README.md
+++ b/src/Azure/README.md
@@ -17,7 +17,7 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
   'redirect' => env('AZURE_REDIRECT_URI'),
   'tenant' => env('AZURE_TENANT_ID'),
   'proxy' => env('PROXY'), // optionally
-  'graph_url' => env('AZURE_GRAPH_URL'), // optionally, defaults to https://graph.microsoft.com/v1.0/me
+  'graph_url' => env('AZURE_GRAPH_URL'), // optionally, defaults to https://graph.microsoft.com/v1.0/me; only set to trusted endpoints because access tokens are sent here, especially when using mocks
 ],
 ```
 

--- a/tests/Azure/AzureProviderTest.php
+++ b/tests/Azure/AzureProviderTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace SocialiteProviders\Tests\Azure;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use SocialiteProviders\Azure\Provider;
+use SocialiteProviders\Manager\Config;
+use SocialiteProviders\Tests\TestCase;
+
+class AzureProviderTest extends TestCase
+{
+    protected function provider(): string
+    {
+        return Provider::class;
+    }
+
+    public function test_graph_url_can_be_configured(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json'], $this->fixture('user.json')),
+        ]);
+
+        /** @var Provider $provider */
+        $provider = $this->makeProvider();
+        $provider->setConfig(new Config(
+            static::CLIENT_ID,
+            static::CLIENT_SECRET,
+            static::REDIRECT_URI,
+            ['graph_url' => 'https://graph.example.test/v1.0/me']
+        ));
+        $provider->setHttpClient(new Client(['handler' => HandlerStack::create($mock)]));
+
+        $user = $provider->userFromToken('access-token');
+
+        $this->assertSame('azure-user-id', $user->getId());
+        $this->assertSame('https://graph.example.test/v1.0/me', (string) $mock->getLastRequest()?->getUri());
+    }
+
+    public function test_graph_url_is_an_additional_config_key(): void
+    {
+        $this->assertContains('graph_url', Provider::additionalConfigKeys());
+    }
+}

--- a/tests/Azure/AzureProviderTest.php
+++ b/tests/Azure/AzureProviderTest.php
@@ -39,6 +39,28 @@ class AzureProviderTest extends TestCase
         $this->assertSame('https://graph.example.test/v1.0/me', (string) $mock->getLastRequest()?->getUri());
     }
 
+    public function test_empty_graph_url_uses_default(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json'], $this->fixture('user.json')),
+        ]);
+
+        /** @var Provider $provider */
+        $provider = $this->makeProvider();
+        $provider->setConfig(new Config(
+            static::CLIENT_ID,
+            static::CLIENT_SECRET,
+            static::REDIRECT_URI,
+            ['graph_url' => '']
+        ));
+        $provider->setHttpClient(new Client(['handler' => HandlerStack::create($mock)]));
+
+        $user = $provider->userFromToken('access-token');
+
+        $this->assertSame('azure-user-id', $user->getId());
+        $this->assertSame('https://graph.microsoft.com/v1.0/me', (string) $mock->getLastRequest()?->getUri());
+    }
+
     public function test_graph_url_is_an_additional_config_key(): void
     {
         $this->assertContains('graph_url', Provider::additionalConfigKeys());

--- a/tests/Azure/fixtures/user.json
+++ b/tests/Azure/fixtures/user.json
@@ -1,0 +1,6 @@
+{
+  "id": "azure-user-id",
+  "displayName": "Azure User",
+  "userPrincipalName": "azure.user@example.com",
+  "mail": "azure.user@example.com"
+}


### PR DESCRIPTION
## Summary

This PR allows the Azure provider's Microsoft Graph user endpoint to be configured via `graph_url`.

By default, the provider continues to use `https://graph.microsoft.com/v1.0/me`, so existing behavior remains unchanged. This makes it easier to point the provider at a mock Graph endpoint in local or test environments without subclassing the provider.

## Changes

- Add `graph_url` to Azure additional config keys
- Use configured `graph_url` when fetching the user profile
- Document the optional config value
- Add Azure provider test coverage