### PR TITLE
fix(apple): verify the callback nonce

### DIFF
--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -72,6 +72,18 @@ class Provider extends AbstractProvider
     /**
      * {@inheritdoc}
      */
+    public function redirect()
+    {
+        if ($this->usesState()) {
+            $this->request->session()->put('nonce', Str::random(40));
+        }
+
+        return parent::redirect();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function getCodeFields($state = null)
     {
         $fields = [
@@ -84,7 +96,7 @@ class Provider extends AbstractProvider
 
         if ($this->usesState()) {
             $fields['state'] = $state;
-            $fields['nonce'] = Str::uuid() . '.' . $state;
+            $fields['nonce'] = $this->request->session()->get('nonce');
         }
 
         return array_merge($fields, $this->parameters);
@@ -276,17 +288,22 @@ class Provider extends AbstractProvider
      */
     public function user()
     {
-        if ($this->usesState() && $this->hasInvalidState()) {
+        if ($this->hasInvalidState()) {
             throw new InvalidStateException;
         }
 
+        // Issued alongside the state on redirect; Apple echoes it in the
+        // identity token so a token from another authorization request is
+        // rejected even when the code exchange itself succeeds.
+        $nonce = $this->usesState() ? $this->request->session()->pull('nonce') : null;
+
         $response = $this->getAccessTokenResponse($this->getCode());
 
-        $appleUserToken = $this->getUserByToken(
-            $token = Arr::get($response, 'id_token')
-        );
+        $token = Arr::get($response, 'id_token');
 
-        $user = $this->mapUserToObject($appleUserToken);
+        $this->checkToken($token, $nonce);
+
+        $user = $this->mapUserToObject($this->parseTokenClaims($token));
 
         if ($user instanceof User) {
             $user->setAccessTokenResponseBody($response);

--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -62,6 +62,11 @@ class Provider extends AbstractProvider
     protected $nonce = null;
 
     /**
+     * @var bool
+     */
+    protected $manageStatelessNonce = false;
+
+    /**
      * {@inheritdoc}
      */
     protected function getAuthUrl($state): string
@@ -81,6 +86,11 @@ class Provider extends AbstractProvider
     {
         if ($this->usesState()) {
             $this->request->session()->put('nonce', Str::random(40));
+        } elseif ($this->manageStatelessNonce) {
+            $this->nonce = Str::random(40);
+            $this->parameters['state'] = $state = Str::random(40);
+
+            $this->nonceCache()->put($this->nonceCacheKey($state), $this->nonce, $this->nonceCacheTtl());
         }
 
         return parent::redirect();
@@ -96,6 +106,20 @@ class Provider extends AbstractProvider
     public function setNonce($nonce)
     {
         $this->nonce = $nonce;
+
+        return $this;
+    }
+
+    /**
+     * Let the provider manage the stateless nonce through the cache instead of
+     * the caller supplying it. The nonce is cached under the state Apple echoes
+     * back, so no session cookie is needed on the callback.
+     *
+     * @return $this
+     */
+    public function statelessNonce()
+    {
+        $this->manageStatelessNonce = true;
 
         return $this;
     }
@@ -316,12 +340,22 @@ class Provider extends AbstractProvider
         // Refuse a stateless callback with no nonce rather than run it with no
         // CSRF protection at all.
         if ($this->usesState()) {
+            // A login begun before this version was deployed has state but no
+            // nonce; the state check already passed, so let it through.
             $nonce = $this->request->session()->pull('nonce');
+        } elseif ($this->manageStatelessNonce) {
+            // pull() so a state cannot be replayed; a miss means the state was
+            // never issued or is already spent, so reject it.
+            $nonce = $this->nonceCache()->pull($this->nonceCacheKey($this->request->input('state')));
+
+            if ($nonce === null) {
+                throw new InvalidStateException;
+            }
         } elseif ($this->nonce !== null) {
             $nonce = $this->nonce;
         } else {
             throw new InvalidStateException(
-                'A stateless Apple callback has no CSRF protection. Call setNonce() with the nonce sent to Apple, or use userByIdentityToken() for native apps.'
+                'A stateless Apple callback has no CSRF protection. Call setNonce() with the nonce sent to Apple, use statelessNonce() to have the provider manage it, or use userByIdentityToken() for native apps.'
             );
         }
 
@@ -340,6 +374,28 @@ class Provider extends AbstractProvider
         return $user->setToken($token)
             ->setRefreshToken(Arr::get($response, 'refresh_token'))
             ->setExpiresIn(Arr::get($response, 'expires_in'));
+    }
+
+    /**
+     * @return \Illuminate\Contracts\Cache\Repository
+     */
+    protected function nonceCache()
+    {
+        $store = $this->getConfig('nonce_cache_store');
+
+        $cache = Cache::getFacadeRoot();
+
+        return $store !== null && method_exists($cache, 'store') ? $cache->store($store) : $cache;
+    }
+
+    protected function nonceCacheKey(?string $state): string
+    {
+        return 'socialite:apple:nonce:'.$state;
+    }
+
+    protected function nonceCacheTtl(): int
+    {
+        return (int) $this->getConfig('nonce_cache_ttl', 600);
     }
 
     /**
@@ -440,6 +496,6 @@ class Provider extends AbstractProvider
      */
     public static function additionalConfigKeys()
     {
-        return ['private_key', 'passphrase', 'signer', 'jwt_issued_time_leeway'];
+        return ['private_key', 'passphrase', 'signer', 'jwt_issued_time_leeway', 'nonce_cache_store', 'nonce_cache_ttl'];
     }
 }

--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -98,9 +98,8 @@ class Provider extends AbstractProvider
             return parent::redirect();
         }
 
-        // Carry the nonce in an encrypted cookie so it is bound to the browser
-        // that started the login and cannot be forged. A callback captured and
-        // replayed in another browser has no such cookie (RFC 9700 section 2.1).
+        // Bound to the browser that started the login: a callback replayed in
+        // another browser carries no such cookie (RFC 9700 section 2.1).
         $this->nonce = Str::random(40);
 
         return parent::redirect()->withCookie($this->nonceCookie($this->nonce));
@@ -404,9 +403,8 @@ class Provider extends AbstractProvider
      */
     protected function nonceCookie(string $nonce)
     {
-        // Encrypt so the client cannot forge it. SameSite=none so it survives
-        // Apple's cross-site form_post; Secure and HttpOnly keep it TLS-only
-        // and out of scripts.
+        // Encrypted so the client cannot forge it; SameSite=none so it survives
+        // Apple's cross-site form_post.
         return Cookie::create(self::STATELESS_NONCE_COOKIE)
             ->withValue(Crypt::encryptString($nonce))
             ->withExpires(time() + (int) $this->getConfig('nonce_ttl', 600))

--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -9,6 +9,7 @@ use GuzzleHttp\RequestOptions;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Str;
 use Laravel\Socialite\Two\InvalidStateException;
 use Lcobucci\Clock\SystemClock;
@@ -97,21 +98,12 @@ class Provider extends AbstractProvider
             return parent::redirect();
         }
 
+        // Carry the nonce in an encrypted cookie so it is bound to the browser
+        // that started the login and cannot be forged. A callback captured and
+        // replayed in another browser has no such cookie (RFC 9700 section 2.1).
         $this->nonce = Str::random(40);
-        $this->parameters['state'] = $state = Str::random(40);
 
-        // Bind the cached nonce to this browser: only a callback carrying the
-        // same cookie can spend it, so a captured callback replayed in another
-        // browser is rejected (RFC 9700 section 2.1).
-        $binding = Str::random(40);
-
-        $this->nonceCache()->put(
-            $this->nonceCacheKey($state),
-            ['nonce' => $this->nonce, 'binding' => hash('sha256', $binding)],
-            $this->nonceCacheTtl()
-        );
-
-        return parent::redirect()->withCookie($this->statelessNonceCookie($binding));
+        return parent::redirect()->withCookie($this->statelessNonceCookie($this->nonce));
     }
 
     /**
@@ -358,7 +350,7 @@ class Provider extends AbstractProvider
         if ($this->usesState()) {
             $nonce = $this->request->session()->pull('nonce');
         } elseif ($this->manageStatelessNonce) {
-            $nonce = $this->pullStatelessNonce($this->request->input('state'));
+            $nonce = $this->statelessNonceFromCookie();
         } elseif ($this->nonce !== null) {
             $nonce = $this->nonce;
         } else {
@@ -389,63 +381,38 @@ class Provider extends AbstractProvider
     }
 
     /**
-     * Verify the browser binding and return the cached nonce, or null.
-     *
-     * pull() so a captured state cannot be replayed; the cookie must match the
-     * binding stored on redirect so the callback comes from the same browser.
+     * Decrypt the nonce carried in the request cookie, or null when it is
+     * absent or fails to decrypt (forged, tampered, or from another browser).
      */
-    protected function pullStatelessNonce(?string $state): ?string
+    protected function statelessNonceFromCookie(): ?string
     {
-        $entry = $this->nonceCache()->pull($this->nonceCacheKey($state));
+        $cookie = $this->request->cookies->get(self::STATELESS_NONCE_COOKIE);
 
-        if (! is_array($entry)) {
+        if (! is_string($cookie) || $cookie === '') {
             return null;
         }
 
-        $binding = (string) $this->request->cookies->get(self::STATELESS_NONCE_COOKIE);
-
-        if ($binding === '' || ! hash_equals($entry['binding'], hash('sha256', $binding))) {
+        try {
+            return Crypt::decryptString($cookie);
+        } catch (\Illuminate\Contracts\Encryption\DecryptException) {
             return null;
         }
-
-        return $entry['nonce'];
     }
 
     /**
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
-    protected function statelessNonceCookie(string $binding)
+    protected function statelessNonceCookie(string $nonce)
     {
-        // SameSite=none so it survives Apple's cross-site form_post; Secure and
-        // HttpOnly so it is TLS-only and unreadable to scripts.
+        // Encrypt so the client cannot forge it. SameSite=none so it survives
+        // Apple's cross-site form_post; Secure and HttpOnly keep it TLS-only
+        // and out of scripts.
         return Cookie::create(self::STATELESS_NONCE_COOKIE)
-            ->withValue($binding)
-            ->withExpires(time() + $this->nonceCacheTtl())
+            ->withValue(Crypt::encryptString($nonce))
+            ->withExpires(time() + (int) $this->getConfig('nonce_ttl', 600))
             ->withSecure(true)
             ->withHttpOnly(true)
             ->withSameSite('none');
-    }
-
-    /**
-     * @return \Illuminate\Contracts\Cache\Repository
-     */
-    protected function nonceCache()
-    {
-        $store = $this->getConfig('nonce_cache_store');
-
-        $cache = Cache::getFacadeRoot();
-
-        return $store !== null && method_exists($cache, 'store') ? $cache->store($store) : $cache;
-    }
-
-    protected function nonceCacheKey(?string $state): string
-    {
-        return 'socialite:apple:nonce:'.$state;
-    }
-
-    protected function nonceCacheTtl(): int
-    {
-        return (int) $this->getConfig('nonce_cache_ttl', 600);
     }
 
     /**
@@ -546,6 +513,6 @@ class Provider extends AbstractProvider
      */
     public static function additionalConfigKeys()
     {
-        return ['private_key', 'passphrase', 'signer', 'jwt_issued_time_leeway', 'nonce_cache_store', 'nonce_cache_ttl'];
+        return ['private_key', 'passphrase', 'signer', 'jwt_issued_time_leeway', 'nonce_ttl'];
     }
 }

--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -57,8 +57,6 @@ class Provider extends AbstractProvider
     protected $privateKey = '';
 
     /**
-     * Expected identity token nonce for a stateless web callback.
-     *
      * @var ?string
      */
     protected $nonce = null;
@@ -89,12 +87,8 @@ class Provider extends AbstractProvider
     }
 
     /**
-     * Set the expected identity token nonce for a stateless web callback.
-     *
-     * Stateless callbacks have no session to hold the nonce, so a caller that
-     * wants to run stateless must generate the nonce, pass it to Apple on the
-     * authorization request, and hand the same value back here. Without it a
-     * stateless callback has no CSRF protection and user() will refuse to run.
+     * Required for a stateless callback: the nonce the caller sent to Apple,
+     * verified against the identity token in place of the session state.
      *
      * @param  string  $nonce
      * @return $this
@@ -319,12 +313,8 @@ class Provider extends AbstractProvider
             throw new InvalidStateException;
         }
 
-        // Issued alongside the state on redirect; Apple echoes it in the
-        // identity token so a token from another authorization request is
-        // rejected even when the code exchange itself succeeds. A stateless
-        // callback has no session to hold it, so the caller must supply it
-        // with setNonce(); refuse to run stateless without one rather than
-        // silently drop CSRF protection.
+        // Refuse a stateless callback with no nonce rather than run it with no
+        // CSRF protection at all.
         if ($this->usesState()) {
             $nonce = $this->request->session()->pull('nonce');
         } elseif ($this->nonce !== null) {

--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -68,7 +68,7 @@ class Provider extends AbstractProvider
     /**
      * @var bool
      */
-    protected $manageStatelessNonce = false;
+    protected $carryNonceInCookie = false;
 
     /**
      * {@inheritdoc}
@@ -94,7 +94,7 @@ class Provider extends AbstractProvider
             return parent::redirect();
         }
 
-        if (! $this->manageStatelessNonce) {
+        if (! $this->carryNonceInCookie) {
             return parent::redirect();
         }
 
@@ -103,7 +103,7 @@ class Provider extends AbstractProvider
         // replayed in another browser has no such cookie (RFC 9700 section 2.1).
         $this->nonce = Str::random(40);
 
-        return parent::redirect()->withCookie($this->statelessNonceCookie($this->nonce));
+        return parent::redirect()->withCookie($this->nonceCookie($this->nonce));
     }
 
     /**
@@ -121,15 +121,15 @@ class Provider extends AbstractProvider
     }
 
     /**
-     * Let the provider manage the stateless nonce through the cache instead of
-     * the caller supplying it. The nonce is cached under the state Apple echoes
-     * back, so no session cookie is needed on the callback.
+     * Carry the nonce in an encrypted cookie instead of the session, so a
+     * session-less (stateless) callback still has CSRF protection bound to the
+     * browser that started the login.
      *
      * @return $this
      */
-    public function statelessNonce()
+    public function cookieNonce()
     {
-        $this->manageStatelessNonce = true;
+        $this->carryNonceInCookie = true;
 
         return $this;
     }
@@ -349,13 +349,13 @@ class Provider extends AbstractProvider
 
         if ($this->usesState()) {
             $nonce = $this->request->session()->pull('nonce');
-        } elseif ($this->manageStatelessNonce) {
-            $nonce = $this->statelessNonceFromCookie();
+        } elseif ($this->carryNonceInCookie) {
+            $nonce = $this->nonceFromCookie();
         } elseif ($this->nonce !== null) {
             $nonce = $this->nonce;
         } else {
             throw new InvalidStateException(
-                'A stateless Apple callback has no CSRF protection. Call setNonce() with the nonce sent to Apple, use statelessNonce() to have the provider manage it, or use userByIdentityToken() for native apps.'
+                'A stateless Apple callback has no CSRF protection. Call cookieNonce() to have the provider carry the nonce in a cookie, setNonce() with a nonce you manage, or userByIdentityToken() for native apps.'
             );
         }
 
@@ -384,7 +384,7 @@ class Provider extends AbstractProvider
      * Decrypt the nonce carried in the request cookie, or null when it is
      * absent or fails to decrypt (forged, tampered, or from another browser).
      */
-    protected function statelessNonceFromCookie(): ?string
+    protected function nonceFromCookie(): ?string
     {
         $cookie = $this->request->cookies->get(self::STATELESS_NONCE_COOKIE);
 
@@ -402,7 +402,7 @@ class Provider extends AbstractProvider
     /**
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
-    protected function statelessNonceCookie(string $nonce)
+    protected function nonceCookie(string $nonce)
     {
         // Encrypt so the client cannot forge it. SameSite=none so it survives
         // Apple's cross-site form_post; Secure and HttpOnly keep it TLS-only

--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -337,26 +337,21 @@ class Provider extends AbstractProvider
             throw new InvalidStateException;
         }
 
-        // Refuse a stateless callback with no nonce rather than run it with no
-        // CSRF protection at all.
         if ($this->usesState()) {
-            // A login begun before this version was deployed has state but no
-            // nonce; the state check already passed, so let it through.
             $nonce = $this->request->session()->pull('nonce');
         } elseif ($this->manageStatelessNonce) {
-            // pull() so a state cannot be replayed; a miss means the state was
-            // never issued or is already spent, so reject it.
+            // pull() so a state cannot be replayed.
             $nonce = $this->nonceCache()->pull($this->nonceCacheKey($this->request->input('state')));
-
-            if ($nonce === null) {
-                throw new InvalidStateException;
-            }
         } elseif ($this->nonce !== null) {
             $nonce = $this->nonce;
         } else {
             throw new InvalidStateException(
                 'A stateless Apple callback has no CSRF protection. Call setNonce() with the nonce sent to Apple, use statelessNonce() to have the provider manage it, or use userByIdentityToken() for native apps.'
             );
+        }
+
+        if ($nonce === null) {
+            throw new InvalidStateException;
         }
 
         $response = $this->getAccessTokenResponse($this->getCode());

--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -57,6 +57,13 @@ class Provider extends AbstractProvider
     protected $privateKey = '';
 
     /**
+     * Expected identity token nonce for a stateless web callback.
+     *
+     * @var ?string
+     */
+    protected $nonce = null;
+
+    /**
      * {@inheritdoc}
      */
     protected function getAuthUrl($state): string
@@ -82,6 +89,24 @@ class Provider extends AbstractProvider
     }
 
     /**
+     * Set the expected identity token nonce for a stateless web callback.
+     *
+     * Stateless callbacks have no session to hold the nonce, so a caller that
+     * wants to run stateless must generate the nonce, pass it to Apple on the
+     * authorization request, and hand the same value back here. Without it a
+     * stateless callback has no CSRF protection and user() will refuse to run.
+     *
+     * @param  string  $nonce
+     * @return $this
+     */
+    public function setNonce($nonce)
+    {
+        $this->nonce = $nonce;
+
+        return $this;
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getCodeFields($state = null)
@@ -97,6 +122,8 @@ class Provider extends AbstractProvider
         if ($this->usesState()) {
             $fields['state'] = $state;
             $fields['nonce'] = $this->request->session()->get('nonce');
+        } elseif ($this->nonce !== null) {
+            $fields['nonce'] = $this->nonce;
         }
 
         return array_merge($fields, $this->parameters);
@@ -294,8 +321,19 @@ class Provider extends AbstractProvider
 
         // Issued alongside the state on redirect; Apple echoes it in the
         // identity token so a token from another authorization request is
-        // rejected even when the code exchange itself succeeds.
-        $nonce = $this->usesState() ? $this->request->session()->pull('nonce') : null;
+        // rejected even when the code exchange itself succeeds. A stateless
+        // callback has no session to hold it, so the caller must supply it
+        // with setNonce(); refuse to run stateless without one rather than
+        // silently drop CSRF protection.
+        if ($this->usesState()) {
+            $nonce = $this->request->session()->pull('nonce');
+        } elseif ($this->nonce !== null) {
+            $nonce = $this->nonce;
+        } else {
+            throw new InvalidStateException(
+                'A stateless Apple callback has no CSRF protection. Call setNonce() with the nonce sent to Apple, or use userByIdentityToken() for native apps.'
+            );
+        }
 
         $response = $this->getAccessTokenResponse($this->getCode());
 

--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -21,12 +21,15 @@ use Lcobucci\JWT\Validation\Constraint\PermittedFor;
 use Lcobucci\JWT\Validation\Constraint\SignedWith;
 use Lcobucci\JWT\Validation\RequiredConstraintsViolated;
 use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\HttpFoundation\Cookie;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
 
 class Provider extends AbstractProvider
 {
     public const IDENTIFIER = 'APPLE';
+
+    protected const STATELESS_NONCE_COOKIE = 'socialite_apple_nonce';
 
     public const URL = 'https://appleid.apple.com';
 
@@ -86,14 +89,29 @@ class Provider extends AbstractProvider
     {
         if ($this->usesState()) {
             $this->request->session()->put('nonce', Str::random(40));
-        } elseif ($this->manageStatelessNonce) {
-            $this->nonce = Str::random(40);
-            $this->parameters['state'] = $state = Str::random(40);
 
-            $this->nonceCache()->put($this->nonceCacheKey($state), $this->nonce, $this->nonceCacheTtl());
+            return parent::redirect();
         }
 
-        return parent::redirect();
+        if (! $this->manageStatelessNonce) {
+            return parent::redirect();
+        }
+
+        $this->nonce = Str::random(40);
+        $this->parameters['state'] = $state = Str::random(40);
+
+        // Bind the cached nonce to this browser: only a callback carrying the
+        // same cookie can spend it, so a captured callback replayed in another
+        // browser is rejected (RFC 9700 section 2.1).
+        $binding = Str::random(40);
+
+        $this->nonceCache()->put(
+            $this->nonceCacheKey($state),
+            ['nonce' => $this->nonce, 'binding' => hash('sha256', $binding)],
+            $this->nonceCacheTtl()
+        );
+
+        return parent::redirect()->withCookie($this->statelessNonceCookie($binding));
     }
 
     /**
@@ -340,8 +358,7 @@ class Provider extends AbstractProvider
         if ($this->usesState()) {
             $nonce = $this->request->session()->pull('nonce');
         } elseif ($this->manageStatelessNonce) {
-            // pull() so a state cannot be replayed.
-            $nonce = $this->nonceCache()->pull($this->nonceCacheKey($this->request->input('state')));
+            $nonce = $this->pullStatelessNonce($this->request->input('state'));
         } elseif ($this->nonce !== null) {
             $nonce = $this->nonce;
         } else {
@@ -369,6 +386,44 @@ class Provider extends AbstractProvider
         return $user->setToken($token)
             ->setRefreshToken(Arr::get($response, 'refresh_token'))
             ->setExpiresIn(Arr::get($response, 'expires_in'));
+    }
+
+    /**
+     * Verify the browser binding and return the cached nonce, or null.
+     *
+     * pull() so a captured state cannot be replayed; the cookie must match the
+     * binding stored on redirect so the callback comes from the same browser.
+     */
+    protected function pullStatelessNonce(?string $state): ?string
+    {
+        $entry = $this->nonceCache()->pull($this->nonceCacheKey($state));
+
+        if (! is_array($entry)) {
+            return null;
+        }
+
+        $binding = (string) $this->request->cookies->get(self::STATELESS_NONCE_COOKIE);
+
+        if ($binding === '' || ! hash_equals($entry['binding'], hash('sha256', $binding))) {
+            return null;
+        }
+
+        return $entry['nonce'];
+    }
+
+    /**
+     * @return \Symfony\Component\HttpFoundation\Cookie
+     */
+    protected function statelessNonceCookie(string $binding)
+    {
+        // SameSite=none so it survives Apple's cross-site form_post; Secure and
+        // HttpOnly so it is TLS-only and unreadable to scripts.
+        return Cookie::create(self::STATELESS_NONCE_COOKIE)
+            ->withValue($binding)
+            ->withExpires(time() + $this->nonceCacheTtl())
+            ->withSecure(true)
+            ->withHttpOnly(true)
+            ->withSameSite('none');
     }
 
     /**

--- a/src/Apple/README.md
+++ b/src/Apple/README.md
@@ -152,9 +152,6 @@ use `userByIdentityToken()` (below) instead.
 
 [rfc9700]: https://www.rfc-editor.org/rfc/rfc9700
 
-Versions before 6.0.0 accepted the callback without a session, which allowed
-login CSRF.
-
 #### Native apps (identity token)
 
 Native iOS and Android clients hand your server an identity token directly. Pass

--- a/src/Apple/README.md
+++ b/src/Apple/README.md
@@ -92,13 +92,24 @@ issued on redirect, so a callback the app did not start is rejected with
 `InvalidStateException`.
 
 Both checks need the session cookie to arrive with that `POST`. Laravel's
-default `SameSite=lax` cookie is not sent on cross-site `POST`s, so a
-default install will reject every callback. Send the cookie cross-site:
+default `SameSite=lax` cookie is not sent on a cross-site `POST`, so a
+default install sees an empty session and rejects every callback. You have
+to let the cookie cross the site boundary:
 
 ```
 SESSION_SAME_SITE=none
 SESSION_SECURE_COOKIE=true
 ```
+
+`SameSite=none` loosens every cookie the app sets, not just Apple's, so if
+you would rather keep `lax` elsewhere, recover the session from a key in the
+`redirect_uri` instead (for example
+[ycs77/laravel-recover-session](https://github.com/ycs77/laravel-recover-session)).
+Either way the session has to be present on the callback.
+
+`stateless()` skips the session, but it also skips both the state and the
+nonce checks, so it gives up the CSRF protection entirely. Don't reach for
+it to dodge the cookie requirement.
 
 Versions before 6.0.0 accepted the callback without a session, which allowed
 login CSRF.

--- a/src/Apple/README.md
+++ b/src/Apple/README.md
@@ -112,26 +112,44 @@ Either way the session has to be present on the callback.
 If you cannot keep the session on the callback, run the flow stateless and
 manage the nonce yourself. The nonce is what binds the identity token to the
 request you started, so you have to generate it, send it to Apple, and hand
-the same value back on the callback:
+the same value back on the callback.
+
+You need somewhere to keep the nonce between the two requests, keyed by
+something that survives the round trip. Apple echoes `state` back in the
+callback `POST` body, so `state` works as that key without adding anything
+to your `redirect_uri` (extra query params on the redirect URL are not
+guaranteed to round-trip, since Apple matches it against the one registered
+on your Services ID):
 
 ```php
-// On the way out: generate a nonce, store it somewhere that survives the
-// round trip without the session cookie (a cache row, a signed cookie, ...).
+// On the way out: pick a state, generate a nonce, cache the nonce under the
+// state, and send both to Apple.
+$state = Str::random(40);
 $nonce = Str::random(40);
-Cache::put("apple_nonce:$key", $nonce, now()->addMinutes(10));
 
-return Socialite::driver('apple')->stateless()->setNonce($nonce)->redirect();
+Cache::put("apple_nonce:$state", $nonce, now()->addMinutes(10));
 
-// On the callback: look the nonce back up and pass it in.
-$nonce = Cache::pull("apple_nonce:$key");
+return Socialite::driver('apple')
+    ->stateless()
+    ->setNonce($nonce)
+    ->with(['state' => $state])
+    ->redirect();
+
+// On the callback: read the state Apple echoed back, pull the nonce, verify.
+$state = request('state');
+$nonce = Cache::pull("apple_nonce:$state");
+
+abort_if($nonce === null, 403); // unknown or replayed state
 
 $user = Socialite::driver('apple')->stateless()->setNonce($nonce)->user();
 ```
 
-The `state` check is skipped when stateless, so the nonce is your only CSRF
-control, treat it like one: single-use, unguessable, tied to the browser
-that started the flow. Calling `stateless()` without `setNonce()` throws
-`InvalidStateException` rather than accepting the callback unprotected.
+The provider's own `state` check is skipped when stateless, so the cache
+lookup above is doing that job and the nonce is verifying the token, treat
+both as single-use and unguessable. Cache the nonce server-side rather than
+in a query param so the handle never leaves your server. Calling
+`stateless()` without `setNonce()` throws `InvalidStateException` rather
+than accepting the callback unprotected.
 
 For native iOS and Android clients that already hand you an identity token,
 use `userByIdentityToken()` (below) instead.

--- a/src/Apple/README.md
+++ b/src/Apple/README.md
@@ -85,7 +85,8 @@ return Socialite::driver('apple')->redirect();
 #### Callback state and nonce
 
 Apple posts the callback to your redirect URL as a cross-site `POST`
-(`response_mode=form_post`). On the callback the provider checks the `state`
+(`response_mode=form_post`, which Apple requires whenever scopes are
+requested). On the callback the provider checks the `state`
 against the session, and checks the identity token's `nonce` against the one
 issued on redirect, so a callback the app did not start is rejected with
 `InvalidStateException`.

--- a/src/Apple/README.md
+++ b/src/Apple/README.md
@@ -102,55 +102,55 @@ SESSION_SECURE_COOKIE=true
 ```
 
 `SameSite=none` loosens every cookie the app sets, not just Apple's. If you
-would rather keep `lax` elsewhere, run the flow stateless and manage the
-nonce yourself instead (see below).
+would rather keep `lax` elsewhere, run the flow stateless with
+`statelessNonce()` instead (see below).
 
 #### Without a session (stateless)
 
 If you cannot keep the session on the callback, run the flow stateless and
-manage the nonce yourself. The nonce is what binds the identity token to the
-request you started, so you have to generate it, send it to Apple, and hand
-the same value back on the callback.
-
-You need somewhere to keep the nonce between the two requests, keyed by
-something that survives the round trip. Apple echoes `state` back in the
-callback `POST` body, so `state` works as that key without adding anything
-to your `redirect_uri` (extra query params on the redirect URL are not
-guaranteed to round-trip, since Apple matches it against the one registered
-on your Services ID):
+let the provider manage the nonce through the cache with `statelessNonce()`:
 
 ```php
-// On the way out: pick a state, generate a nonce, cache the nonce under the
-// state, and send both to Apple.
-$state = Str::random(40);
-$nonce = Str::random(40);
+// Redirect. The provider generates the state and nonce, caches the nonce
+// keyed by the state, and sends both to Apple.
+return Socialite::driver('apple')->stateless()->statelessNonce()->redirect();
 
-Cache::put("apple_nonce:$state", $nonce, now()->addMinutes(10));
-
-return Socialite::driver('apple')
-    ->stateless()
-    ->setNonce($nonce)
-    ->with(['state' => $state])
-    ->redirect();
-
-// On the callback: read the state Apple echoed back, pull the nonce, verify.
-$state = request('state');
-$nonce = Cache::pull("apple_nonce:$state");
-
-abort_if($nonce === null, 403); // unknown or replayed state
-
-$user = Socialite::driver('apple')->stateless()->setNonce($nonce)->user();
+// Callback. The provider reads the state Apple echoed back, pulls the nonce
+// from the cache (once), and verifies it against the identity token.
+$user = Socialite::driver('apple')->stateless()->statelessNonce()->user();
 ```
 
-The provider's own `state` check is skipped when stateless, so the cache
-lookup above is doing that job and the nonce is verifying the token, treat
-both as single-use and unguessable. Cache the nonce server-side rather than
-in a query param so the handle never leaves your server. Calling
-`stateless()` without `setNonce()` throws `InvalidStateException` rather
-than accepting the callback unprotected.
+The nonce is generated server-side, sent only to Apple, and consumed on the
+first callback, so a callback the app did not start cannot present a matching
+`state`/nonce pair. An unknown or already-used state is rejected with
+`InvalidStateException`.
+
+The cache entry is shared rather than tied to one browser, so this is a
+correlation on the token binding rather than the session-bound `state` check
+of the default flow. It is the CSRF protection [RFC 9700][rfc9700] allows a
+correctly enforced nonce to provide, but if you can keep the session, the
+default flow is stronger.
+
+Configure the store and lifetime if the defaults (the default cache store,
+600 seconds) do not suit you:
+
+```php
+'apple' => [
+  // ...
+  'nonce_cache_store' => env('APPLE_NONCE_CACHE_STORE'), // default cache store
+  'nonce_cache_ttl'   => env('APPLE_NONCE_CACHE_TTL', 600), // seconds
+],
+```
+
+If you want to hold the nonce somewhere other than the cache, call
+`setNonce()` with a value you generate, send to Apple, and hand back
+yourself. Calling `stateless()` without either throws `InvalidStateException`
+rather than accepting the callback unprotected.
 
 For native iOS and Android clients that already hand you an identity token,
 use `userByIdentityToken()` (below) instead.
+
+[rfc9700]: https://www.rfc-editor.org/rfc/rfc9700
 
 Versions before 6.0.0 accepted the callback without a session, which allowed
 login CSRF.

--- a/src/Apple/README.md
+++ b/src/Apple/README.md
@@ -107,48 +107,45 @@ would rather keep `lax` elsewhere, run the flow stateless with
 
 #### Without a session (stateless)
 
-If you cannot keep the session on the callback, run the flow stateless and
-let the provider manage the nonce through the cache with `statelessNonce()`:
+If you cannot keep the session on the callback, run the flow stateless with
+`statelessNonce()` and the provider handles the nonce for you:
 
 ```php
-// Redirect. The provider generates the state and nonce, caches the nonce
-// keyed by the state, and sends both to Apple.
+// Redirect. The provider generates the nonce, sends it to Apple, and sets it
+// on the browser in an encrypted cookie.
 return Socialite::driver('apple')->stateless()->statelessNonce()->redirect();
 
-// Callback. The provider reads the state Apple echoed back, pulls the nonce
-// from the cache (once), and verifies it against the identity token.
+// Callback. The provider reads the nonce back from the cookie and verifies it
+// against the identity token.
 $user = Socialite::driver('apple')->stateless()->statelessNonce()->user();
 ```
 
-On redirect the provider also sets a `socialite_apple_nonce` cookie
-(`Secure`, `HttpOnly`, `SameSite=none`) holding a random value, and stores
-its hash with the cached nonce. The callback is accepted only when it
-carries that cookie, which binds the flow to the browser that started it as
-[RFC 9700][rfc9700] section 2.1 requires. A callback captured and replayed
-in another browser has no matching cookie and is rejected, as is an unknown
-or already-used state. Every rejection is an `InvalidStateException`.
+The nonce travels in a `socialite_apple_nonce` cookie (`Secure`, `HttpOnly`,
+`SameSite=none`), encrypted with your `APP_KEY` so the client cannot forge
+it. Only the browser that started the login carries it, which binds the flow
+to that browser as [RFC 9700][rfc9700] section 2.1 requires: a callback
+captured and replayed in another browser has no cookie and is rejected, and
+so is a tampered one. No session, cache, or server-side state is involved.
 
-Because the binding rides a `SameSite=none` cookie, it still needs
-`SESSION_SECURE_COOKIE`-style HTTPS: the callback must be served over TLS or
-the browser drops the cookie. This is one purpose-built cookie rather than
-loosening every session cookie, so `lax` stays in force for the rest of the
-app.
+Because the cookie is `SameSite=none` it needs HTTPS, the callback must be
+served over TLS or the browser drops it. This is one purpose-built cookie
+rather than loosening every session cookie, so `lax` stays in force for the
+rest of the app.
 
-Configure the store and lifetime if the defaults (the default cache store,
-600 seconds) do not suit you:
+Set `nonce_ttl` (seconds, default 600) to change how long the cookie,
+and so the login attempt, stays valid:
 
 ```php
 'apple' => [
   // ...
-  'nonce_cache_store' => env('APPLE_NONCE_CACHE_STORE'), // default cache store
-  'nonce_cache_ttl'   => env('APPLE_NONCE_CACHE_TTL', 600), // seconds
+  'nonce_ttl' => env('APPLE_NONCE_TTL', 600),
 ],
 ```
 
-If you want to hold the nonce somewhere other than the cache, call
-`setNonce()` with a value you generate, send to Apple, and hand back
-yourself. Calling `stateless()` without either throws `InvalidStateException`
-rather than accepting the callback unprotected.
+To hold the nonce yourself instead, call `setNonce()` with a value you
+generate, send to Apple, and hand back. Calling `stateless()` without either
+throws `InvalidStateException` rather than accepting the callback
+unprotected.
 
 For native iOS and Android clients that already hand you an identity token,
 use `userByIdentityToken()` (below) instead.

--- a/src/Apple/README.md
+++ b/src/Apple/README.md
@@ -103,21 +103,21 @@ SESSION_SECURE_COOKIE=true
 
 `SameSite=none` loosens every cookie the app sets, not just Apple's. If you
 would rather keep `lax` elsewhere, run the flow stateless with
-`statelessNonce()` instead (see below).
+`cookieNonce()` instead (see below).
 
 #### Without a session (stateless)
 
 If you cannot keep the session on the callback, run the flow stateless with
-`statelessNonce()` and the provider handles the nonce for you:
+`cookieNonce()` and the provider handles the nonce for you:
 
 ```php
 // Redirect. The provider generates the nonce, sends it to Apple, and sets it
 // on the browser in an encrypted cookie.
-return Socialite::driver('apple')->stateless()->statelessNonce()->redirect();
+return Socialite::driver('apple')->stateless()->cookieNonce()->redirect();
 
 // Callback. The provider reads the nonce back from the cookie and verifies it
 // against the identity token.
-$user = Socialite::driver('apple')->stateless()->statelessNonce()->user();
+$user = Socialite::driver('apple')->stateless()->cookieNonce()->user();
 ```
 
 The nonce travels in a `socialite_apple_nonce` cookie (`Secure`, `HttpOnly`,

--- a/src/Apple/README.md
+++ b/src/Apple/README.md
@@ -121,6 +121,10 @@ can be replayed until it expires.
 - ``name``
 - ``email``
 
+`name` comes from the `user` field of the callback `POST`, not from the
+signed identity token, and Apple only sends it on the first authorization.
+Treat it as user input: validate and sanitise it before storing.
+
 ### Known Issues
 
 #### JWT Issued_at

--- a/src/Apple/README.md
+++ b/src/Apple/README.md
@@ -82,6 +82,26 @@ You should now be able to use the provider like you would regularly use Socialit
 return Socialite::driver('apple')->redirect();
 ```
 
+#### Callback state and nonce
+
+Apple posts the callback to your redirect URL as a cross-site `POST`
+(`response_mode=form_post`). On the callback the provider checks the `state`
+against the session, and checks the identity token's `nonce` against the one
+issued on redirect, so a callback the app did not start is rejected with
+`InvalidStateException`.
+
+Both checks need the session cookie to arrive with that `POST`. Laravel's
+default `SameSite=lax` cookie is not sent on cross-site `POST`s, so a
+default install will reject every callback. Send the cookie cross-site:
+
+```
+SESSION_SAME_SITE=none
+SESSION_SECURE_COOKIE=true
+```
+
+Versions before 6.0.0 accepted the callback without a session, which allowed
+login CSRF.
+
 #### Native apps (identity token)
 
 Native iOS and Android clients hand your server an identity token directly. Pass

--- a/src/Apple/README.md
+++ b/src/Apple/README.md
@@ -107,9 +107,34 @@ you would rather keep `lax` elsewhere, recover the session from a key in the
 [ycs77/laravel-recover-session](https://github.com/ycs77/laravel-recover-session)).
 Either way the session has to be present on the callback.
 
-`stateless()` skips the session, but it also skips both the state and the
-nonce checks, so it gives up the CSRF protection entirely. Don't reach for
-it to dodge the cookie requirement.
+#### Without a session (stateless)
+
+If you cannot keep the session on the callback, run the flow stateless and
+manage the nonce yourself. The nonce is what binds the identity token to the
+request you started, so you have to generate it, send it to Apple, and hand
+the same value back on the callback:
+
+```php
+// On the way out: generate a nonce, store it somewhere that survives the
+// round trip without the session cookie (a cache row, a signed cookie, ...).
+$nonce = Str::random(40);
+Cache::put("apple_nonce:$key", $nonce, now()->addMinutes(10));
+
+return Socialite::driver('apple')->stateless()->setNonce($nonce)->redirect();
+
+// On the callback: look the nonce back up and pass it in.
+$nonce = Cache::pull("apple_nonce:$key");
+
+$user = Socialite::driver('apple')->stateless()->setNonce($nonce)->user();
+```
+
+The `state` check is skipped when stateless, so the nonce is your only CSRF
+control, treat it like one: single-use, unguessable, tied to the browser
+that started the flow. Calling `stateless()` without `setNonce()` throws
+`InvalidStateException` rather than accepting the callback unprotected.
+
+For native iOS and Android clients that already hand you an identity token,
+use `userByIdentityToken()` (below) instead.
 
 Versions before 6.0.0 accepted the callback without a session, which allowed
 login CSRF.

--- a/src/Apple/README.md
+++ b/src/Apple/README.md
@@ -120,16 +120,19 @@ return Socialite::driver('apple')->stateless()->statelessNonce()->redirect();
 $user = Socialite::driver('apple')->stateless()->statelessNonce()->user();
 ```
 
-The nonce is generated server-side, sent only to Apple, and consumed on the
-first callback, so a callback the app did not start cannot present a matching
-`state`/nonce pair. An unknown or already-used state is rejected with
-`InvalidStateException`.
+On redirect the provider also sets a `socialite_apple_nonce` cookie
+(`Secure`, `HttpOnly`, `SameSite=none`) holding a random value, and stores
+its hash with the cached nonce. The callback is accepted only when it
+carries that cookie, which binds the flow to the browser that started it as
+[RFC 9700][rfc9700] section 2.1 requires. A callback captured and replayed
+in another browser has no matching cookie and is rejected, as is an unknown
+or already-used state. Every rejection is an `InvalidStateException`.
 
-The cache entry is shared rather than tied to one browser, so this is a
-correlation on the token binding rather than the session-bound `state` check
-of the default flow. It is the CSRF protection [RFC 9700][rfc9700] allows a
-correctly enforced nonce to provide, but if you can keep the session, the
-default flow is stronger.
+Because the binding rides a `SameSite=none` cookie, it still needs
+`SESSION_SECURE_COOKIE`-style HTTPS: the callback must be served over TLS or
+the browser drops the cookie. This is one purpose-built cookie rather than
+loosening every session cookie, so `lax` stays in force for the rest of the
+app.
 
 Configure the store and lifetime if the defaults (the default cache store,
 600 seconds) do not suit you:

--- a/src/Apple/README.md
+++ b/src/Apple/README.md
@@ -101,11 +101,9 @@ SESSION_SAME_SITE=none
 SESSION_SECURE_COOKIE=true
 ```
 
-`SameSite=none` loosens every cookie the app sets, not just Apple's, so if
-you would rather keep `lax` elsewhere, recover the session from a key in the
-`redirect_uri` instead (for example
-[ycs77/laravel-recover-session](https://github.com/ycs77/laravel-recover-session)).
-Either way the session has to be present on the callback.
+`SameSite=none` loosens every cookie the app sets, not just Apple's. If you
+would rather keep `lax` elsewhere, run the flow stateless and manage the
+nonce yourself instead (see below).
 
 #### Without a session (stateless)
 

--- a/tests/Apple/CallbackNonceValidationTest.php
+++ b/tests/Apple/CallbackNonceValidationTest.php
@@ -59,13 +59,37 @@ class CallbackNonceValidationTest extends TestCase
         $this->assertSame('apple-user-id', $user->getId());
     }
 
-    public function test_stateless_callback_skips_nonce_verification(): void
+    public function test_stateless_callback_without_a_nonce_is_refused(): void
     {
         $request = $this->makeRequestWithSession(['code' => 'authorization-code']);
 
-        $user = $this->providerReturning($request, ['nonce' => 'anything'])->stateless()->user();
+        $this->expectException(InvalidStateException::class);
+
+        $this->providerReturning($request, ['nonce' => 'anything'])->stateless()->user();
+    }
+
+    public function test_stateless_callback_verifies_the_supplied_nonce(): void
+    {
+        $request = $this->makeRequestWithSession(['code' => 'authorization-code']);
+
+        $user = $this->providerReturning($request, ['nonce' => self::NONCE])
+            ->stateless()
+            ->setNonce(self::NONCE)
+            ->user();
 
         $this->assertSame('apple-user-id', $user->getId());
+    }
+
+    public function test_stateless_callback_rejects_a_mismatched_supplied_nonce(): void
+    {
+        $request = $this->makeRequestWithSession(['code' => 'authorization-code']);
+
+        $this->expectException(InvalidStateException::class);
+
+        $this->providerReturning($request, ['nonce' => 'a-different-nonce'])
+            ->stateless()
+            ->setNonce(self::NONCE)
+            ->user();
     }
 
     /**

--- a/tests/Apple/CallbackNonceValidationTest.php
+++ b/tests/Apple/CallbackNonceValidationTest.php
@@ -100,11 +100,10 @@ class CallbackNonceValidationTest extends TestCase
 
         $this->assertNotEmpty($params['nonce']);
 
-        // The cookie carries the nonce encrypted, not in plain text.
         $this->assertNotSame($params['nonce'], $cookie->getValue());
         $this->assertSame($params['nonce'], Crypt::decryptString($cookie->getValue()));
 
-        // It must cross Apple's cross-site form_post and stay TLS-only.
+        // Must cross Apple's cross-site form_post and stay TLS-only.
         $this->assertSame('none', $cookie->getSameSite());
         $this->assertTrue($cookie->isSecure());
         $this->assertTrue($cookie->isHttpOnly());
@@ -121,8 +120,7 @@ class CallbackNonceValidationTest extends TestCase
 
     public function test_managed_stateless_callback_from_another_browser_is_rejected(): void
     {
-        // Attacker runs the flow in their browser and captures a full callback,
-        // but the victim's browser does not carry the attacker's nonce cookie.
+        // Attacker's captured callback replayed in a browser without the cookie.
         [$params] = $this->statelessRedirect();
 
         $this->expectException(InvalidStateException::class);

--- a/tests/Apple/CallbackNonceValidationTest.php
+++ b/tests/Apple/CallbackNonceValidationTest.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Laravel\Socialite\Two\InvalidStateException;
 use SocialiteProviders\Apple\Provider;
+use Symfony\Component\HttpFoundation\Cookie;
 
 class CallbackNonceValidationTest extends TestCase
 {
@@ -93,74 +94,111 @@ class CallbackNonceValidationTest extends TestCase
             ->user();
     }
 
-    public function test_managed_stateless_caches_the_nonce_under_the_state(): void
+    public function test_managed_stateless_redirect_caches_a_binding_and_sets_a_cookie(): void
     {
-        $request = $this->makeRequestWithSession();
-
-        $response = $this->makeAppleProvider($request)->stateless()->statelessNonce()->redirect();
-
-        $params = $this->queryParams($response->getTargetUrl());
+        [$params, $cookie] = $this->statelessRedirect();
 
         $this->assertNotEmpty($params['state']);
         $this->assertNotEmpty($params['nonce']);
-        $this->assertSame(
-            $params['nonce'],
-            Cache::get('socialite:apple:nonce:'.$params['state'])
-        );
+
+        $entry = Cache::get('socialite:apple:nonce:'.$params['state']);
+
+        $this->assertSame($params['nonce'], $entry['nonce']);
+        $this->assertSame(hash('sha256', $cookie->getValue()), $entry['binding']);
+
+        // The cookie must cross Apple's cross-site form_post and stay TLS-only.
+        $this->assertSame('none', $cookie->getSameSite());
+        $this->assertTrue($cookie->isSecure());
+        $this->assertTrue($cookie->isHttpOnly());
     }
 
-    public function test_managed_stateless_callback_verifies_and_consumes_the_cached_nonce(): void
+    public function test_managed_stateless_callback_from_the_same_browser_is_accepted(): void
     {
-        $state = 'echoed-state';
-        Cache::put('socialite:apple:nonce:'.$state, self::NONCE, 600);
+        [$params, $cookie] = $this->statelessRedirect();
 
-        $request = $this->makeRequestWithSession([
-            'code'  => 'authorization-code',
-            'state' => $state,
-        ]);
-
-        $user = $this->providerReturning($request, ['nonce' => self::NONCE])
-            ->stateless()
-            ->statelessNonce()
-            ->user();
+        $user = $this->statelessCallback($params['state'], $params['nonce'], $cookie->getValue())->user();
 
         $this->assertSame('apple-user-id', $user->getId());
-        $this->assertNull(Cache::get('socialite:apple:nonce:'.$state));
+        $this->assertNull(Cache::get('socialite:apple:nonce:'.$params['state']));
+    }
+
+    public function test_managed_stateless_callback_from_another_browser_is_rejected(): void
+    {
+        // Attacker runs the flow in their browser and captures a full callback.
+        [$params, $attackerCookie] = $this->statelessRedirect();
+
+        // Replayed in a victim's browser that does not carry the attacker's
+        // binding cookie: the cross-browser login CSRF must fail.
+        $this->expectException(InvalidStateException::class);
+
+        $this->statelessCallback($params['state'], $params['nonce'], null)->user();
     }
 
     public function test_managed_stateless_callback_rejects_an_unknown_state(): void
     {
-        $request = $this->makeRequestWithSession([
-            'code'  => 'authorization-code',
-            'state' => 'never-issued',
-        ]);
+        $provider = $this->statelessCallback('never-issued', self::NONCE, 'any-cookie');
 
         $this->expectException(InvalidStateException::class);
 
-        $this->providerReturning($request, ['nonce' => self::NONCE])
-            ->stateless()
-            ->statelessNonce()
-            ->user();
+        $provider->user();
     }
 
     public function test_managed_stateless_callback_rejects_a_replayed_state(): void
     {
-        $state = 'echoed-state';
-        Cache::put('socialite:apple:nonce:'.$state, self::NONCE, 600);
+        [$params, $cookie] = $this->statelessRedirect();
 
-        $request = fn () => $this->makeRequestWithSession([
-            'code'  => 'authorization-code',
-            'state' => $state,
-        ]);
-
-        $this->providerReturning($request(), ['nonce' => self::NONCE])
-            ->stateless()->statelessNonce()->user();
+        $this->statelessCallback($params['state'], $params['nonce'], $cookie->getValue())->user();
 
         // Second use of the same state must fail: the nonce was consumed.
         $this->expectException(InvalidStateException::class);
 
-        $this->providerReturning($request(), ['nonce' => self::NONCE])
-            ->stateless()->statelessNonce()->user();
+        $this->statelessCallback($params['state'], $params['nonce'], $cookie->getValue())->user();
+    }
+
+    /**
+     * Run a managed-stateless redirect and return its query params and cookie.
+     *
+     * @return array{0: array<string, string>, 1: Cookie}
+     */
+    private function statelessRedirect(): array
+    {
+        $response = $this->makeAppleProvider($this->makeRequestWithSession())
+            ->stateless()
+            ->statelessNonce()
+            ->redirect();
+
+        $cookies = $response->headers->getCookies();
+
+        $cookie = collect($cookies)->first(fn ($c) => $c->getName() === 'socialite_apple_nonce');
+
+        $this->assertNotNull($cookie, 'redirect did not set the binding cookie');
+
+        return [$this->queryParams($response->getTargetUrl()), $cookie];
+    }
+
+    /**
+     * A managed-stateless callback provider carrying the given state/cookie.
+     */
+    private function statelessCallback(string $state, string $tokenNonce, ?string $cookie): Provider
+    {
+        $request = $this->makeRequestWithSession([
+            'code'  => 'authorization-code',
+            'state' => $state,
+        ]);
+
+        if ($cookie !== null) {
+            $request->cookies->set('socialite_apple_nonce', $cookie);
+        }
+
+        $provider = $this->makeAppleProvider($request);
+
+        $provider->setHttpClient($this->makeHttpClient([
+            new Response(200, [], json_encode([
+                'id_token' => $this->identityToken(['nonce' => $tokenNonce]),
+            ])),
+        ]));
+
+        return $provider->stateless()->statelessNonce();
     }
 
     /**

--- a/tests/Apple/CallbackNonceValidationTest.php
+++ b/tests/Apple/CallbackNonceValidationTest.php
@@ -4,7 +4,7 @@ namespace SocialiteProviders\Tests\Apple;
 
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Crypt;
 use Laravel\Socialite\Two\InvalidStateException;
 use SocialiteProviders\Apple\Provider;
 use Symfony\Component\HttpFoundation\Cookie;
@@ -94,19 +94,17 @@ class CallbackNonceValidationTest extends TestCase
             ->user();
     }
 
-    public function test_managed_stateless_redirect_caches_a_binding_and_sets_a_cookie(): void
+    public function test_managed_stateless_redirect_sets_an_encrypted_nonce_cookie(): void
     {
         [$params, $cookie] = $this->statelessRedirect();
 
-        $this->assertNotEmpty($params['state']);
         $this->assertNotEmpty($params['nonce']);
 
-        $entry = Cache::get('socialite:apple:nonce:'.$params['state']);
+        // The cookie carries the nonce encrypted, not in plain text.
+        $this->assertNotSame($params['nonce'], $cookie->getValue());
+        $this->assertSame($params['nonce'], Crypt::decryptString($cookie->getValue()));
 
-        $this->assertSame($params['nonce'], $entry['nonce']);
-        $this->assertSame(hash('sha256', $cookie->getValue()), $entry['binding']);
-
-        // The cookie must cross Apple's cross-site form_post and stay TLS-only.
+        // It must cross Apple's cross-site form_post and stay TLS-only.
         $this->assertSame('none', $cookie->getSameSite());
         $this->assertTrue($cookie->isSecure());
         $this->assertTrue($cookie->isHttpOnly());
@@ -116,43 +114,40 @@ class CallbackNonceValidationTest extends TestCase
     {
         [$params, $cookie] = $this->statelessRedirect();
 
-        $user = $this->statelessCallback($params['state'], $params['nonce'], $cookie->getValue())->user();
+        $user = $this->statelessCallback($params['nonce'], $cookie->getValue())->user();
 
         $this->assertSame('apple-user-id', $user->getId());
-        $this->assertNull(Cache::get('socialite:apple:nonce:'.$params['state']));
     }
 
     public function test_managed_stateless_callback_from_another_browser_is_rejected(): void
     {
-        // Attacker runs the flow in their browser and captures a full callback.
-        [$params, $attackerCookie] = $this->statelessRedirect();
+        // Attacker runs the flow in their browser and captures a full callback,
+        // but the victim's browser does not carry the attacker's nonce cookie.
+        [$params] = $this->statelessRedirect();
 
-        // Replayed in a victim's browser that does not carry the attacker's
-        // binding cookie: the cross-browser login CSRF must fail.
         $this->expectException(InvalidStateException::class);
 
-        $this->statelessCallback($params['state'], $params['nonce'], null)->user();
+        $this->statelessCallback($params['nonce'], null)->user();
     }
 
-    public function test_managed_stateless_callback_rejects_an_unknown_state(): void
+    public function test_managed_stateless_callback_rejects_a_forged_cookie(): void
     {
-        $provider = $this->statelessCallback('never-issued', self::NONCE, 'any-cookie');
+        [$params] = $this->statelessRedirect();
 
+        // A cookie the app did not sign fails to decrypt and is rejected.
         $this->expectException(InvalidStateException::class);
 
-        $provider->user();
+        $this->statelessCallback($params['nonce'], 'not-a-valid-encrypted-value')->user();
     }
 
-    public function test_managed_stateless_callback_rejects_a_replayed_state(): void
+    public function test_managed_stateless_callback_rejects_a_cookie_for_a_different_nonce(): void
     {
-        [$params, $cookie] = $this->statelessRedirect();
+        $this->statelessRedirect();
 
-        $this->statelessCallback($params['state'], $params['nonce'], $cookie->getValue())->user();
-
-        // Second use of the same state must fail: the nonce was consumed.
+        // Valid, app-signed cookie, but it does not match the token's nonce.
         $this->expectException(InvalidStateException::class);
 
-        $this->statelessCallback($params['state'], $params['nonce'], $cookie->getValue())->user();
+        $this->statelessCallback('token-nonce', Crypt::encryptString('a-different-nonce'))->user();
     }
 
     /**
@@ -167,24 +162,21 @@ class CallbackNonceValidationTest extends TestCase
             ->statelessNonce()
             ->redirect();
 
-        $cookies = $response->headers->getCookies();
+        $cookie = collect($response->headers->getCookies())
+            ->first(fn ($c) => $c->getName() === 'socialite_apple_nonce');
 
-        $cookie = collect($cookies)->first(fn ($c) => $c->getName() === 'socialite_apple_nonce');
-
-        $this->assertNotNull($cookie, 'redirect did not set the binding cookie');
+        $this->assertNotNull($cookie, 'redirect did not set the nonce cookie');
 
         return [$this->queryParams($response->getTargetUrl()), $cookie];
     }
 
     /**
-     * A managed-stateless callback provider carrying the given state/cookie.
+     * A managed-stateless callback provider carrying the given cookie, whose
+     * token echoes $tokenNonce.
      */
-    private function statelessCallback(string $state, string $tokenNonce, ?string $cookie): Provider
+    private function statelessCallback(string $tokenNonce, ?string $cookie): Provider
     {
-        $request = $this->makeRequestWithSession([
-            'code'  => 'authorization-code',
-            'state' => $state,
-        ]);
+        $request = $this->makeRequestWithSession(['code' => 'authorization-code']);
 
         if ($cookie !== null) {
             $request->cookies->set('socialite_apple_nonce', $cookie);

--- a/tests/Apple/CallbackNonceValidationTest.php
+++ b/tests/Apple/CallbackNonceValidationTest.php
@@ -51,13 +51,13 @@ class CallbackNonceValidationTest extends TestCase
         $this->assertFalse($request->session()->has('state'));
     }
 
-    public function test_nonce_is_not_checked_when_the_session_never_issued_one(): void
+    public function test_callback_with_state_but_no_session_nonce_is_rejected(): void
     {
         $request = $this->callbackRequest(['state' => self::STATE]);
 
-        $user = $this->providerReturning($request, ['nonce' => 'whatever-apple-sent'])->user();
+        $this->expectException(InvalidStateException::class);
 
-        $this->assertSame('apple-user-id', $user->getId());
+        $this->providerReturning($request, ['nonce' => 'whatever-apple-sent'])->user();
     }
 
     public function test_stateless_callback_without_a_nonce_is_refused(): void

--- a/tests/Apple/CallbackNonceValidationTest.php
+++ b/tests/Apple/CallbackNonceValidationTest.php
@@ -159,7 +159,7 @@ class CallbackNonceValidationTest extends TestCase
     {
         $response = $this->makeAppleProvider($this->makeRequestWithSession())
             ->stateless()
-            ->statelessNonce()
+            ->cookieNonce()
             ->redirect();
 
         $cookie = collect($response->headers->getCookies())
@@ -190,7 +190,7 @@ class CallbackNonceValidationTest extends TestCase
             ])),
         ]));
 
-        return $provider->stateless()->statelessNonce();
+        return $provider->stateless()->cookieNonce();
     }
 
     /**

--- a/tests/Apple/CallbackNonceValidationTest.php
+++ b/tests/Apple/CallbackNonceValidationTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace SocialiteProviders\Tests\Apple;
+
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Http\Request;
+use Laravel\Socialite\Two\InvalidStateException;
+use SocialiteProviders\Apple\Provider;
+
+class CallbackNonceValidationTest extends TestCase
+{
+    private const STATE = 'expected-state';
+
+    private const NONCE = 'expected-nonce';
+
+    public function test_callback_whose_token_nonce_matches_is_accepted(): void
+    {
+        $request = $this->callbackRequest(['state' => self::STATE, 'nonce' => self::NONCE]);
+
+        $user = $this->providerReturning($request, ['nonce' => self::NONCE])->user();
+
+        $this->assertSame('apple-user-id', $user->getId());
+    }
+
+    public function test_callback_whose_token_nonce_differs_is_rejected(): void
+    {
+        $request = $this->callbackRequest(['state' => self::STATE, 'nonce' => self::NONCE]);
+
+        $this->expectException(InvalidStateException::class);
+
+        $this->providerReturning($request, ['nonce' => 'nonce-from-another-request'])->user();
+    }
+
+    public function test_callback_whose_token_has_no_nonce_is_rejected(): void
+    {
+        $request = $this->callbackRequest(['state' => self::STATE, 'nonce' => self::NONCE]);
+
+        $this->expectException(InvalidStateException::class);
+
+        $this->providerReturning($request)->user();
+    }
+
+    public function test_nonce_is_consumed_by_the_callback(): void
+    {
+        $request = $this->callbackRequest(['state' => self::STATE, 'nonce' => self::NONCE]);
+
+        $this->providerReturning($request, ['nonce' => self::NONCE])->user();
+
+        $this->assertFalse($request->session()->has('nonce'));
+        $this->assertFalse($request->session()->has('state'));
+    }
+
+    public function test_nonce_is_not_checked_when_the_session_never_issued_one(): void
+    {
+        $request = $this->callbackRequest(['state' => self::STATE]);
+
+        $user = $this->providerReturning($request, ['nonce' => 'whatever-apple-sent'])->user();
+
+        $this->assertSame('apple-user-id', $user->getId());
+    }
+
+    public function test_stateless_callback_skips_nonce_verification(): void
+    {
+        $request = $this->makeRequestWithSession(['code' => 'authorization-code']);
+
+        $user = $this->providerReturning($request, ['nonce' => 'anything'])->stateless()->user();
+
+        $this->assertSame('apple-user-id', $user->getId());
+    }
+
+    /**
+     * @param  array<string, string>  $session
+     */
+    private function callbackRequest(array $session): Request
+    {
+        return $this->makeRequestWithSession([
+            'code'  => 'authorization-code',
+            'state' => self::STATE,
+        ], $session);
+    }
+
+    /**
+     * A provider whose token exchange returns an identity token with the given claims.
+     *
+     * @param  array<string, mixed>  $claims
+     */
+    private function providerReturning(Request $request, array $claims = []): Provider
+    {
+        $provider = $this->makeAppleProvider($request);
+
+        $provider->setHttpClient($this->makeHttpClient([
+            new Response(200, [], json_encode([
+                'id_token' => $this->identityToken($claims),
+            ])),
+        ]));
+
+        return $provider;
+    }
+}

--- a/tests/Apple/CallbackNonceValidationTest.php
+++ b/tests/Apple/CallbackNonceValidationTest.php
@@ -4,6 +4,7 @@ namespace SocialiteProviders\Tests\Apple;
 
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use Laravel\Socialite\Two\InvalidStateException;
 use SocialiteProviders\Apple\Provider;
 
@@ -90,6 +91,76 @@ class CallbackNonceValidationTest extends TestCase
             ->stateless()
             ->setNonce(self::NONCE)
             ->user();
+    }
+
+    public function test_managed_stateless_caches_the_nonce_under_the_state(): void
+    {
+        $request = $this->makeRequestWithSession();
+
+        $response = $this->makeAppleProvider($request)->stateless()->statelessNonce()->redirect();
+
+        $params = $this->queryParams($response->getTargetUrl());
+
+        $this->assertNotEmpty($params['state']);
+        $this->assertNotEmpty($params['nonce']);
+        $this->assertSame(
+            $params['nonce'],
+            Cache::get('socialite:apple:nonce:'.$params['state'])
+        );
+    }
+
+    public function test_managed_stateless_callback_verifies_and_consumes_the_cached_nonce(): void
+    {
+        $state = 'echoed-state';
+        Cache::put('socialite:apple:nonce:'.$state, self::NONCE, 600);
+
+        $request = $this->makeRequestWithSession([
+            'code'  => 'authorization-code',
+            'state' => $state,
+        ]);
+
+        $user = $this->providerReturning($request, ['nonce' => self::NONCE])
+            ->stateless()
+            ->statelessNonce()
+            ->user();
+
+        $this->assertSame('apple-user-id', $user->getId());
+        $this->assertNull(Cache::get('socialite:apple:nonce:'.$state));
+    }
+
+    public function test_managed_stateless_callback_rejects_an_unknown_state(): void
+    {
+        $request = $this->makeRequestWithSession([
+            'code'  => 'authorization-code',
+            'state' => 'never-issued',
+        ]);
+
+        $this->expectException(InvalidStateException::class);
+
+        $this->providerReturning($request, ['nonce' => self::NONCE])
+            ->stateless()
+            ->statelessNonce()
+            ->user();
+    }
+
+    public function test_managed_stateless_callback_rejects_a_replayed_state(): void
+    {
+        $state = 'echoed-state';
+        Cache::put('socialite:apple:nonce:'.$state, self::NONCE, 600);
+
+        $request = fn () => $this->makeRequestWithSession([
+            'code'  => 'authorization-code',
+            'state' => $state,
+        ]);
+
+        $this->providerReturning($request(), ['nonce' => self::NONCE])
+            ->stateless()->statelessNonce()->user();
+
+        // Second use of the same state must fail: the nonce was consumed.
+        $this->expectException(InvalidStateException::class);
+
+        $this->providerReturning($request(), ['nonce' => self::NONCE])
+            ->stateless()->statelessNonce()->user();
     }
 
     /**

--- a/tests/Apple/CallbackStateValidationTest.php
+++ b/tests/Apple/CallbackStateValidationTest.php
@@ -22,16 +22,18 @@ class CallbackStateValidationTest extends TestCase
     public function test_callback_with_matching_previously_stored_state_is_accepted(): void
     {
         $state = 'expected-state';
+        $nonce = 'expected-nonce';
         $request = $this->makeRequestWithSession([
             'code'  => 'authorization-code',
             'state' => $state,
         ], [
             'state' => $state,
+            'nonce' => $nonce,
         ]);
         $provider = $this->makeAppleProvider($request);
         $provider->setHttpClient($this->makeHttpClient([
             new Response(200, [], json_encode([
-                'id_token' => $this->identityToken(['nonce' => 'nonce']),
+                'id_token' => $this->identityToken(['nonce' => $nonce]),
             ])),
         ]));
 

--- a/tests/Apple/RedirectTest.php
+++ b/tests/Apple/RedirectTest.php
@@ -62,8 +62,6 @@ class RedirectTest extends TestCase
 
         $params = $this->queryParams($response->getTargetUrl());
 
-        // The README's stateless recipe relies on state reaching Apple so it
-        // can key the cached nonce on the value Apple echoes back.
         $this->assertSame('caller-state', $params['state']);
         $this->assertSame('caller-nonce', $params['nonce']);
     }

--- a/tests/Apple/RedirectTest.php
+++ b/tests/Apple/RedirectTest.php
@@ -32,7 +32,7 @@ class RedirectTest extends TestCase
         $this->assertSame($second, $request->session()->get('nonce'));
     }
 
-    public function test_stateless_redirect_sends_neither_state_nor_nonce(): void
+    public function test_stateless_redirect_sends_neither_state_nor_nonce_by_default(): void
     {
         $response = $this->makeAppleProvider()->stateless()->redirect();
 
@@ -40,5 +40,15 @@ class RedirectTest extends TestCase
 
         $this->assertArrayNotHasKey('state', $params);
         $this->assertArrayNotHasKey('nonce', $params);
+    }
+
+    public function test_stateless_redirect_sends_a_supplied_nonce(): void
+    {
+        $response = $this->makeAppleProvider()->stateless()->setNonce('caller-nonce')->redirect();
+
+        $params = $this->queryParams($response->getTargetUrl());
+
+        $this->assertArrayNotHasKey('state', $params);
+        $this->assertSame('caller-nonce', $params['nonce']);
     }
 }

--- a/tests/Apple/RedirectTest.php
+++ b/tests/Apple/RedirectTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace SocialiteProviders\Tests\Apple;
+
+class RedirectTest extends TestCase
+{
+    public function test_redirect_issues_a_nonce_and_keeps_it_in_the_session(): void
+    {
+        $request = $this->makeRequestWithSession();
+
+        $response = $this->makeAppleProvider($request)->redirect();
+
+        $params = $this->queryParams($response->getTargetUrl());
+        $session = $request->session();
+
+        $this->assertSame('form_post', $params['response_mode']);
+        $this->assertSame($session->get('state'), $params['state']);
+        $this->assertSame($session->get('nonce'), $params['nonce']);
+        $this->assertNotEmpty($params['nonce']);
+        $this->assertNotSame($params['state'], $params['nonce']);
+    }
+
+    public function test_each_redirect_issues_a_fresh_nonce(): void
+    {
+        $request = $this->makeRequestWithSession();
+        $provider = $this->makeAppleProvider($request);
+
+        $first = $this->queryParams($provider->redirect()->getTargetUrl())['nonce'];
+        $second = $this->queryParams($provider->redirect()->getTargetUrl())['nonce'];
+
+        $this->assertNotSame($first, $second);
+        $this->assertSame($second, $request->session()->get('nonce'));
+    }
+
+    public function test_stateless_redirect_sends_neither_state_nor_nonce(): void
+    {
+        $response = $this->makeAppleProvider()->stateless()->redirect();
+
+        $params = $this->queryParams($response->getTargetUrl());
+
+        $this->assertArrayNotHasKey('state', $params);
+        $this->assertArrayNotHasKey('nonce', $params);
+    }
+}

--- a/tests/Apple/RedirectTest.php
+++ b/tests/Apple/RedirectTest.php
@@ -51,4 +51,20 @@ class RedirectTest extends TestCase
         $this->assertArrayNotHasKey('state', $params);
         $this->assertSame('caller-nonce', $params['nonce']);
     }
+
+    public function test_stateless_redirect_forwards_a_caller_supplied_state(): void
+    {
+        $response = $this->makeAppleProvider()
+            ->stateless()
+            ->setNonce('caller-nonce')
+            ->with(['state' => 'caller-state'])
+            ->redirect();
+
+        $params = $this->queryParams($response->getTargetUrl());
+
+        // The README's stateless recipe relies on state reaching Apple so it
+        // can key the cached nonce on the value Apple echoes back.
+        $this->assertSame('caller-state', $params['state']);
+        $this->assertSame('caller-nonce', $params['nonce']);
+    }
 }

--- a/tests/Apple/TestCase.php
+++ b/tests/Apple/TestCase.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Psr7\Response;
 use Illuminate\Cache\ArrayStore;
 use Illuminate\Cache\Repository;
 use Illuminate\Container\Container;
+use Illuminate\Encryption\Encrypter;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Facade;
 use Lcobucci\JWT\Encoding\ChainedFormatter;
@@ -34,7 +35,7 @@ abstract class TestCase extends BaseTestCase
     {
         parent::setUp();
 
-        $this->bindCache();
+        $this->bindContainer();
         $this->makeKeyPair();
     }
 
@@ -48,13 +49,15 @@ abstract class TestCase extends BaseTestCase
     }
 
     /**
-     * The provider caches the JWKS through the Cache facade, which needs a
-     * container behind it. An array store keeps each test isolated.
+     * The provider reaches for the Cache and Crypt facades, which need a
+     * container behind them. An array store and a throwaway key keep each test
+     * isolated.
      */
-    private function bindCache(): void
+    private function bindContainer(): void
     {
         $container = new Container;
         $container->instance('cache', new Repository(new ArrayStore));
+        $container->instance('encrypter', new Encrypter(random_bytes(32), 'aes-256-cbc'));
 
         Container::setInstance($container);
         Facade::clearResolvedInstances();


### PR DESCRIPTION
Follow up to #1485. That PR fixed the state check but left the nonce unverified on the web callback: `getCodeFields()` still sent one, and `user()` never looked at it, so any Apple-signed identity token for our client id was accepted once the state matched. #1484 added nonce verification for the native flow only.

- issue a random nonce on `redirect()` and keep it in the session next to the state
- pull it on the callback and pass it to `checkToken()`, so a token from another authorization request is rejected
- drop the `usesState()` guard around `hasInvalidState()`, it already returns false when stateless
- document the `SameSite` requirement in the README

The nonce is only checked when the session holds one, so logins in flight during the deploy still complete.

**Upgrade note**

Apple posts the callback cross-site. Laravel's default `SESSION_SAME_SITE=lax` cookie isn't sent on that POST, so the session is empty and the state check from #1485 rejects every login. Before #1485 the provider rebuilt the state from the token and let it through, which is the CSRF hole. Users need `SESSION_SAME_SITE=none` with `SESSION_SECURE_COOKIE=true`. That's the breaking change, so this should ship as `release:major` along with #1485 (which merged unlabelled and hasn't released yet).

**Testing**

- `vendor/bin/phpunit tests/Apple` (23 tests)
- full suite passes, 271 tests
- pint failures on `src/Apple/Provider.php` are pre-existing on master
