### PR TITLE
fix(kanidm): enable PKCE using intended mechanism

### DIFF
--- a/src/Kanidm/Provider.php
+++ b/src/Kanidm/Provider.php
@@ -34,15 +34,16 @@ class Provider extends AbstractProvider
             throw new InvalidArgumentException('Missing base URL value.');
         }
 
-        /**
-         * PKCE is the default in recent versions of Kanidm, and heavily encouraged
-         * to be enforced whenever possible.
-         */
-        if (!$this->usesPKCE() && $this->getConfig('enable_pkce')) {
-            $this->enablePKCE();
-        }
-
         return $baseUrl;
+    }
+
+    /**
+     * PKCE is enforced by default in Kanidm. `enable_pkce` should be enabled
+     * in services.php unless you have explicitly disabled PKCE in Kanidm.
+     */
+    protected function usesPKCE()
+    {
+        return parent::usesPKCE() || filter_var($this->getConfig('enable_pkce'), FILTER_VALIDATE_BOOLEAN);
     }
 
     public static function additionalConfigKeys(): array

--- a/tests/Kanidm/KanidmProviderTest.php
+++ b/tests/Kanidm/KanidmProviderTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace SocialiteProviders\Tests\Kanidm;
+
+use Illuminate\Http\Request;
+use SocialiteProviders\Kanidm\Provider;
+use SocialiteProviders\Manager\Config;
+use SocialiteProviders\Tests\TestCase;
+
+class KanidmProviderTest extends TestCase
+{
+    private const BASE_URL = 'https://idm.example.com';
+
+    protected function provider(): string
+    {
+        return Provider::class;
+    }
+
+    /**
+     * Computes PKCE challenge
+     * See getCodeChallenge() in AbstractProvider
+     */
+    private static function s256(string $verifier): string
+    {
+        return rtrim(strtr(base64_encode(hash('sha256', $verifier, true)), '+/', '-_'), '=');
+    }
+
+    private function configured(?Request $request = null, array $responses = [], array $config = []): Provider
+    {
+        /** @var Provider $provider */
+        $provider = $this->makeProvider($request ?? $this->makeRequestWithSession());
+        $provider->setConfig(new Config(
+            static::CLIENT_ID,
+            static::CLIENT_SECRET,
+            static::REDIRECT_URI,
+            array_merge(['base_url' => self::BASE_URL], $config)
+        ));
+
+        $client = $this->makeHttpClient($responses);
+        $provider->setHttpClient($client);
+
+        return $provider;
+    }
+
+    public function test_redirect_with_pkce_enabled_stores_verifier_and_derives_challenge_from_it(): void
+    {
+        $request = $this->makeRequestWithSession();
+        $url = $this->configured($request, [], ['enable_pkce' => true])->redirect()->getTargetUrl();
+        $params = $this->queryParams($url);
+
+        $this->assertStringStartsWith(self::BASE_URL.'/ui/oauth2?', $url);
+        $this->assertSame(static::CLIENT_ID, $params['client_id']);
+        $this->assertSame(static::REDIRECT_URI, $params['redirect_uri']);
+        $this->assertSame('code', $params['response_type']);
+        $this->assertSame('email openid profile', $params['scope']);
+        $this->assertSame($request->session()->get('state'), $params['state']);
+
+        $verifier = $request->session()->get('code_verifier');
+        $this->assertNotNull($verifier, 'code_verifier was not stored in the session');
+        $this->assertSame('S256', $params['code_challenge_method']);
+        $this->assertSame($this->s256($verifier), $params['code_challenge']);
+        $this->assertNotSame($this->s256(''), $params['code_challenge']);
+    }
+
+    public function test_redirect_without_pkce_config_sends_no_challenge(): void
+    {
+        $request = $this->makeRequestWithSession();
+        $url = $this->configured($request)->redirect()->getTargetUrl();
+        $params = $this->queryParams($url);
+
+        $this->assertArrayNotHasKey('code_challenge', $params);
+        $this->assertArrayNotHasKey('code_challenge_method', $params);
+        $this->assertFalse($request->session()->has('code_verifier'));
+    }
+}


### PR DESCRIPTION
A previous change (#1421) enabled PKCE for Kanidm by turning it on in the `getBaseUrl()` function.

This can cause authentication to fail if `usesPKCE()` is called *before* `getBaseUrl()`, which is the case when using Kanidm with [Lychee](https://github.com/LycheeOrg/Lychee), resulting in a 500 error during the auth flow, and this error in Kanidm logs:

```
kanidm-1       | 6db89809-5bcc-4469-bd6a-54d717ec98d1 INFO     ┕━ handle_oauth2_token_exchange [ 123µs | 54.21% ]
kanidm-1       | 6db89809-5bcc-4469-bd6a-54d717ec98d1 INFO        ┕━ ｉ [info]: PKCE code verification failed - code challenge is present, but no verifier was provided | event_tag_id: 10
```

AbstractProvider.php is meant to populate `code_verifier` [here](https://github.com/laravel/socialite/blob/fa0181ee6204ca28a55cd67145fadd631ac209cf/src/Two/AbstractProvider.php#L169-L171) but doesn't, due to `usesPKCE()` returning false.

This change adds the explicit function override for `usesPKCE()`, which will properly indicate to socialite that PKCE is enabled.