### PR TITLE
Validate Apple callback state

### DIFF
--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -276,26 +276,15 @@ class Provider extends AbstractProvider
      */
     public function user()
     {
-        //Temporary fix to enable stateless
+        if ($this->usesState() && $this->hasInvalidState()) {
+            throw new InvalidStateException;
+        }
+
         $response = $this->getAccessTokenResponse($this->getCode());
 
         $appleUserToken = $this->getUserByToken(
             $token = Arr::get($response, 'id_token')
         );
-
-        if ($this->usesState()) {
-            $state = explode('.', $appleUserToken['nonce'])[1];
-            if ($state === $this->request->input('state')) {
-                $this->request->session()->put([
-                    'state'        => $state,
-                    'state_verify' => $state,
-                ]);
-            }
-
-            if ($this->hasInvalidState()) {
-                throw new InvalidStateException;
-            }
-        }
 
         $user = $this->mapUserToObject($appleUserToken);
 

--- a/tests/Apple/CallbackStateValidationTest.php
+++ b/tests/Apple/CallbackStateValidationTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace SocialiteProviders\Tests\Apple;
+
+use GuzzleHttp\Psr7\Response;
+use Laravel\Socialite\Two\InvalidStateException;
+
+class CallbackStateValidationTest extends TestCase
+{
+    public function test_callback_without_previously_stored_state_is_rejected(): void
+    {
+        $request = $this->makeRequestWithSession([
+            'code'  => 'authorization-code',
+            'state' => 'attacker-controlled-state',
+        ]);
+
+        $this->expectException(InvalidStateException::class);
+
+        $this->makeAppleProvider($request)->user();
+    }
+
+    public function test_callback_with_matching_previously_stored_state_is_accepted(): void
+    {
+        $state = 'expected-state';
+        $request = $this->makeRequestWithSession([
+            'code'  => 'authorization-code',
+            'state' => $state,
+        ], [
+            'state' => $state,
+        ]);
+        $provider = $this->makeAppleProvider($request);
+        $provider->setHttpClient($this->makeHttpClient([
+            new Response(200, [], json_encode([
+                'id_token' => $this->identityToken(['nonce' => 'nonce']),
+            ])),
+        ]));
+
+        $user = $provider->user();
+
+        $this->assertSame('apple-user-id', $user->getId());
+        $this->assertSame('user@example.com', $user->getEmail());
+    }
+}


### PR DESCRIPTION
## Summary
- Validate OAuth state before exchanging the Apple authorization code
- Remove reconstruction of the expected state from the callback token
- Add callback state regression coverage

## Testing
- `vendor/bin/phpunit tests/Apple/AppleProviderTest.php --testdox`