### PR TITLE
Allow configuring azure OAuth base URL

### DIFF
--- a/src/Azure/Provider.php
+++ b/src/Azure/Provider.php
@@ -10,6 +10,13 @@ class Provider extends AbstractProvider
     public const IDENTIFIER = 'AZURE';
 
     /**
+     * The base Azure OAuth URL.
+     *
+     * @var string
+     */
+    protected $baseUrl = 'https://login.microsoftonline.com';
+
+    /**
      * The base Azure Graph URL.
      *
      * @var string
@@ -111,11 +118,11 @@ class Provider extends AbstractProvider
      */
     protected function getBaseUrl(): string
     {
-        return 'https://login.microsoftonline.com/'.$this->getConfig('tenant', 'common');
+        return rtrim($this->getConfig('base_url', $this->baseUrl), '/').'/'.$this->getConfig('tenant', 'common');
     }
 
     public static function additionalConfigKeys(): array
     {
-        return ['tenant', 'proxy', 'graph_url'];
+        return ['tenant', 'proxy', 'base_url', 'graph_url'];
     }
 }

--- a/src/Azure/README.md
+++ b/src/Azure/README.md
@@ -17,6 +17,7 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
   'redirect' => env('AZURE_REDIRECT_URI'),
   'tenant' => env('AZURE_TENANT_ID'),
   'proxy' => env('PROXY'), // optionally
+  'base_url' => env('AZURE_BASE_URL'), // optionally, defaults to https://login.microsoftonline.com; only set to trusted endpoints because tokens are sent here, especially when using mocks
   'graph_url' => env('AZURE_GRAPH_URL'), // optionally, defaults to https://graph.microsoft.com/v1.0/me; only set to trusted endpoints because access tokens are sent here, especially when using mocks
 ],
 ```

--- a/tests/Azure/AzureProviderTest.php
+++ b/tests/Azure/AzureProviderTest.php
@@ -61,8 +61,49 @@ class AzureProviderTest extends TestCase
         $this->assertSame('https://graph.microsoft.com/v1.0/me', (string) $mock->getLastRequest()?->getUri());
     }
 
+    public function test_base_url_can_be_configured(): void
+    {
+        /** @var Provider $provider */
+        $provider = $this->makeProvider();
+        $provider->setConfig(new Config(
+            static::CLIENT_ID,
+            static::CLIENT_SECRET,
+            static::REDIRECT_URI,
+            [
+                'base_url' => 'https://login.example.test',
+                'tenant'   => 'tenant-id',
+            ]
+        ));
+
+        $this->assertStringStartsWith(
+            'https://login.example.test/tenant-id/oauth2/v2.0/authorize',
+            $provider->stateless()->redirect()->getTargetUrl()
+        );
+    }
+
+    public function test_empty_base_url_uses_default(): void
+    {
+        /** @var Provider $provider */
+        $provider = $this->makeProvider();
+        $provider->setConfig(new Config(
+            static::CLIENT_ID,
+            static::CLIENT_SECRET,
+            static::REDIRECT_URI,
+            [
+                'base_url' => '',
+                'tenant'   => 'tenant-id',
+            ]
+        ));
+
+        $this->assertStringStartsWith(
+            'https://login.microsoftonline.com/tenant-id/oauth2/v2.0/authorize',
+            $provider->stateless()->redirect()->getTargetUrl()
+        );
+    }
+
     public function test_graph_url_is_an_additional_config_key(): void
     {
+        $this->assertContains('base_url', Provider::additionalConfigKeys());
         $this->assertContains('graph_url', Provider::additionalConfigKeys());
     }
 }


### PR DESCRIPTION
## Summary
This PR allows the Azure provider's OAuth base URL to be configured via `base_url`.

This follows the same use case as the recently added #1479 `graph_url` configuration: callers can point Azure requests at mock endpoints in local or test environments without subclassing the provider.

By default, the provider continues to use `https://login.microsoftonline.com`, so existing behavior remains unchanged.

## Changes

- Add `base_url` to Azure additional config keys
- Use configured `base_url` when building Azure OAuth URLs
- Document the optional config value
- Add Azure provider test coverage