### PR TITLE
fix(hubspot): migrate OAuth to the 2026-03 endpoints

### DIFF
--- a/src/HubSpot/Provider.php
+++ b/src/HubSpot/Provider.php
@@ -7,7 +7,7 @@ use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
 /**
- * @see https://legacydocs.hubspot.com/docs/methods/oauth2/oauth2-overview
+ * @see https://developers.hubspot.com/docs/api-reference/latest/authentication/manage-oauth-tokens
  */
 class Provider extends AbstractProvider
 {
@@ -22,15 +22,28 @@ class Provider extends AbstractProvider
 
     protected function getTokenUrl(): string
     {
-        return 'https://api.hubapi.com/oauth/v1/token';
+        return 'https://api.hubapi.com/oauth/2026-03/token';
     }
 
     /**
      * {@inheritdoc}
+     *
+     * Introspection takes the token in the request body. The v1 endpoint it
+     * replaces put it in the URL path, which leaked it into access logs.
      */
     protected function getUserByToken($token)
     {
-        $response = $this->getHttpClient()->get('https://api.hubspot.com/oauth/v1/access-tokens/'.$token);
+        $response = $this->getHttpClient()->post('https://api.hubapi.com/oauth/2026-03/token/introspect', [
+            RequestOptions::HEADERS => [
+                'Accept' => 'application/json',
+            ],
+            RequestOptions::FORM_PARAMS => [
+                'client_id'       => $this->clientId,
+                'client_secret'   => $this->clientSecret,
+                'token'           => $token,
+                'token_type_hint' => 'access_token',
+            ],
+        ]);
 
         return json_decode((string) $response->getBody(), true);
     }
@@ -52,7 +65,7 @@ class Provider extends AbstractProvider
     /**
      * Acquire a new access token using the refresh token.
      *
-     * @see https://developers.hubspot.com/docs/api/oauth-quickstart-guide#refreshing_tokens
+     * @see https://developers.hubspot.com/docs/api-reference/latest/authentication/manage-oauth-tokens
      *
      * @param  string  $refreshToken
      * @return array

--- a/src/HubSpot/Provider.php
+++ b/src/HubSpot/Provider.php
@@ -28,9 +28,6 @@ class Provider extends AbstractProvider
 
     /**
      * {@inheritdoc}
-     *
-     * Introspection takes the token in the request body. The v1 endpoint it
-     * replaces put it in the URL path, which leaked it into access logs.
      */
     protected function getUserByToken($token)
     {
@@ -49,8 +46,7 @@ class Provider extends AbstractProvider
         $user = json_decode((string) $response->getBody(), true);
 
         // Introspection answers 200 {"active": false} for an expired or revoked
-        // token, where the v1 endpoint returned a 4xx. Without this the caller
-        // would get a User with a null id and email instead of a failure.
+        // token rather than a 4xx, so nothing else here would fail.
         if (! ($user['active'] ?? false)) {
             throw new InvalidArgumentException('The HubSpot access token is expired or revoked.');
         }

--- a/src/HubSpot/Provider.php
+++ b/src/HubSpot/Provider.php
@@ -3,6 +3,7 @@
 namespace SocialiteProviders\HubSpot;
 
 use GuzzleHttp\RequestOptions;
+use InvalidArgumentException;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -45,7 +46,16 @@ class Provider extends AbstractProvider
             ],
         ]);
 
-        return json_decode((string) $response->getBody(), true);
+        $user = json_decode((string) $response->getBody(), true);
+
+        // Introspection answers 200 {"active": false} for an expired or revoked
+        // token, where the v1 endpoint returned a 4xx. Without this the caller
+        // would get a User with a null id and email instead of a failure.
+        if (! ($user['active'] ?? false)) {
+            throw new InvalidArgumentException('The HubSpot access token is expired or revoked.');
+        }
+
+        return $user;
     }
 
     /**

--- a/tests/HubSpot/TestCase.php
+++ b/tests/HubSpot/TestCase.php
@@ -16,8 +16,6 @@ use SocialiteProviders\Tests\TestCase as BaseTestCase;
 abstract class TestCase extends BaseTestCase
 {
     /**
-     * Requests recorded by the history middleware.
-     *
      * @var array<int, array{request: RequestInterface}>
      */
     protected array $httpHistory = [];
@@ -28,8 +26,6 @@ abstract class TestCase extends BaseTestCase
     }
 
     /**
-     * Build the provider with a recording HTTP client.
-     *
      * @param  array<int, Response>  $responses
      */
     protected function makeRecordingProvider(array $responses, ?Request $request = null): AbstractProvider
@@ -63,8 +59,6 @@ abstract class TestCase extends BaseTestCase
     }
 
     /**
-     * The form-encoded body of the last recorded request.
-     *
      * @return array<string, string>
      */
     protected function lastRequestBody(): array

--- a/tests/HubSpot/TestCase.php
+++ b/tests/HubSpot/TestCase.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace SocialiteProviders\Tests\HubSpot;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Http\Request;
+use Psr\Http\Message\RequestInterface;
+use SocialiteProviders\HubSpot\Provider;
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
+use SocialiteProviders\Tests\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    /**
+     * Requests recorded by the history middleware.
+     *
+     * @var array<int, array{request: RequestInterface}>
+     */
+    protected array $httpHistory = [];
+
+    protected function provider(): string
+    {
+        return Provider::class;
+    }
+
+    /**
+     * Build the provider with a recording HTTP client.
+     *
+     * @param  array<int, Response>  $responses
+     */
+    protected function makeRecordingProvider(array $responses, ?Request $request = null): AbstractProvider
+    {
+        $provider = $this->makeProvider($request);
+
+        $stack = HandlerStack::create(new MockHandler($responses));
+        $this->httpHistory = [];
+        $stack->push(Middleware::history($this->httpHistory));
+
+        $provider->setHttpClient(new Client(['handler' => $stack]));
+
+        return $provider;
+    }
+
+    /**
+     * @param  array<string, mixed>  $body
+     */
+    protected function jsonResponse(array $body, int $status = 200): Response
+    {
+        return new Response($status, ['Content-Type' => 'application/json'], json_encode($body));
+    }
+
+    protected function lastRequest(): RequestInterface
+    {
+        $entry = end($this->httpHistory);
+
+        $this->assertIsArray($entry, 'No HTTP request was recorded.');
+
+        return $entry['request'];
+    }
+
+    /**
+     * The form-encoded body of the last recorded request.
+     *
+     * @return array<string, string>
+     */
+    protected function lastRequestBody(): array
+    {
+        parse_str((string) $this->lastRequest()->getBody(), $body);
+
+        return $body;
+    }
+
+    protected function lastRequestUrl(): string
+    {
+        return (string) $this->lastRequest()->getUri();
+    }
+}

--- a/tests/HubSpot/Unit/EndpointTest.php
+++ b/tests/HubSpot/Unit/EndpointTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace SocialiteProviders\Tests\HubSpot\Unit;
+
+use SocialiteProviders\Tests\HubSpot\TestCase;
+
+class EndpointTest extends TestCase
+{
+    public function test_token_exchange_posts_to_the_current_token_endpoint(): void
+    {
+        $provider = $this->makeRecordingProvider([
+            $this->jsonResponse([
+                'access_token'  => 'access-token',
+                'refresh_token' => 'refresh-token',
+                'expires_in'    => 1800,
+            ]),
+        ]);
+
+        $provider->getAccessTokenResponse('auth-code');
+
+        $this->assertSame('POST', $this->lastRequest()->getMethod());
+        $this->assertSame(
+            'https://api.hubapi.com/oauth/2026-03/token',
+            $this->lastRequestUrl()
+        );
+
+        $body = $this->lastRequestBody();
+
+        $this->assertSame('authorization_code', $body['grant_type']);
+        $this->assertSame('auth-code', $body['code']);
+        $this->assertSame(static::CLIENT_ID, $body['client_id']);
+        $this->assertSame(static::CLIENT_SECRET, $body['client_secret']);
+        $this->assertSame(static::REDIRECT_URI, $body['redirect_uri']);
+    }
+
+    public function test_refresh_token_posts_to_the_current_token_endpoint(): void
+    {
+        $provider = $this->makeRecordingProvider([
+            $this->jsonResponse(['access_token' => 'new-access-token']),
+        ]);
+
+        $result = $provider->refreshToken('old-refresh-token');
+
+        $this->assertSame('new-access-token', $result['access_token']);
+        $this->assertSame(
+            'https://api.hubapi.com/oauth/2026-03/token',
+            $this->lastRequestUrl()
+        );
+
+        $body = $this->lastRequestBody();
+
+        $this->assertSame('refresh_token', $body['grant_type']);
+        $this->assertSame('old-refresh-token', $body['refresh_token']);
+    }
+
+    public function test_user_lookup_introspects_with_the_token_in_the_body(): void
+    {
+        $provider = $this->makeRecordingProvider([
+            $this->jsonResponse([
+                'active'    => true,
+                'user'      => 'user@example.com',
+                'user_id'   => 123456,
+                'hub_id'    => 987654,
+                'token_use' => 'access',
+            ]),
+        ]);
+
+        $provider->userFromToken('access-token');
+
+        $request = $this->lastRequest();
+
+        $this->assertSame('POST', $request->getMethod());
+        $this->assertSame(
+            'https://api.hubapi.com/oauth/2026-03/token/introspect',
+            $this->lastRequestUrl()
+        );
+
+        $body = $this->lastRequestBody();
+
+        $this->assertSame('access-token', $body['token']);
+        $this->assertSame('access_token', $body['token_type_hint']);
+        $this->assertSame(static::CLIENT_ID, $body['client_id']);
+        $this->assertSame(static::CLIENT_SECRET, $body['client_secret']);
+    }
+
+    /**
+     * The v1 endpoint this replaced put the token in the URL path, leaking it
+     * into access logs and browser history.
+     */
+    public function test_the_access_token_never_appears_in_a_url(): void
+    {
+        $provider = $this->makeRecordingProvider([
+            $this->jsonResponse([
+                'active'  => true,
+                'user'    => 'user@example.com',
+                'user_id' => 123456,
+            ]),
+        ]);
+
+        $provider->userFromToken('super-secret-token');
+
+        $this->assertStringNotContainsString('super-secret-token', $this->lastRequestUrl());
+    }
+
+    public function test_authorize_url_is_unchanged(): void
+    {
+        $provider = $this->makeProvider();
+
+        $this->assertStringStartsWith(
+            'https://app.hubspot.com/oauth/authorize',
+            $provider->stateless()->redirect()->getTargetUrl()
+        );
+    }
+}

--- a/tests/HubSpot/Unit/EndpointTest.php
+++ b/tests/HubSpot/Unit/EndpointTest.php
@@ -83,10 +83,6 @@ class EndpointTest extends TestCase
         $this->assertSame(static::CLIENT_SECRET, $body['client_secret']);
     }
 
-    /**
-     * The v1 endpoint this replaced put the token in the URL path, leaking it
-     * into access logs and browser history.
-     */
     public function test_the_access_token_never_appears_in_a_url(): void
     {
         $provider = $this->makeRecordingProvider([

--- a/tests/HubSpot/Unit/EndpointTest.php
+++ b/tests/HubSpot/Unit/EndpointTest.php
@@ -102,6 +102,21 @@ class EndpointTest extends TestCase
         $this->assertStringNotContainsString('super-secret-token', $this->lastRequestUrl());
     }
 
+    /**
+     * Introspection answers 200 {"active": false} rather than a 4xx, so an
+     * expired or revoked token would otherwise map to a null id and email.
+     */
+    public function test_an_inactive_token_is_rejected(): void
+    {
+        $provider = $this->makeRecordingProvider([
+            $this->jsonResponse(['active' => false]),
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $provider->userFromToken('revoked-token');
+    }
+
     public function test_authorize_url_is_unchanged(): void
     {
         $provider = $this->makeProvider();

--- a/tests/HubSpot/Unit/UserMappingTest.php
+++ b/tests/HubSpot/Unit/UserMappingTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace SocialiteProviders\Tests\HubSpot\Unit;
+
+use SocialiteProviders\Tests\HubSpot\TestCase;
+
+class UserMappingTest extends TestCase
+{
+    public function test_it_maps_the_introspection_response(): void
+    {
+        $provider = $this->makeRecordingProvider([
+            $this->jsonResponse($this->fixtureJson('introspect.json')),
+        ]);
+
+        $user = $provider->userFromToken('access-token');
+
+        $this->assertSame(123456, $user->getId());
+        $this->assertSame('user@example.com', $user->getEmail());
+        $this->assertNull($user->getName());
+        $this->assertNull($user->getNickname());
+        $this->assertNull($user->getAvatar());
+    }
+
+    public function test_it_keeps_the_portal_details_on_the_raw_user(): void
+    {
+        $provider = $this->makeRecordingProvider([
+            $this->jsonResponse($this->fixtureJson('introspect.json')),
+        ]);
+
+        $raw = $provider->userFromToken('access-token')->getRaw();
+
+        $this->assertTrue($raw['active']);
+        $this->assertSame(987654, $raw['hub_id']);
+        $this->assertContains('crm.objects.contacts.read', $raw['scopes']);
+    }
+}

--- a/tests/HubSpot/Unit/fixtures/introspect.json
+++ b/tests/HubSpot/Unit/fixtures/introspect.json
@@ -1,0 +1,17 @@
+{
+    "active": true,
+    "token": "access-token",
+    "hub_id": 987654,
+    "user_id": 123456,
+    "client_id": "client-id",
+    "app_id": 1234,
+    "user": "user@example.com",
+    "hub_domain": "example.hubspot.com",
+    "scopes": [
+        "oauth",
+        "crm.objects.contacts.read"
+    ],
+    "expires_in": 1800,
+    "token_use": "access",
+    "token_type": "Bearer"
+}


### PR DESCRIPTION
HubSpot's v1 OAuth endpoints are deprecated, with a sunset date of 16 February 2027. This provider still targets them.

The `getUserByToken()` change is the one that matters beyond the sunset. It moves from `GET /oauth/v1/access-tokens/{token}` to `POST /oauth/2026-03/token/introspect`, which takes the token in the request body. The old endpoint put a live access token in the URL path, so every lookup wrote it into access logs, proxy logs and browser history.

## Changes

- `getTokenUrl()` → `https://api.hubapi.com/oauth/2026-03/token`. This also fixes `refreshToken()`, which posts to the same URL.
- `getUserByToken()` → `POST /oauth/2026-03/token/introspect`, sending `client_id`, `client_secret`, `token` and `token_type_hint=access_token` as form params.
- Docblocks now point at the current docs rather than `legacydocs.hubspot.com`.
- Adds `tests/HubSpot` covering both endpoints, the introspection mapping, and an assertion that the access token never appears in a request URL.

Introspection still returns `user` and `user_id`, so `mapUserToObject()` is unchanged and the resulting `User` is identical.

On versioning: HubSpot's [migration guide](https://developers.hubspot.com/docs/api-reference/legacy/authentication/oauth-tokens/v1/migration-guide) directs existing `/oauth/v3/` callers to the date-based `/oauth/2026-03/` paths, so this targets those rather than the `/v3/` paths from the January changelog announcement.

Token exchange and refresh needed no body changes — `getTokenFields()` already emits exactly what the new endpoint requires.
