### PR TITLE
feat(apple): verify the identity token nonce

### DIFF
--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -14,6 +14,7 @@ use Laravel\Socialite\Two\InvalidStateException;
 use Lcobucci\Clock\SystemClock;
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Signer\Rsa\Sha256;
+use Lcobucci\JWT\Validation\Constraint\HasClaimWithValue;
 use Lcobucci\JWT\Validation\Constraint\IssuedBy;
 use Lcobucci\JWT\Validation\Constraint\LooseValidAt;
 use Lcobucci\JWT\Validation\Constraint\PermittedFor;
@@ -108,9 +109,19 @@ class Provider extends AbstractProvider
     protected function getUserByToken($token)
     {
         $this->checkToken($token);
-        $claims = explode('.', $token)[1];
 
-        return json_decode(base64_decode($claims), true);
+        return $this->parseTokenClaims($token);
+    }
+
+    /**
+     * Decode the claims of an already-verified token.
+     *
+     * @param  string  $token
+     * @return array<string, mixed>
+     */
+    protected function parseTokenClaims($token)
+    {
+        return json_decode(base64_decode(explode('.', $token)[1]), true);
     }
 
     protected function getClientSecret()
@@ -158,37 +169,35 @@ class Provider extends AbstractProvider
      * Return the user given the identity token provided on the client
      * side by Apple.
      *
+     * Pass the nonce from the authorization request to have it verified, as
+     * Apple requires. Without it a token can be replayed until it expires.
+     *
      * @param  string  $token
      * @return User $user
      *
      * @throws InvalidStateException when token can't be parsed
      */
-    public function userByIdentityToken(string $token): User
+    public function userByIdentityToken(string $token, ?string $nonce = null): User
     {
-        $array = $this->getUserByToken($token);
+        $this->checkToken($token, $nonce);
 
-        return $this->mapUserToObject($array);
+        return $this->mapUserToObject($this->parseTokenClaims($token));
     }
 
     /**
      * Verify Apple JWT.
      *
      * @param  string  $jwt
+     * @param  string|null  $nonce
      * @return bool
      *
      * @see https://appleid.apple.com/auth/keys
      */
-    public function checkToken($jwt)
+    public function checkToken($jwt, $nonce = null)
     {
         $token = $this->getJwtConfig()->parser()->parse($jwt);
 
-        $data = Cache::remember('socialite:Apple-JWKSet', 5 * 60, function () {
-            $response = (new Client)->get(self::URL . '/auth/keys');
-
-            return json_decode((string) $response->getBody(), true);
-        });
-
-        $publicKeys = JWK::parseKeySet($data);
+        $publicKeys = JWK::parseKeySet($this->getJwkSet());
         $kid = $token->headers()->get('kid');
 
         if (isset($publicKeys[$kid])) {
@@ -201,6 +210,10 @@ class Provider extends AbstractProvider
                 new LooseValidAt(SystemClock::fromSystemTimezone(), new DateInterval($this->getConfig('jwt_issued_time_leeway', 'PT3S'))),
             ];
 
+            if ($nonce !== null) {
+                $constraints[] = new HasClaimWithValue('nonce', $nonce);
+            }
+
             try {
                 $this->jwtConfig->validator()->assert($token, ...$constraints);
 
@@ -211,6 +224,30 @@ class Provider extends AbstractProvider
         }
 
         throw new InvalidStateException('Invalid JWT Signature');
+    }
+
+    /**
+     * Apple's public keys, cached so every token check does not refetch them.
+     *
+     * @return array<string, mixed>
+     */
+    protected function getJwkSet()
+    {
+        return Cache::remember('socialite:Apple-JWKSet', 5 * 60, function () {
+            $response = $this->getJwkHttpClient()->get(self::URL . '/auth/keys');
+
+            return json_decode((string) $response->getBody(), true);
+        });
+    }
+
+    /**
+     * Separate from getHttpClient(), whose client carries OAuth request options.
+     *
+     * @return Client
+     */
+    protected function getJwkHttpClient()
+    {
+        return new Client;
     }
 
     /**

--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -121,7 +121,9 @@ class Provider extends AbstractProvider
      */
     protected function parseTokenClaims($token)
     {
-        return json_decode(base64_decode(explode('.', $token)[1]), true);
+        $payload = explode('.', $token)[1];
+
+        return json_decode(base64_decode(strtr($payload, '-_', '+/')), true);
     }
 
     protected function getClientSecret()

--- a/src/Apple/README.md
+++ b/src/Apple/README.md
@@ -82,6 +82,18 @@ You should now be able to use the provider like you would regularly use Socialit
 return Socialite::driver('apple')->redirect();
 ```
 
+#### Native apps (identity token)
+
+Native iOS and Android clients hand your server an identity token directly. Pass
+the nonce from the authorization request to have it verified, as Apple requires:
+
+```php
+$user = Socialite::driver('apple')->userByIdentityToken($identityToken, $nonce);
+```
+
+The nonce is optional for backwards compatibility, but omitting it means a token
+can be replayed until it expires.
+
 ### Returned User fields
 
 - ``id``
@@ -98,6 +110,19 @@ Examples of possible values are PT3S -> 3 seconds, PT1M -> 1 Minute etc ...
 The thrown exception may look like this:
 ```
 [object] (Laravel\\Socialite\\Two\\InvalidStateException(code: 0): The token violates some mandatory constraints, details:                                                                                           - The token was issued in the future at /vendor/socialiteproviders/apple/Provider.php:207)                      [stacktrace]              
+```
+
+#### Invalid audience
+
+The identity token's `aud` claim must match `config('services.apple.client_id')`.
+Native apps send their bundle ID as the audience, which is not always the Services
+ID used for the web flow - if the two differ, configure the one your clients
+actually send.
+
+The thrown exception looks like this:
+```
+Laravel\Socialite\Two\InvalidStateException: The token violates some mandatory constraints, details:
+- The token is not allowed to be used by this audience
 ```
 
 ### Reference

--- a/tests/Apple/AppleProviderStub.php
+++ b/tests/Apple/AppleProviderStub.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SocialiteProviders\Tests\Apple;
+
+use GuzzleHttp\Client;
+use SocialiteProviders\Apple\Provider;
+
+/**
+ * Serves Apple's JWKS from a mocked client instead of the network.
+ */
+class AppleProviderStub extends Provider
+{
+    private ?Client $jwkHttpClient = null;
+
+    public function setJwkHttpClient(Client $client): void
+    {
+        $this->jwkHttpClient = $client;
+    }
+
+    protected function getJwkHttpClient()
+    {
+        return $this->jwkHttpClient ?? parent::getJwkHttpClient();
+    }
+}

--- a/tests/Apple/AppleProviderTest.php
+++ b/tests/Apple/AppleProviderTest.php
@@ -2,36 +2,13 @@
 
 namespace SocialiteProviders\Tests\Apple;
 
-use Firebase\JWT\JWT;
-use Illuminate\Support\Facades\Cache;
 use Laravel\Socialite\Two\InvalidStateException;
-use SocialiteProviders\Apple\Provider;
-use SocialiteProviders\Tests\TestCase;
 
 class AppleProviderTest extends TestCase
 {
-    private const KEY_ID = 'test-key';
-
-    protected function provider(): string
-    {
-        return Provider::class;
-    }
-
-    protected function tearDown(): void
-    {
-        Cache::clearResolvedInstance('cache');
-
-        parent::tearDown();
-    }
-
     public function test_identity_token_with_matching_audience_is_accepted(): void
     {
-        [$privateKey, $jwks] = $this->createKeyPair();
-        $this->fakeAppleJwks($jwks);
-
-        $user = $this->makeProvider()->userByIdentityToken(
-            $this->identityToken($privateKey, static::CLIENT_ID)
-        );
+        $user = $this->makeAppleProvider()->userByIdentityToken($this->identityToken());
 
         $this->assertSame('apple-user-id', $user->getId());
         $this->assertSame('user@example.com', $user->getEmail());
@@ -39,82 +16,11 @@ class AppleProviderTest extends TestCase
 
     public function test_identity_token_with_different_audience_is_rejected(): void
     {
-        [$privateKey, $jwks] = $this->createKeyPair();
-        $this->fakeAppleJwks($jwks);
-
         $this->expectException(InvalidStateException::class);
         $this->expectExceptionMessage('The token is not allowed to be used by this audience');
 
-        $this->makeProvider()->userByIdentityToken(
-            $this->identityToken($privateKey, 'another-client-id')
+        $this->makeAppleProvider()->userByIdentityToken(
+            $this->identityToken(['aud' => 'another-client-id'])
         );
-    }
-
-    /**
-     * @return array{string, array{keys: array<int, array<string, string>>}}
-     */
-    private function createKeyPair(): array
-    {
-        $key = openssl_pkey_new([
-            'private_key_bits' => 2048,
-            'private_key_type' => OPENSSL_KEYTYPE_RSA,
-        ]);
-
-        $this->assertNotFalse($key);
-        $this->assertTrue(openssl_pkey_export($key, $privateKey));
-
-        $details = openssl_pkey_get_details($key);
-
-        $this->assertIsArray($details);
-
-        return [
-            $privateKey,
-            [
-                'keys' => [[
-                    'kty' => 'RSA',
-                    'kid' => self::KEY_ID,
-                    'use' => 'sig',
-                    'alg' => 'RS256',
-                    'n'   => $this->base64UrlEncode($details['rsa']['n']),
-                    'e'   => $this->base64UrlEncode($details['rsa']['e']),
-                ]],
-            ],
-        ];
-    }
-
-    /**
-     * @param  array{keys: array<int, array<string, string>>}  $jwks
-     */
-    private function fakeAppleJwks(array $jwks): void
-    {
-        Cache::swap(new class($jwks)
-        {
-            public function __construct(private readonly array $jwks) {}
-
-            public function remember(string $key, int $ttl, callable $callback): array
-            {
-                return $this->jwks;
-            }
-        });
-    }
-
-    private function identityToken(string $privateKey, string $audience): string
-    {
-        $now = time();
-
-        return JWT::encode([
-            'iss'   => Provider::URL,
-            'sub'   => 'apple-user-id',
-            'aud'   => $audience,
-            'iat'   => $now - 5,
-            'nbf'   => $now - 5,
-            'exp'   => $now + 300,
-            'email' => 'user@example.com',
-        ], $privateKey, 'RS256', self::KEY_ID);
-    }
-
-    private function base64UrlEncode(string $value): string
-    {
-        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
     }
 }

--- a/tests/Apple/IdentityTokenTest.php
+++ b/tests/Apple/IdentityTokenTest.php
@@ -35,6 +35,19 @@ class IdentityTokenTest extends TestCase
         );
     }
 
+    public function test_it_decodes_claims_whose_payload_uses_base64url_characters(): void
+    {
+        // A nonce chosen so the encoded payload contains - and _, which plain
+        // base64_decode does not understand.
+        $user = $this->makeAppleProvider()->userByIdentityToken(
+            $this->identityToken(['nonce' => 'aa?bb>>cc']),
+            'aa?bb>>cc'
+        );
+
+        $this->assertSame('apple-user-id', $user->getId());
+        $this->assertSame('user@example.com', $user->getEmail());
+    }
+
     public function test_it_rejects_a_token_from_another_issuer(): void
     {
         $this->expectException(InvalidStateException::class);

--- a/tests/Apple/IdentityTokenTest.php
+++ b/tests/Apple/IdentityTokenTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace SocialiteProviders\Tests\Apple;
+
+use Laravel\Socialite\Two\InvalidStateException;
+
+class IdentityTokenTest extends TestCase
+{
+    public function test_it_accepts_a_token_whose_audience_list_contains_the_client_id(): void
+    {
+        $user = $this->makeAppleProvider()->userByIdentityToken(
+            $this->identityToken(['aud' => ['another-client-id', static::CLIENT_ID]])
+        );
+
+        $this->assertSame('apple-user-id', $user->getId());
+    }
+
+    public function test_it_rejects_a_token_whose_audience_list_omits_the_client_id(): void
+    {
+        $this->expectException(InvalidStateException::class);
+        $this->expectExceptionMessage('The token is not allowed to be used by this audience');
+
+        $this->makeAppleProvider()->userByIdentityToken(
+            $this->identityToken(['aud' => ['another-client-id', 'a-third-client-id']])
+        );
+    }
+
+    public function test_it_rejects_a_token_with_no_audience_claim(): void
+    {
+        $this->expectException(InvalidStateException::class);
+        $this->expectExceptionMessage('The token is not allowed to be used by this audience');
+
+        $this->makeAppleProvider()->userByIdentityToken(
+            $this->identityTokenWithoutAudience()
+        );
+    }
+
+    public function test_it_rejects_a_token_from_another_issuer(): void
+    {
+        $this->expectException(InvalidStateException::class);
+        $this->expectExceptionMessage('The token was not issued by the given issuers');
+
+        $this->makeAppleProvider()->userByIdentityToken(
+            $this->identityToken(['iss' => 'https://accounts.google.com'])
+        );
+    }
+
+    public function test_it_rejects_a_token_signed_by_an_unknown_key(): void
+    {
+        $token = $this->identityToken();
+
+        // Re-key the JWKS so the token's kid no longer resolves.
+        $this->jwks['keys'][0]['kid'] = 'a-different-key';
+
+        $this->expectException(InvalidStateException::class);
+        $this->expectExceptionMessage('Invalid JWT Signature');
+
+        $this->makeAppleProvider()->userByIdentityToken($token);
+    }
+}

--- a/tests/Apple/NonceValidationTest.php
+++ b/tests/Apple/NonceValidationTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace SocialiteProviders\Tests\Apple;
+
+use Laravel\Socialite\Two\InvalidStateException;
+
+class NonceValidationTest extends TestCase
+{
+    public function test_it_accepts_a_token_whose_nonce_matches(): void
+    {
+        $user = $this->makeAppleProvider()->userByIdentityToken(
+            $this->identityToken(['nonce' => 'expected-nonce']),
+            'expected-nonce'
+        );
+
+        $this->assertSame('apple-user-id', $user->getId());
+    }
+
+    public function test_it_rejects_a_token_whose_nonce_differs(): void
+    {
+        $this->expectException(InvalidStateException::class);
+
+        $this->makeAppleProvider()->userByIdentityToken(
+            $this->identityToken(['nonce' => 'some-other-nonce']),
+            'expected-nonce'
+        );
+    }
+
+    public function test_it_rejects_a_token_with_no_nonce_when_one_is_expected(): void
+    {
+        $this->expectException(InvalidStateException::class);
+
+        $this->makeAppleProvider()->userByIdentityToken(
+            $this->identityToken(),
+            'expected-nonce'
+        );
+    }
+
+    public function test_it_skips_nonce_verification_when_none_is_expected(): void
+    {
+        $user = $this->makeAppleProvider()->userByIdentityToken(
+            $this->identityToken(['nonce' => 'some-nonce'])
+        );
+
+        $this->assertSame('apple-user-id', $user->getId());
+    }
+}

--- a/tests/Apple/TestCase.php
+++ b/tests/Apple/TestCase.php
@@ -10,7 +10,6 @@ use Illuminate\Cache\ArrayStore;
 use Illuminate\Cache\Repository;
 use Illuminate\Container\Container;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Facade;
 use Lcobucci\JWT\Encoding\ChainedFormatter;
 use Lcobucci\JWT\Encoding\JoseEncoder;
@@ -87,11 +86,11 @@ abstract class TestCase extends BaseTestCase
     /**
      * A Guzzle client that replays Apple's JWKS endpoint.
      */
-    protected function makeJwkClient(?Response $response = null): Client
+    protected function makeJwkClient(): Client
     {
         return new Client([
             'handler' => HandlerStack::create(new MockHandler([
-                $response ?? new Response(200, ['Content-Type' => 'application/json'], json_encode($this->jwks)),
+                new Response(200, ['Content-Type' => 'application/json'], json_encode($this->jwks)),
             ])),
         ]);
     }
@@ -150,11 +149,6 @@ abstract class TestCase extends BaseTestCase
         // Re-signing is unnecessary: aud is checked alongside the signature, and
         // asserting on the audience violation would hide a signature failure.
         return $headers.'.'.$this->base64UrlEncode(json_encode($decoded)).'.'.$signature;
-    }
-
-    protected function flushJwkCache(): void
-    {
-        Cache::forget('socialite:Apple-JWKSet');
     }
 
     private function makeKeyPair(): void

--- a/tests/Apple/TestCase.php
+++ b/tests/Apple/TestCase.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace SocialiteProviders\Tests\Apple;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Repository;
+use Illuminate\Container\Container;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Facade;
+use Lcobucci\JWT\Encoding\ChainedFormatter;
+use Lcobucci\JWT\Encoding\JoseEncoder;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Signer\Rsa\Sha256;
+use Lcobucci\JWT\Token\Builder;
+use SocialiteProviders\Apple\Provider;
+use SocialiteProviders\Tests\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    protected const KEY_ID = 'test-key';
+
+    protected string $privateKey;
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $jwks;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->bindCache();
+        $this->makeKeyPair();
+    }
+
+    protected function tearDown(): void
+    {
+        Facade::clearResolvedInstances();
+        Facade::setFacadeApplication(null);
+        Container::setInstance(null);
+
+        parent::tearDown();
+    }
+
+    /**
+     * The provider caches the JWKS through the Cache facade, which needs a
+     * container behind it. An array store keeps each test isolated.
+     */
+    private function bindCache(): void
+    {
+        $container = new Container;
+        $container->instance('cache', new Repository(new ArrayStore));
+
+        Container::setInstance($container);
+        Facade::clearResolvedInstances();
+        Facade::setFacadeApplication($container);
+    }
+
+    protected function provider(): string
+    {
+        return Provider::class;
+    }
+
+    /**
+     * A provider whose JWKS fetch is served from the generated key pair.
+     */
+    protected function makeAppleProvider(?Request $request = null): Provider
+    {
+        $provider = new AppleProviderStub(
+            $request ?? $this->makeRequest(),
+            static::CLIENT_ID,
+            static::CLIENT_SECRET,
+            static::REDIRECT_URI
+        );
+
+        $provider->setJwkHttpClient($this->makeJwkClient());
+
+        return $provider;
+    }
+
+    /**
+     * A Guzzle client that replays Apple's JWKS endpoint.
+     */
+    protected function makeJwkClient(?Response $response = null): Client
+    {
+        return new Client([
+            'handler' => HandlerStack::create(new MockHandler([
+                $response ?? new Response(200, ['Content-Type' => 'application/json'], json_encode($this->jwks)),
+            ])),
+        ]);
+    }
+
+    /**
+     * Build an Apple-shaped identity token signed with the generated key.
+     *
+     * @param  array<string, mixed>  $claims
+     */
+    protected function identityToken(array $claims = []): string
+    {
+        $claims = array_merge([
+            'iss'   => Provider::URL,
+            'sub'   => 'apple-user-id',
+            'aud'   => static::CLIENT_ID,
+            'email' => 'user@example.com',
+        ], $claims);
+
+        $now = new \DateTimeImmutable;
+
+        $builder = (new Builder(new JoseEncoder, ChainedFormatter::default()))
+            ->issuedAt($now->modify('-5 seconds'))
+            ->canOnlyBeUsedAfter($now->modify('-5 seconds'))
+            ->expiresAt($now->modify('+5 minutes'))
+            ->withHeader('kid', static::KEY_ID);
+
+        foreach ((array) $claims['aud'] as $audience) {
+            $builder = $builder->permittedFor($audience);
+        }
+
+        $builder = $builder->issuedBy($claims['iss'])->relatedTo($claims['sub']);
+
+        foreach ($claims as $name => $value) {
+            if (! in_array($name, ['iss', 'sub', 'aud'], true)) {
+                $builder = $builder->withClaim($name, $value);
+            }
+        }
+
+        return $builder->getToken(new Sha256, InMemory::plainText($this->privateKey))->toString();
+    }
+
+    /**
+     * A token with no aud claim at all, which the builder cannot express.
+     *
+     * @param  array<string, mixed>  $claims
+     */
+    protected function identityTokenWithoutAudience(array $claims = []): string
+    {
+        $token = $this->identityToken($claims);
+
+        [$headers, $payload, $signature] = explode('.', $token);
+
+        $decoded = json_decode($this->base64UrlDecode($payload), true);
+        unset($decoded['aud']);
+
+        // Re-signing is unnecessary: aud is checked alongside the signature, and
+        // asserting on the audience violation would hide a signature failure.
+        return $headers.'.'.$this->base64UrlEncode(json_encode($decoded)).'.'.$signature;
+    }
+
+    protected function flushJwkCache(): void
+    {
+        Cache::forget('socialite:Apple-JWKSet');
+    }
+
+    private function makeKeyPair(): void
+    {
+        $key = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+
+        $this->assertNotFalse($key);
+        $this->assertTrue(openssl_pkey_export($key, $privateKey));
+
+        $details = openssl_pkey_get_details($key);
+
+        $this->assertIsArray($details);
+
+        $this->privateKey = $privateKey;
+        $this->jwks = [
+            'keys' => [[
+                'kty' => 'RSA',
+                'kid' => static::KEY_ID,
+                'use' => 'sig',
+                'alg' => 'RS256',
+                'n'   => $this->base64UrlEncode($details['rsa']['n']),
+                'e'   => $this->base64UrlEncode($details['rsa']['e']),
+            ]],
+        ];
+    }
+
+    private function base64UrlEncode(string $value): string
+    {
+        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
+    }
+
+    private function base64UrlDecode(string $value): string
+    {
+        return base64_decode(strtr($value, '-_', '+/'));
+    }
+}


### PR DESCRIPTION
Apple requires relying parties to verify the nonce alongside the audience, which #1483 added. Without it a token can be replayed until it expires.

- accept the expected nonce as an optional argument to userByIdentityToken()
- fetch the JWKS through an overridable client so tests can stub it
- cover the audience constraint for array and missing aud claims

