### PR TITLE
Validate Apple identity token audience

### DIFF
--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -16,6 +16,7 @@ use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Signer\Rsa\Sha256;
 use Lcobucci\JWT\Validation\Constraint\IssuedBy;
 use Lcobucci\JWT\Validation\Constraint\LooseValidAt;
+use Lcobucci\JWT\Validation\Constraint\PermittedFor;
 use Lcobucci\JWT\Validation\Constraint\SignedWith;
 use Lcobucci\JWT\Validation\RequiredConstraintsViolated;
 use Psr\Http\Message\ResponseInterface;
@@ -195,6 +196,7 @@ class Provider extends AbstractProvider
             $constraints = [
                 new SignedWith(new Sha256, AppleSignerInMemory::plainText($publicKey['key'])),
                 new IssuedBy(self::URL),
+                new PermittedFor($this->clientId),
                 // fix for #1354
                 new LooseValidAt(SystemClock::fromSystemTimezone(), new DateInterval($this->getConfig('jwt_issued_time_leeway', 'PT3S'))),
             ];

--- a/tests/Apple/AppleProviderTest.php
+++ b/tests/Apple/AppleProviderTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace SocialiteProviders\Tests\Apple;
+
+use Firebase\JWT\JWT;
+use Illuminate\Support\Facades\Cache;
+use Laravel\Socialite\Two\InvalidStateException;
+use SocialiteProviders\Apple\Provider;
+use SocialiteProviders\Tests\TestCase;
+
+class AppleProviderTest extends TestCase
+{
+    private const KEY_ID = 'test-key';
+
+    protected function provider(): string
+    {
+        return Provider::class;
+    }
+
+    protected function tearDown(): void
+    {
+        Cache::clearResolvedInstance('cache');
+
+        parent::tearDown();
+    }
+
+    public function test_identity_token_with_matching_audience_is_accepted(): void
+    {
+        [$privateKey, $jwks] = $this->createKeyPair();
+        $this->fakeAppleJwks($jwks);
+
+        $user = $this->makeProvider()->userByIdentityToken(
+            $this->identityToken($privateKey, static::CLIENT_ID)
+        );
+
+        $this->assertSame('apple-user-id', $user->getId());
+        $this->assertSame('user@example.com', $user->getEmail());
+    }
+
+    public function test_identity_token_with_different_audience_is_rejected(): void
+    {
+        [$privateKey, $jwks] = $this->createKeyPair();
+        $this->fakeAppleJwks($jwks);
+
+        $this->expectException(InvalidStateException::class);
+        $this->expectExceptionMessage('The token is not allowed to be used by this audience');
+
+        $this->makeProvider()->userByIdentityToken(
+            $this->identityToken($privateKey, 'another-client-id')
+        );
+    }
+
+    /**
+     * @return array{string, array{keys: array<int, array<string, string>>}}
+     */
+    private function createKeyPair(): array
+    {
+        $key = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+
+        $this->assertNotFalse($key);
+        $this->assertTrue(openssl_pkey_export($key, $privateKey));
+
+        $details = openssl_pkey_get_details($key);
+
+        $this->assertIsArray($details);
+
+        return [
+            $privateKey,
+            [
+                'keys' => [[
+                    'kty' => 'RSA',
+                    'kid' => self::KEY_ID,
+                    'use' => 'sig',
+                    'alg' => 'RS256',
+                    'n'   => $this->base64UrlEncode($details['rsa']['n']),
+                    'e'   => $this->base64UrlEncode($details['rsa']['e']),
+                ]],
+            ],
+        ];
+    }
+
+    /**
+     * @param  array{keys: array<int, array<string, string>>}  $jwks
+     */
+    private function fakeAppleJwks(array $jwks): void
+    {
+        Cache::swap(new class($jwks)
+        {
+            public function __construct(private readonly array $jwks) {}
+
+            public function remember(string $key, int $ttl, callable $callback): array
+            {
+                return $this->jwks;
+            }
+        });
+    }
+
+    private function identityToken(string $privateKey, string $audience): string
+    {
+        $now = time();
+
+        return JWT::encode([
+            'iss'   => Provider::URL,
+            'sub'   => 'apple-user-id',
+            'aud'   => $audience,
+            'iat'   => $now - 5,
+            'nbf'   => $now - 5,
+            'exp'   => $now + 300,
+            'email' => 'user@example.com',
+        ], $privateKey, 'RS256', self::KEY_ID);
+    }
+
+    private function base64UrlEncode(string $value): string
+    {
+        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
+    }
+}


### PR DESCRIPTION
## Summary

- validate that Apple identity tokens are intended for the configured client ID
- add regression coverage for matching and mismatched audiences

## Rationale

Apple requires relying parties to verify that an identity token's aud claim matches their client ID. The provider already validates the signature, issuer, and token lifetime; this adds the corresponding audience constraint.

## Testing

- 237 tests passed
- 497 assertions